### PR TITLE
Catch NoClassDefFoundError when detecting logging framework

### DIFF
--- a/component/component-commons/src/main/java/org/bithon/component/commons/logging/LoggerFactory.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/logging/LoggerFactory.java
@@ -50,7 +50,7 @@ public class LoggerFactory {
                     factory.newLogger("default").info("Using [{}] as logging framework", factory.getClass().getSimpleName());
                     LoggerFactory.adaptorFactory = factory;
                     break;
-                } catch (InstantiationException | IllegalAccessException ignored) {
+                } catch (NoClassDefFoundError | InstantiationException | IllegalAccessException ignored) {
                 }
             }
         }


### PR DESCRIPTION
Introduced by #271 