### PR TITLE
Fix NPE in agent

### DIFF
--- a/agent/agent-plugins/logging-log4j2/src/main/java/org/bithon/agent/plugin/log4j2/interceptor/LoggerLogMessage.java
+++ b/agent/agent-plugins/logging-log4j2/src/main/java/org/bithon/agent/plugin/log4j2/interceptor/LoggerLogMessage.java
@@ -47,7 +47,7 @@ public class LoggerLogMessage extends AbstractInterceptor {
 
         Map<String, String> exceptionArgs = new HashMap<>();
         exceptionArgs.put("exceptionClass", exception.getClass().getName());
-        exceptionArgs.put("message", exception.getMessage());
+        exceptionArgs.put("message", exception.getMessage() == null ? "" : exception.getMessage());
         exceptionArgs.put("stack", exception.toString());
         EventMessage exceptionEvent = new EventMessage("exception", exceptionArgs);
         Dispatcher dispatcher = Dispatchers.getOrCreate(Dispatchers.DISPATCHER_NAME_EVENT);

--- a/agent/agent-plugins/logging-logback/src/main/java/org/bithon/agent/plugin/logback/interceptor/LoggerCallAppenders.java
+++ b/agent/agent-plugins/logging-logback/src/main/java/org/bithon/agent/plugin/logback/interceptor/LoggerCallAppenders.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public class LoggerCallAppenders extends AbstractInterceptor {
 
     @Override
-    public InterceptionDecision onMethodEnter(AopContext aopContext) throws Exception {
+    public InterceptionDecision onMethodEnter(AopContext aopContext) {
         ILoggingEvent iLoggingEvent = (ILoggingEvent) aopContext.getArgs()[0];
         if (iLoggingEvent.getLevel().toInt() != Level.ERROR.toInt()) {
             return InterceptionDecision.SKIP_LEAVE;
@@ -55,7 +55,7 @@ public class LoggerCallAppenders extends AbstractInterceptor {
 
         Map<String, String> exceptionArgs = new HashMap<>();
         exceptionArgs.put("exceptionClass", exception.getClassName());
-        exceptionArgs.put("message", exception.getMessage());
+        exceptionArgs.put("message", exception.getMessage() == null ? "" : exception.getMessage());
         exceptionArgs.put("stack", exception.toString());
         EventMessage exceptionEvent = new EventMessage("exception", exceptionArgs);
         Dispatcher dispatcher = Dispatchers.getOrCreate(Dispatchers.DISPATCHER_NAME_EVENT);


### PR DESCRIPTION
```bash
java.lang.NullPointerException
	at shaded.com.google.protobuf.Internal.checkNotNull(Internal.java:63)
	at shaded.com.google.protobuf.MapField$MutatabilityAwareMap.putAll(MapField.java:339)
	at org.bithon.agent.rpc.brpc.event.BrpcEventMessage$Builder.putAllArguments(BrpcEventMessage.java:853)
	at org.bithon.agent.dispatcher.brpc.BrpcMessageConverter.from(BrpcMessageConverter.java:235)
	at org.bithon.agent.plugin.logback.interceptor.LoggerCallAppenders.onMethodLeave(LoggerCallAppenders.java:62)
```

This is because the plugin is going to send NullPointerException whose message is NULL.