### PR TITLE
Update propagation model in webflux

### DIFF
--- a/agent/agent-plugins/spring-webflux/README.md
+++ b/agent/agent-plugins/spring-webflux/README.md
@@ -3,8 +3,8 @@
 
 ```mermaid
 graph 
-    ReactorHttpHandlerAdapter 
-    ---> filters 
+    ReactorHttpHandlerAdapter(HttpServerOperations, resp)
+    ---> filters ( AbstractServerHttpRequest(HttpServerOperations) )
     ---> NettyRoutingFilter 
     ---> HttpClientFinializer#send
     ---> HttpClientFinializer#responseConnection

--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
@@ -83,6 +83,7 @@ public class ReactorHttpHandlerAdapter$Apply extends AbstractInterceptor {
         // which is instrumented as IBithonObject
         //
         if (request instanceof IBithonObject) {
+            // the injected object is created in HttpServerOperation$Ctor
             Object injected = ((IBithonObject) request).getInjectedObject();
             if (injected instanceof HttpServerContext) {
                 final ITraceContext traceContext = Tracer.get()
@@ -100,12 +101,6 @@ public class ReactorHttpHandlerAdapter$Apply extends AbstractInterceptor {
                             .start();
 
                 ((HttpServerContext) injected).setTraceContext(traceContext);
-
-                // this thread-local variable won't be removed in the 'onMethodLeave' below
-                // that's because the filter chain is executed after 'onMethodLeave'
-                // since webflux is built upon netty which means the network threads are fixed
-                // we don't need to care about the thread-local variable causes memory-leak
-                TraceContextHolder.set(traceContext);
             }
         }
 
@@ -122,8 +117,6 @@ public class ReactorHttpHandlerAdapter$Apply extends AbstractInterceptor {
             update(request, response, aopContext.getCostTime());
             finishTrace(request, response);
 
-            // in this execution path, filters won't be executed, it's safe to remove the thread-local variable
-            TraceContextHolder.remove();
             return;
         }
 

--- a/dev/spotbugs-exclude.xml
+++ b/dev/spotbugs-exclude.xml
@@ -66,6 +66,7 @@
     <Bug pattern="CN_IDIOM_NO_SUPER_CALL"/>
     <Bug pattern="CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE"/>
     <Bug pattern="DC_DOUBLECHECK"/>
+    <Bug pattern="DE_MIGHT_IGNORE"/> <!--we might use catch(Exception ignored) pattern to ignore some exceptions-->
     <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING"/>
     <Bug pattern="DM_EXIT"/>
     <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>


### PR DESCRIPTION
No use of ThreadLocal because Flux/Mono might be scheduled on a different thread from the thread where the entry point is scheduled.