### PR TITLE
Support to sanitize sensitive information in trace span

### DIFF
--- a/server/server-starter/src/main/resources/application.yml
+++ b/server/server-starter/src/main/resources/application.yml
@@ -3,6 +3,11 @@ server:
 
 bithon:
   tracing:
+    globalSanitizer:
+      type: uri
+      args:
+        sensitiveParameters:
+          - password
     mapping:
       - type: uri
         args:

--- a/server/sink/src/main/java/org/bithon/server/common/utils/MiscUtils.java
+++ b/server/sink/src/main/java/org/bithon/server/common/utils/MiscUtils.java
@@ -23,7 +23,6 @@ import org.springframework.util.StringUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;

--- a/server/sink/src/main/java/org/bithon/server/common/utils/MiscUtils.java
+++ b/server/sink/src/main/java/org/bithon/server/common/utils/MiscUtils.java
@@ -22,21 +22,17 @@ import org.springframework.util.StringUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * @author frank.chen021@outlook.com
  * @date 2021/3/22
  */
 public class MiscUtils {
-
-    @Getter
-    @AllArgsConstructor
-    public static class ConnectionString {
-        private final String hostAndPort;
-        private final String database;
-        private final EndPointType endPointType;
-    }
 
     public static ConnectionString parseConnectionString(String connectionString) {
         if (StringUtils.isEmpty(connectionString)) {
@@ -69,5 +65,55 @@ public class MiscUtils {
         } catch (URISyntaxException e) {
             throw new RuntimeException(String.format(Locale.ENGLISH, "Invalid format of Connection String: [%s]", connectionString));
         }
+    }
+
+    public static Map<String, String> parseURLParameters(String uriText) {
+        if (uriText == null) {
+            return Collections.emptyMap();
+        }
+
+        URI uri = null;
+        try {
+            uri = new URI(uriText);
+        } catch (URISyntaxException ignored) {
+            return Collections.emptyMap();
+        }
+
+        String query = uri.getQuery();
+        if (!StringUtils.hasText(query)) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> variables = new TreeMap<>();
+        int fromIndex = 0;
+        int toIndex = 0;
+        while (toIndex != -1) {
+            String name;
+            String value;
+            toIndex = query.indexOf('=', fromIndex);
+            if (toIndex - fromIndex > 1) {
+                name = query.substring(fromIndex, toIndex);
+                fromIndex = toIndex + 1;
+                toIndex = query.indexOf('&', fromIndex);
+                if (toIndex == -1) {
+                    value = query.substring(fromIndex);
+                } else {
+                    value = query.substring(fromIndex, toIndex);
+                }
+                variables.put(name, value);
+                fromIndex = toIndex + 1;
+            } else {
+                fromIndex = query.indexOf('&', toIndex) + 1;
+            }
+        }
+        return variables;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ConnectionString {
+        private final String hostAndPort;
+        private final String database;
+        private final EndPointType endPointType;
     }
 }

--- a/server/sink/src/main/java/org/bithon/server/common/utils/collection/IteratorableCollection.java
+++ b/server/sink/src/main/java/org/bithon/server/common/utils/collection/IteratorableCollection.java
@@ -30,7 +30,7 @@ public class IteratorableCollection<E> implements Iterator<E> {
     private final Iterator<E> delegate;
     private boolean end;
 
-    private IteratorableCollection(Iterator<E> delegate) {
+    protected IteratorableCollection(Iterator<E> delegate) {
         this.delegate = delegate;
     }
 

--- a/server/sink/src/main/java/org/bithon/server/tracing/TraceConfig.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/TraceConfig.java
@@ -18,10 +18,12 @@ package org.bithon.server.tracing;
 
 import lombok.Data;
 import org.bithon.server.tracing.mapping.TraceIdMappingConfig;
+import org.bithon.server.tracing.sanitization.SanitizerConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Frank Chen
@@ -32,4 +34,6 @@ import java.util.List;
 @ConfigurationProperties(prefix = "bithon.tracing")
 public class TraceConfig {
     private List<TraceIdMappingConfig> mapping;
+
+    private Map<String, SanitizerConfig> applicationSanitizer;
 }

--- a/server/sink/src/main/java/org/bithon/server/tracing/TraceConfig.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/TraceConfig.java
@@ -35,5 +35,6 @@ import java.util.Map;
 public class TraceConfig {
     private List<TraceIdMappingConfig> mapping;
 
+    private SanitizerConfig globalSanitizer;
     private Map<String, SanitizerConfig> applicationSanitizer;
 }

--- a/server/sink/src/main/java/org/bithon/server/tracing/mapping/TraceMappingFactory.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/mapping/TraceMappingFactory.java
@@ -60,6 +60,7 @@ public class TraceMappingFactory {
             ObjectMapper mapper = context.getBean(ObjectMapper.class);
             for (TraceIdMappingConfig mappingConfig : config.getMapping()) {
                 try {
+                    // flatten the configuration
                     Map<String, Object> map = new HashMap<>();
                     map.put("type", mappingConfig.getType());
                     map.putAll(mappingConfig.getArgs());

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/ISanitizer.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/ISanitizer.java
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package org.bithon.server.tracing.sanitization;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/ISanitizer.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/ISanitizer.java
@@ -1,0 +1,17 @@
+package org.bithon.server.tracing.sanitization;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.bithon.server.tracing.sink.TraceSpan;
+
+/**
+ * @author Frank Chen
+ * @date 10/1/22 2:28 PM
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "uri", value = UrlSanitizer.class),
+})
+public interface ISanitizer {
+    void sanitize(TraceSpan span);
+}

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerConfig.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerConfig.java
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package org.bithon.server.tracing.sanitization;
 
 import lombok.Data;

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerConfig.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerConfig.java
@@ -1,0 +1,15 @@
+package org.bithon.server.tracing.sanitization;
+
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * @author Frank Chen
+ * @date 10/1/22 2:31 PM
+ */
+@Data
+public class SanitizerConfig {
+    private String type;
+    private Map<String, Object> args;
+}

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerFactory.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerFactory.java
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package org.bithon.server.tracing.sanitization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerFactory.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerFactory.java
@@ -39,7 +39,7 @@ public class SanitizerFactory {
     public SanitizerFactory(ObjectMapper objectMapper, TraceConfig traceConfig) {
         this.objectMapper = objectMapper;
         this.applicationSanitizers = new HashMap<>();
-        if ( traceConfig.getApplicationSanitizer() != null) {
+        if (traceConfig.getApplicationSanitizer() != null) {
             traceConfig.getApplicationSanitizer().forEach((application, config) -> {
                 ISanitizer sanitizer = getSanitizer(config);
                 if (sanitizer != null) {
@@ -81,7 +81,7 @@ public class SanitizerFactory {
                 sanitizer.sanitize(span);
             }
         }
-        if(globalSanitizer != null) {
+        if (globalSanitizer != null) {
             globalSanitizer.sanitize(span);
         }
     }

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerFactory.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/SanitizerFactory.java
@@ -1,0 +1,67 @@
+package org.bithon.server.tracing.sanitization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.bithon.server.common.utils.collection.IteratorableCollection;
+import org.bithon.server.tracing.TraceConfig;
+import org.bithon.server.tracing.sink.TraceSpan;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Frank Chen
+ * @date 10/1/22 2:28 PM
+ */
+@Slf4j
+public class SanitizerFactory {
+    private final ObjectMapper objectMapper;
+    private final Map<String, ISanitizer> applicationSanitizers;
+
+    public SanitizerFactory(ObjectMapper objectMapper, TraceConfig traceConfig) {
+        this.objectMapper = objectMapper;
+        this.applicationSanitizers = new HashMap<>();
+        traceConfig.getApplicationSanitizer().forEach((application, config) -> {
+            ISanitizer sanitizer = getSanitizer(config);
+            if (sanitizer != null) {
+                applicationSanitizers.put(application, sanitizer);
+            }
+        });
+    }
+
+    private ISanitizer getSanitizer(SanitizerConfig config) {
+        try {
+            //flatten the configuration
+            Map<String, Object> map = new HashMap<>();
+            map.put("type", config.getType());
+            map.putAll(config.getArgs());
+            String json = objectMapper.writeValueAsString(map);
+
+            return objectMapper.readValue(json, ISanitizer.class);
+        } catch (IOException e) {
+            log.error("Unable to create extractor for type " + config.getType(), e);
+            return null;
+        }
+    }
+
+    public void sanitize(IteratorableCollection<TraceSpan> spans) {
+        if (applicationSanitizers.isEmpty()) {
+            return;
+        }
+        while (spans.hasNext()) {
+            sanitize(spans.next());
+        }
+    }
+
+    private void sanitize(TraceSpan span) {
+        if (span.getAppName() == null) {
+            return;
+        }
+        ISanitizer sanitizer = applicationSanitizers.get(span.getAppName());
+        if (sanitizer == null) {
+            return;
+        }
+        sanitizer.sanitize(span);
+    }
+}

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/UrlSanitizer.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/UrlSanitizer.java
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package org.bithon.server.tracing.sanitization;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/UrlSanitizer.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/UrlSanitizer.java
@@ -27,12 +27,11 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- *
  * The tracing at the agent side will catch information from the uri and user specified header.
  * But there might be some sensitive information in the information above for some specific applications
- *
+ * <p>
  * So, this class is used to sanitize the sensitive information according to user's configuration.
- *
+ * <p>
  * Currently, only sanitizing on the 'uri' parameter is supported.
  *
  * @author Frank Chen
@@ -47,7 +46,7 @@ public class UrlSanitizer implements ISanitizer {
      */
     @JsonCreator
     public UrlSanitizer(@JsonProperty("sensitiveParameters") Map<String, String> sensitiveParameters) {
-        this.sensitiveParameters= new ArrayList<>(sensitiveParameters.values());
+        this.sensitiveParameters = new ArrayList<>(sensitiveParameters.values());
     }
 
     @Override

--- a/server/sink/src/main/java/org/bithon/server/tracing/sanitization/UrlSanitizer.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sanitization/UrlSanitizer.java
@@ -1,0 +1,77 @@
+package org.bithon.server.tracing.sanitization;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.bithon.server.tracing.sink.TraceSpan;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ *
+ * The tracing at the agent side will catch information from the uri and user specified header.
+ * But there might be some sensitive information in the information above for some specific applications
+ *
+ * So, this class is used to sanitize the sensitive information according to user's configuration.
+ *
+ * Currently, only sanitizing on the 'uri' parameter is supported.
+ *
+ * @author Frank Chen
+ * @date 10/1/22 1:38 PM
+ */
+public class UrlSanitizer implements ISanitizer {
+    private final Collection<String> sensitiveParameters;
+
+    /**
+     * NOTE: the ctor is passed from configuration which are deserialized from the application yml
+     * The default deserialization treats the list as a LinkedHashMap, so we have to define the ctor as the map
+     */
+    @JsonCreator
+    public UrlSanitizer(@JsonProperty("sensitiveParameters") Map<String, String> sensitiveParameters) {
+        this.sensitiveParameters= new ArrayList<>(sensitiveParameters.values());
+    }
+
+    @Override
+    public void sanitize(TraceSpan span) {
+        boolean sanitized = false;
+
+        Map<String, String> parameters = span.getURLParameters();
+        for (String sensitiveParameter : sensitiveParameters) {
+            if (parameters.containsKey(sensitiveParameter)) {
+                parameters.put(sensitiveParameter, "***MASKED***");
+                sanitized = true;
+            }
+        }
+        if (!sanitized) {
+            return;
+        }
+
+        // write back the query parameters to uri
+        try {
+            URI uri = new URI(span.getTag("uri"));
+
+            StringBuilder query = new StringBuilder();
+            parameters.forEach((key, val) -> {
+                query.append(key);
+                query.append("=");
+                query.append(val);
+                query.append("&");
+            });
+            query.deleteCharAt(query.length() - 1);
+
+            URI modified = new URI(uri.getScheme(),
+                                   uri.getUserInfo(),
+                                   uri.getHost(),
+                                   uri.getPort(),
+                                   uri.getPath(),
+                                   query.toString(),
+                                   uri.getFragment());
+
+            span.setTag("uri", modified.toString());
+        } catch (URISyntaxException ignored) {
+        }
+    }
+}

--- a/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
@@ -46,6 +46,7 @@ public class TraceSpan {
 
     @JsonIgnore
     private Map<String, String> urlParameters;
+
     public Map<String, String> getURLParameters() {
         if (urlParameters == null) {
             urlParameters = MiscUtils.parseURLParameters(tags.get("uri"));
@@ -64,7 +65,7 @@ public class TraceSpan {
     public void setTag(String name, String value) {
         try {
             this.tags.put(name, value);
-        } catch(UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException e) {
             this.tags = new HashMap<>(this.tags);
             this.tags.put(name, value);
         }

--- a/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
@@ -16,8 +16,11 @@
 
 package org.bithon.server.tracing.sink;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
+import org.bithon.server.common.utils.MiscUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,12 +44,30 @@ public class TraceSpan {
     public String clazz;
     public String method;
 
+    @JsonIgnore
+    private Map<String, String> urlParameters;
+    public Map<String, String> getURLParameters() {
+        if (urlParameters == null) {
+            urlParameters = MiscUtils.parseURLParameters(tags.get("uri"));
+        }
+        return urlParameters;
+    }
+
     public boolean containsTag(String name) {
         return tags.containsKey(name);
     }
 
     public String getTag(String name) {
         return tags.get(name);
+    }
+
+    public void setTag(String name, String value) {
+        try {
+            this.tags.put(name, value);
+        } catch(UnsupportedOperationException e) {
+            this.tags = new HashMap<>(this.tags);
+            this.tags.put(name, value);
+        }
     }
 
     @Override


### PR DESCRIPTION
After this, some sensitive information could be mask as demonstrated below

![image](https://user-images.githubusercontent.com/6525742/148764404-a472e242-059b-42db-9883-b0d3daff2abf.png)

New configuration introduced by this PR:

```yaml
bithon:
  tracing:
    globalSanitizer:
      type: uri
      args:
        sensitiveParameters:
          - password
```