### PR TITLE
agent-bootstrap is not on boot class path

### DIFF
--- a/agent/agent-main/src/main/java/com/sbss/bithon/agen/main/Main.java
+++ b/agent/agent-main/src/main/java/com/sbss/bithon/agen/main/Main.java
@@ -46,7 +46,7 @@ public class Main {
         boolean hasBootstrapJar = Arrays.stream(ManagementFactory.getRuntimeMXBean()
                                                                  .getBootClassPath()
                                                                  .split(File.pathSeparator))
-                                        .anyMatch(path -> path.endsWith("/agent-bootstrap.jar"));
+                                        .anyMatch(path -> path.endsWith(File.separator + "agent-bootstrap.jar"));
         if (!hasBootstrapJar) {
             throw new IllegalStateException("agent-bootstrap.jar is not on boot class path");
         }


### PR DESCRIPTION
This bug exists on Windows OS because directory separator on Windows OS is different from that on Linux or macOS