### PR TITLE
Support disable certain plugin via configuration

### DIFF
--- a/agent/agent-core/src/main/java/com/sbss/bithon/agent/core/config/AgentConfigManager.java
+++ b/agent/agent-core/src/main/java/com/sbss/bithon/agent/core/config/AgentConfigManager.java
@@ -171,7 +171,6 @@ public class AgentConfigManager {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public <T> T getConfig(Class<T> clazz) {
         Configuration cfg = clazz.getAnnotation(Configuration.class);
         if (cfg != null && !StringUtils.isEmpty(cfg.prefix())) {
@@ -223,9 +222,17 @@ public class AgentConfigManager {
 
         if (configurationNode == null) {
             try {
+                if (clazz == Boolean.class) {
+                    //noinspection unchecked
+                    return (T) Boolean.FALSE;
+                }
                 value = clazz.newInstance();
-            } catch (InstantiationException | IllegalAccessException e) {
+            } catch (IllegalAccessException e) {
                 throw new AgentException("Unable create instance for [%s]: %s", clazz.getName(), e.getMessage());
+            } catch (InstantiationException e) {
+                throw new AgentException("Unable create instance for [%s]: %s",
+                                         clazz.getName(),
+                                         e.getCause().getMessage());
             }
         } else {
             ObjectMapper mapper = new ObjectMapper();

--- a/agent/agent-core/src/main/java/com/sbss/bithon/agent/core/plugin/PluginClassLoaderManager.java
+++ b/agent/agent-core/src/main/java/com/sbss/bithon/agent/core/plugin/PluginClassLoaderManager.java
@@ -21,7 +21,6 @@ import com.sbss.bithon.agent.bootstrap.loader.AgentClassLoader;
 import com.sbss.bithon.agent.bootstrap.loader.JarClassLoader;
 import com.sbss.bithon.agent.bootstrap.loader.JarResolver;
 import com.sbss.bithon.agent.core.context.AgentContext;
-import shaded.org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.List;
@@ -59,12 +58,6 @@ public final class PluginClassLoaderManager {
 
     public static void createDefault(String agentPath) {
         List<JarFile> pluginJars = JarResolver.resolve(new File(agentPath + "/" + AgentContext.PLUGIN_DIR));
-
-        // show plugins
-        pluginJars.stream().map(jar -> new File(jar.getName()).getName()).sorted().forEach((name) -> {
-            LoggerFactory.getLogger(PluginClassLoaderManager.class)
-                         .info("Found plugin {}", name);
-        });
 
         defaultLoader = new JarClassLoader("plugin", pluginJars, AgentClassLoader.getClassLoader());
 


### PR DESCRIPTION
Fixes #126 

Configuration:

1. via command line: `-Dbithon.agent.plugin.redis.disabled=true`
2. via property file:

```
agent:
    plugin:
        redis:
            disabled: true    
```
        
if a plugin is disabled, application log shows as:
```bash
2021-08-11 15:39:31.855 [Agent INFO] - [main:PluginInterceptorInstaller] Find plugin agent-plugin-redis-lettuce-5.x-1.0-SNAPSHOT.jar, but it's DISABLED by configuration
```