### PR TITLE
Well support Apache Druid

### DIFF
--- a/agent/agent-bootstrap/src/main/java/org/bithon/agent/bootstrap/loader/AgentClassLoader.java
+++ b/agent/agent-bootstrap/src/main/java/org/bithon/agent/bootstrap/loader/AgentClassLoader.java
@@ -36,7 +36,7 @@ public class AgentClassLoader {
      */
     public static ClassLoader initialize(File agentDirectory) {
         final Thread mainThread = Thread.currentThread();
-        instance = new JarClassLoader("agent-bootstrap",
+        instance = new JarClassLoader("agent-library",
                                       JarResolver.resolve(new File(agentDirectory, "lib")),
                                       mainThread::getContextClassLoader);
         return instance;

--- a/agent/agent-core/src/main/java/org/bithon/agent/core/aop/interceptor/InterceptorInstaller.java
+++ b/agent/agent-core/src/main/java/org/bithon/agent/core/aop/interceptor/InterceptorInstaller.java
@@ -134,11 +134,11 @@ public class InterceptorInstaller {
 
             if (interceptor == null) {
                 log.info("Interceptor[{}] initial failed, interceptor ignored", interceptorName);
-                return null;
+                return builder;
             }
         } catch (Exception e) {
             log.error(String.format(Locale.ENGLISH, "Failed to load interceptor[%s] due to %s", interceptorName, e.getMessage()), e);
-            return null;
+            return builder;
         }
 
         try {
@@ -200,7 +200,7 @@ public class InterceptorInstaller {
                 if (descriptor == null) {
                     // this must be something wrong
                     log.error("Error to transform [{}] for the descriptor is not found", type);
-                    return null;
+                    return builder;
                 }
 
                 //
@@ -209,7 +209,7 @@ public class InterceptorInstaller {
                 if (CollectionUtils.isNotEmpty(descriptor.getPreconditions())) {
                     for (IInterceptorPrecondition condition : descriptor.getPreconditions()) {
                         if (!condition.canInstall("TODO: provider name", classLoader, typeDescription)) {
-                            return null;
+                            return builder;
                         }
                     }
                 }

--- a/agent/agent-plugins/apache-druid/pom.xml
+++ b/agent/agent-plugins/apache-druid/pom.xml
@@ -20,6 +20,12 @@
       <version>0.16.0-incubating</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-sql</artifactId>
+      <version>0.16.0-incubating</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/agent/agent-plugins/apache-druid/pom.xml
+++ b/agent/agent-plugins/apache-druid/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.bithon.agent</groupId>
+    <artifactId>agent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>agent-plugin-apache-druid</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>agent-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>0.16.0-incubating</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Plugin-Class>org.bithon.agent.plugin.apache.druid.ApacheDruidPlugin
+              </Plugin-Class>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+</project>

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/ApacheDruidPlugin.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/ApacheDruidPlugin.java
@@ -1,0 +1,62 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.apache.druid;
+
+import org.bithon.agent.core.aop.descriptor.InterceptorDescriptor;
+import org.bithon.agent.core.aop.descriptor.MethodPointCutDescriptorBuilder;
+import org.bithon.agent.core.context.AgentContext;
+import org.bithon.agent.core.plugin.IPlugin;
+import org.bithon.agent.core.tracing.config.TraceConfig;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.bithon.agent.core.aop.descriptor.InterceptorDescriptorBuilder.forClass;
+
+/**
+ * @author frankchen
+ * @date 2022-01-04 18:35
+ */
+public class ApacheDruidPlugin implements IPlugin {
+
+    @Override
+    public List<InterceptorDescriptor> getInterceptors() {
+        TraceConfig traceConfig = AgentContext.getInstance()
+                                              .getAgentConfiguration()
+                                              .getConfig(TraceConfig.class);
+        if (traceConfig.isDisabled()) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.asList(
+            forClass("org.apache.druid.sql.SqlLifecycle")
+                .methods(
+                    MethodPointCutDescriptorBuilder.build()
+                                                   .onAllMethods("initialize")
+                                                   .to("org.bithon.agent.plugin.apache.druid.interceptor.SqlLifecycle$Initialize")
+                ),
+
+            forClass("org.apache.druid.server.QueryLifecycle")
+                .methods(
+                    MethodPointCutDescriptorBuilder.build()
+                                                   .onAllMethods("initialize")
+                                                   .to("org.bithon.agent.plugin.apache.druid.interceptor.QueryLifecycle$Initialize")
+                )
+        );
+    }
+}

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/QueryLifecycle$Initialize.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/QueryLifecycle$Initialize.java
@@ -19,7 +19,6 @@ package org.bithon.agent.plugin.apache.druid.interceptor;
 import org.apache.druid.server.QueryLifecycle;
 import org.bithon.agent.bootstrap.aop.AbstractInterceptor;
 import org.bithon.agent.bootstrap.aop.AopContext;
-import org.bithon.agent.bootstrap.aop.InterceptionDecision;
 import org.bithon.agent.core.tracing.context.ITraceContext;
 import org.bithon.agent.core.tracing.context.TraceContextHolder;
 import org.bithon.component.commons.logging.ILogAdaptor;
@@ -52,11 +51,6 @@ public class QueryLifecycle$Initialize extends AbstractInterceptor {
           This is not the best way because we can't use the shaded jackson to serialize/deserialize shaded joda objects anymore.
          */
         this.om.registerModule(new JodaModule());
-    }
-
-    @Override
-    public InterceptionDecision onMethodEnter(AopContext aopContext) {
-        return InterceptionDecision.CONTINUE;
     }
 
     @Override

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/QueryLifecycle$Initialize.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/QueryLifecycle$Initialize.java
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.apache.druid.interceptor;
+
+import org.apache.druid.server.QueryLifecycle;
+import org.bithon.agent.bootstrap.aop.AbstractInterceptor;
+import org.bithon.agent.bootstrap.aop.AopContext;
+import org.bithon.agent.bootstrap.aop.InterceptionDecision;
+import org.bithon.agent.core.tracing.context.ITraceContext;
+import org.bithon.agent.core.tracing.context.TraceContextHolder;
+import org.bithon.component.commons.logging.ILogAdaptor;
+import org.bithon.component.commons.logging.LoggerFactory;
+import shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.com.fasterxml.jackson.databind.SerializationFeature;
+import shaded.com.fasterxml.jackson.datatype.joda.JodaModule;
+
+/**
+ * @author Frank Chen
+ * @date 4/1/22 6:38 PM
+ */
+public class QueryLifecycle$Initialize extends AbstractInterceptor {
+
+    private static final ILogAdaptor log = LoggerFactory.getLogger(QueryLifecycle$Initialize.class);
+
+    private final ObjectMapper om;
+
+    public QueryLifecycle$Initialize() {
+        this.om = new ObjectMapper().configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                                    .configure(SerializationFeature.INDENT_OUTPUT, true);
+        /*
+          NOTE
+          JodaModule is defined in com.fasterxml.jackson.datatype:jackson-datatype-joda and is shaded in shaded-jackson module
+          but the org.joda.time.* classes in that module is excluded from the shaded module
+          This is because that package is not shaded, we want to use these class loaded in user's class loader to do serialization.
+          These classes are used by the Query object below.
+
+          This is not the best way because we can't use the shaded jackson to serialize/deserialize shaded joda objects anymore.
+         */
+        this.om.registerModule(new JodaModule());
+    }
+
+    @Override
+    public InterceptionDecision onMethodEnter(AopContext aopContext) {
+        return InterceptionDecision.CONTINUE;
+    }
+
+    @Override
+    public void onMethodLeave(AopContext aopContext) {
+        ITraceContext ctx = TraceContextHolder.current();
+        if (ctx != null) {
+            QueryLifecycle lifecycle = aopContext.castTargetAs();
+            if (!ctx.currentSpan().tags().containsKey("query")) {
+                try {
+                    ctx.currentSpan().tag("query", om.writeValueAsString(lifecycle.getQuery()));
+                } catch (JsonProcessingException e) {
+                    log.error("Unable to serialize query object: {}", e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/QueryLifecycle$Initialize.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/QueryLifecycle$Initialize.java
@@ -60,7 +60,9 @@ public class QueryLifecycle$Initialize extends AbstractInterceptor {
             QueryLifecycle lifecycle = aopContext.castTargetAs();
             if (!ctx.currentSpan().tags().containsKey("query")) {
                 try {
-                    ctx.currentSpan().tag("query", om.writeValueAsString(lifecycle.getQuery()));
+                    ctx.currentSpan()
+                       .tag("query_id", lifecycle.getQuery().getId())
+                       .tag("query", om.writeValueAsString(lifecycle.getQuery()));
                 } catch (JsonProcessingException e) {
                     log.error("Unable to serialize query object: {}", e.getMessage());
                 }

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/SqlLifecycle$Initialize.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/SqlLifecycle$Initialize.java
@@ -1,0 +1,42 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.apache.druid.interceptor;
+
+import org.bithon.agent.bootstrap.aop.AbstractInterceptor;
+import org.bithon.agent.bootstrap.aop.AopContext;
+import org.bithon.agent.bootstrap.aop.InterceptionDecision;
+import org.bithon.agent.core.tracing.context.ITraceContext;
+import org.bithon.agent.core.tracing.context.TraceContextHolder;
+
+/**
+ * @author Frank Chen
+ * @date 4/1/22 6:37 PM
+ */
+public class SqlLifecycle$Initialize extends AbstractInterceptor {
+
+    @Override
+    public InterceptionDecision onMethodEnter(AopContext aopContext) {
+        ITraceContext ctx = TraceContextHolder.current();
+        if (ctx != null) {
+            Object query = aopContext.getArgs()[0];
+            if (query != null && !ctx.currentSpan().tags().containsKey("query")) {
+                ctx.currentSpan().tag("query", query.toString());
+            }
+        }
+        return InterceptionDecision.SKIP_LEAVE;
+    }
+}

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/SqlLifecycle$Initialize.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/SqlLifecycle$Initialize.java
@@ -22,7 +22,11 @@ import org.bithon.agent.bootstrap.aop.InterceptionDecision;
 import org.bithon.agent.core.tracing.context.ITraceContext;
 import org.bithon.agent.core.tracing.context.TraceContextHolder;
 
+import java.util.Map;
+
 /**
+ * {@link org.apache.druid.sql.SqlLifecycle#initialize(String, Map)}
+ *
  * @author Frank Chen
  * @date 4/1/22 6:37 PM
  */
@@ -33,8 +37,11 @@ public class SqlLifecycle$Initialize extends AbstractInterceptor {
         ITraceContext ctx = TraceContextHolder.current();
         if (ctx != null) {
             Object query = aopContext.getArgs()[0];
+            Map<String, Object> context = aopContext.getArgAs(1);
             if (query != null && !ctx.currentSpan().tags().containsKey("query")) {
-                ctx.currentSpan().tag("query", query.toString());
+                ctx.currentSpan()
+                   .tag("query_id", context == null ? null : (String) context.getOrDefault("queryId", null))
+                   .tag("query", query.toString());
             }
         }
         return InterceptionDecision.SKIP_LEAVE;

--- a/agent/agent-plugins/httpclient-jetty/src/main/java/org/bithon/agent/plugin/httpclient/jetty/HttpRequest$Send.java
+++ b/agent/agent-plugins/httpclient-jetty/src/main/java/org/bithon/agent/plugin/httpclient/jetty/HttpRequest$Send.java
@@ -58,7 +58,7 @@ public class HttpRequest$Send extends AbstractInterceptor {
         final ITraceSpan span = TraceSpanFactory.newAsyncSpan("httpClient-jetty")
                                                 .method(aopContext.getMethod())
                                                 .kind(SpanKind.CLIENT)
-                                                .tag(Tags.URI, httpRequest.getURI().getPath())
+                                                .tag(Tags.URI, httpRequest.getURI().toString())
                                                 .tag(Tags.HTTP_METHOD, httpRequest.getMethod())
                                                 .propagate(httpRequest.getHeaders(), (headersArgs, key, value) -> headersArgs.put(key, value))
                                                 .start();

--- a/agent/agent-plugins/httpclient-netty3/pom.xml
+++ b/agent/agent-plugins/httpclient-netty3/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
-  <artifactId>agent-plugin-httpclient-netty</artifactId>
+  <artifactId>agent-plugin-httpclient-netty3</artifactId>
 
   <dependencies>
     <dependency>
@@ -31,7 +31,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Plugin-Class>org.bithon.agent.plugin.httpclient.netty.NettyHttpClientPlugin
+              <Plugin-Class>org.bithon.agent.plugin.httpclient.netty3.NettyHttpClientPlugin
               </Plugin-Class>
             </manifestEntries>
           </archive>

--- a/agent/agent-plugins/httpclient-netty3/src/main/java/org/bithon/agent/plugin/httpclient/netty3/NettyHttpClientPlugin.java
+++ b/agent/agent-plugins/httpclient-netty3/src/main/java/org/bithon/agent/plugin/httpclient/netty3/NettyHttpClientPlugin.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package org.bithon.agent.plugin.httpclient.netty;
+package org.bithon.agent.plugin.httpclient.netty3;
 
 
 import org.bithon.agent.core.aop.descriptor.InterceptorDescriptor;
@@ -46,7 +46,7 @@ public class NettyHttpClientPlugin implements IPlugin {
                                                        "org.jboss.netty.channel.Channel",
                                                        "java.lang.Object"
                                                    )
-                                                   .to("org.bithon.agent.plugin.httpclient.netty.Channels$Write")
+                                                   .to("org.bithon.agent.plugin.httpclient.netty3.Channels$Write")
 
                 )
         );

--- a/agent/agent-plugins/pom.xml
+++ b/agent/agent-plugins/pom.xml
@@ -15,6 +15,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>apache-druid</module>
     <module>bithon-sdk</module>
     <module>guice</module>
     <module>jdbc-druid</module>
@@ -48,6 +49,12 @@
 
   <dependencies>
     <!-- Use to publish -->
+    <dependency>
+      <groupId>org.bithon.agent</groupId>
+      <artifactId>agent-plugin-apache-druid</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.bithon.agent</groupId>
       <artifactId>agent-plugin-bithon-sdk</artifactId>

--- a/agent/agent-plugins/pom.xml
+++ b/agent/agent-plugins/pom.xml
@@ -31,7 +31,7 @@
     <module>httpclient-jdk</module>
     <module>httpclient-apache</module>
     <module>httpclient-jetty</module>
-    <module>httpclient-netty</module>
+    <module>httpclient-netty3</module>
     <module>redis-jedis</module>
     <module>redis-lettuce-5.x</module>
     <module>mongodb</module>
@@ -153,7 +153,7 @@
     </dependency>
     <dependency>
       <groupId>org.bithon.agent</groupId>
-      <artifactId>agent-plugin-httpclient-netty</artifactId>
+      <artifactId>agent-plugin-httpclient-netty3</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/shaded/shaded-jackson/pom.xml
+++ b/shaded/shaded-jackson/pom.xml
@@ -22,6 +22,11 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-smile</artifactId>
       <version>${jackson.version}</version>
@@ -51,6 +56,14 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>org/joda/time/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>


### PR DESCRIPTION
1. Show query in trace, including queryId
2. leverage existing trace mapping to allow search trace by queryId
3. fix the URI in tag for httpClient-jetty and httpClient-netty plugins
4. fix the component name of httpClient-netty which is mis-spelled as httpClient-jetty
5. rename httpClient-netty to httpClient-netty3

![image](https://user-images.githubusercontent.com/6525742/148084989-f68335c1-fe2c-4b61-9e34-d16d52ab90c0.png)
![image](https://user-images.githubusercontent.com/6525742/148084907-3367a81c-2e64-4c8b-929d-25818f810171.png)

