### PR TITLE
Add http-version to trace tags

### DIFF
--- a/agent/agent-core/src/main/java/org/bithon/agent/core/tracing/context/Tags.java
+++ b/agent/agent-core/src/main/java/org/bithon/agent/core/tracing/context/Tags.java
@@ -21,6 +21,7 @@ package org.bithon.agent.core.tracing.context;
  * @date 25/12/21 5:56 PM
  */
 public class Tags {
+    public static final String HTTP_VERSION = "http-version";
     public static final String HTTP_METHOD = "method";
 
     /**

--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
@@ -28,6 +28,7 @@ import org.bithon.agent.core.tracing.Tracer;
 import org.bithon.agent.core.tracing.config.TraceConfig;
 import org.bithon.agent.core.tracing.context.ITraceContext;
 import org.bithon.agent.core.tracing.context.SpanKind;
+import org.bithon.agent.core.tracing.context.Tags;
 import org.bithon.agent.core.tracing.context.TraceContextHolder;
 import org.bithon.agent.core.tracing.propagation.ITracePropagator;
 import org.bithon.agent.plugin.spring.webflux.context.HttpServerContext;
@@ -93,8 +94,9 @@ public class ReactorHttpHandlerAdapter$Apply extends AbstractInterceptor {
 
                 traceContext.currentSpan()
                             .component("webflux")
-                            .tag("uri", request.fullPath())
-                            .tag("method", request.method().name())
+                            .tag(Tags.URI, request.uri())
+                            .tag(Tags.HTTP_METHOD, request.method().name())
+                            .tag(Tags.HTTP_VERSION, request.version().text())
                             .tag((span) -> traceConfig.getHeaders().forEach((header) -> span.tag("header." + header, request.requestHeaders().get(header))))
                             .method(aopContext.getMethod())
                             .kind(SpanKind.SERVER)

--- a/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/ContextHandlerDoHandle.java
+++ b/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/ContextHandlerDoHandle.java
@@ -29,6 +29,7 @@ import org.bithon.agent.core.tracing.config.TraceConfig;
 import org.bithon.agent.core.tracing.context.ITraceContext;
 import org.bithon.agent.core.tracing.context.ITraceSpan;
 import org.bithon.agent.core.tracing.context.SpanKind;
+import org.bithon.agent.core.tracing.context.Tags;
 import org.bithon.agent.core.tracing.context.TraceContextHolder;
 import org.bithon.agent.core.tracing.propagation.ITracePropagator;
 import org.eclipse.jetty.server.Request;
@@ -81,8 +82,9 @@ public class ContextHandlerDoHandle extends AbstractInterceptor {
 
             traceContext.currentSpan()
                         .component("jetty")
-                        .tag("uri", request.getRequestURI())
-                        .tag("method", request.getMethod())
+                        .tag(Tags.URI, request.getRequestURI())
+                        .tag(Tags.HTTP_METHOD, request.getMethod())
+                        .tag(Tags.HTTP_VERSION, request.getHttpVersion().toString())
                         .tag((span) -> traceConfig.getHeaders().forEach((header) -> span.tag("header." + header, request.getHeader(header))))
                         .method(aopContext.getMethod())
                         .kind(SpanKind.SERVER)

--- a/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/HttpChannel$Handle.java
+++ b/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/HttpChannel$Handle.java
@@ -27,6 +27,7 @@ import org.bithon.agent.core.tracing.Tracer;
 import org.bithon.agent.core.tracing.config.TraceConfig;
 import org.bithon.agent.core.tracing.context.ITraceContext;
 import org.bithon.agent.core.tracing.context.SpanKind;
+import org.bithon.agent.core.tracing.context.Tags;
 import org.bithon.agent.core.tracing.context.TraceContextHolder;
 import org.bithon.agent.plugin.jetty.context.RequestContext;
 import org.eclipse.jetty.server.HttpChannel;
@@ -70,8 +71,9 @@ public class HttpChannel$Handle extends AbstractInterceptor {
 
                 traceContext.currentSpan()
                             .component("jetty")
-                            .tag("uri", request.getRequestURI())
-                            .tag("method", request.getMethod())
+                            .tag(Tags.URI, request.getRequestURI())
+                            .tag(Tags.HTTP_METHOD, request.getMethod())
+                            .tag(Tags.HTTP_VERSION, request.getHttpVersion().toString())
                             .tag((span) -> traceConfig.getHeaders().forEach((header) -> span.tag("header." + header, request.getHeader(header))))
                             .method(aopContext.getMethod())
                             .kind(SpanKind.SERVER)


### PR DESCRIPTION
Some clients are using http 1.0. It's useful to add the version to tags to identify the client in one aspect.