### PR TITLE
Fix the value of interval in GroupBy query

### DIFF
--- a/server/sink/src/main/java/org/bithon/server/metric/storage/GroupByQuery.java
+++ b/server/sink/src/main/java/org/bithon/server/metric/storage/GroupByQuery.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import org.bithon.server.metric.DataSourceSchema;
 import org.bithon.server.metric.api.IQuerableAggregator;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -38,18 +39,21 @@ public class GroupByQuery {
     private final Interval interval;
 
     private final List<String> groupBys;
+    private final OrderBy orderBy;
 
     public GroupByQuery(DataSourceSchema dataSource,
                         List<String> metrics,
                         List<IQuerableAggregator> aggregators,
                         Collection<DimensionCondition> filters,
                         Interval interval,
-                        List<String> groupBys) {
+                        List<String> groupBys,
+                        @Nullable OrderBy orderBy) {
         this.dataSource = dataSource;
         this.metrics = metrics;
         this.aggregators = aggregators;
         this.filters = filters;
         this.interval = interval;
         this.groupBys = groupBys;
+        this.orderBy = orderBy;
     }
 }

--- a/server/sink/src/main/java/org/bithon/server/metric/storage/Interval.java
+++ b/server/sink/src/main/java/org/bithon/server/metric/storage/Interval.java
@@ -30,16 +30,16 @@ public class Interval {
     /**
      * in second
      */
-    private final int granularity;
+    private final int step;
 
     private Interval(TimeSpan startTime, TimeSpan endTime, int step) {
         this.startTime = startTime;
         this.endTime = endTime;
-        this.granularity = step;
+        this.step = step;
     }
 
     public static Interval of(TimeSpan start, TimeSpan end) {
-        return of(start, end, getGranularity(start, end));
+        return of(start, end, getStepLength(start, end));
     }
 
     public static Interval of(TimeSpan start, TimeSpan end, int step) {
@@ -49,7 +49,7 @@ public class Interval {
     /**
      * TODO: interval should be consistent with retention rules
      */
-    private static int getGranularity(TimeSpan start, TimeSpan end) {
+    private static int getStepLength(TimeSpan start, TimeSpan end) {
         long length = end.diff(start) / 1000;
         if (length >= 7 * 24 * 3600) {
             return 15 * 60;
@@ -80,14 +80,14 @@ public class Interval {
     /**
      * @return query granularity in seconds
      */
-    public int getGranularity() {
-        return granularity;
+    public int getStepLength() {
+        return step;
     }
 
     /**
      * @return the length of interval
      */
-    public int getLength() {
+    public int getTotalLength() {
         return (int) (endTime.getMilliseconds() - startTime.getMilliseconds()) / 1000;
     }
 }

--- a/server/sink/src/main/java/org/bithon/server/metric/storage/Interval.java
+++ b/server/sink/src/main/java/org/bithon/server/metric/storage/Interval.java
@@ -83,4 +83,11 @@ public class Interval {
     public int getGranularity() {
         return granularity;
     }
+
+    /**
+     * @return the length of interval
+     */
+    public int getLength() {
+        return (int) (endTime.getMilliseconds() - startTime.getMilliseconds()) / 1000;
+    }
 }

--- a/server/sink/src/main/java/org/bithon/server/metric/storage/OrderBy.java
+++ b/server/sink/src/main/java/org/bithon/server/metric/storage/OrderBy.java
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package org.bithon.server.metric.storage;
 
 import lombok.Data;

--- a/server/sink/src/main/java/org/bithon/server/metric/storage/OrderBy.java
+++ b/server/sink/src/main/java/org/bithon/server/metric/storage/OrderBy.java
@@ -1,0 +1,13 @@
+package org.bithon.server.metric.storage;
+
+import lombok.Data;
+
+/**
+ * @author Frank Chen
+ * @date 15/3/22 3:00 PM
+ */
+@Data
+public class OrderBy {
+    private String name;
+    private String order;
+}

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
@@ -75,10 +75,10 @@ public class MetricJdbcReader implements IMetricReader {
                                                     query.getInterval().getStartTime(),
                                                     query.getInterval().getEndTime(),
                                                     query.getDataSource(),
-                                                    query.getInterval().getGranularity()).filters(query.getFilters())
-                                                                                         .metrics(query.getMetrics())
-                                                                                         .groupBy(query.getGroupBys())
-                                                                                         .build();
+                                                    query.getInterval().getStepLength()).filters(query.getFilters())
+                                                                                        .metrics(query.getMetrics())
+                                                                                        .groupBy(query.getGroupBys())
+                                                                                        .build();
         return executeSql(sql);
     }
 
@@ -91,7 +91,7 @@ public class MetricJdbcReader implements IMetricReader {
                                                                                       "OUTER",
                                                                                       query.getDataSource(),
                                                                                       ImmutableMap.of("interval",
-                                                                                                      query.getInterval().getLength()));
+                                                                                                      query.getInterval().getTotalLength()));
 
         // put non-post aggregator metrics before the post
         String metricList = query.getMetrics()

--- a/server/web-app/src/main/resources/static/js/component/dashboard/component.js
+++ b/server/web-app/src/main/resources/static/js/component/dashboard/component.js
@@ -206,7 +206,7 @@ class Dashboard {
                 const yAxis = metricDef.yAxis == null ? 0 : metricDef.yAxis;
                 formatterFn = this._formatters[chartDescriptor.yAxis[yAxis].format];
             }
-            if ( formatterFn == null ) {
+            if (formatterFn == null) {
                 // if this metric is not found, format in default ways
                 formatterFn = (v) => {
                     return v.formatCompactNumber();

--- a/server/web-app/src/main/resources/static/js/component/dashboard/component.js
+++ b/server/web-app/src/main/resources/static/js/component/dashboard/component.js
@@ -205,7 +205,8 @@ class Dashboard {
             if (metricDef != null && chartDescriptor.yAxis !== undefined) {
                 const yAxis = metricDef.yAxis == null ? 0 : metricDef.yAxis;
                 formatterFn = this._formatters[chartDescriptor.yAxis[yAxis].format];
-            } else {
+            }
+            if ( formatterFn == null ) {
                 // if this metric is not found, format in default ways
                 formatterFn = (v) => {
                     return v.formatCompactNumber();

--- a/server/web-app/src/main/resources/static/js/component/table/component.js
+++ b/server/web-app/src/main/resources/static/js/component/table/component.js
@@ -31,11 +31,17 @@ class TableComponent {
             this.mColumnMap[column.field] = column;
 
             if (column.format !== undefined) {
+                // formatter is an option provided by bootstrap-table
                 column.formatter = this.mFormatters[column.format];
                 if (column.format === 'detail') {
                     this.mDetailViewField = column.field;
                 }
             }
+
+            // original sorter uses string.localeCompare
+            // That comparator returns different order from the result ordered by the server
+            // So here we define a new comparator
+            column.sorter = (a, b) => this.#compare(a, b);
         }
         this.mDetailView = this.mDetailViewField != null;
     }
@@ -97,6 +103,14 @@ class TableComponent {
         }
     }
 
+    #compare(a, b) {
+        if (a === b) {
+            return 0;
+        } else {
+            return a < b ? -1 : 1;
+        }
+    }
+
     #showDetail(index, row) {
         return '<pre>' + row[this.mDetailViewField] + '</pre>';
     }
@@ -104,6 +118,14 @@ class TableComponent {
     #getQueryParams(params) {
         this.mQueryParam.pageNumber = params.pageNumber - 1;
         this.mQueryParam.pageSize = params.pageSize;
+        if (params.sortName === undefined) {
+            delete this.mQueryParam.orderBy;
+        } else {
+            this.mQueryParam.orderBy = {
+                name: params.sortName,
+                order: params.sortOrder
+            };
+        }
         return this.mQueryParam;
     }
 

--- a/server/web-service/src/main/java/org/bithon/server/web/service/api/DataSourceApi.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/api/DataSourceApi.java
@@ -105,7 +105,8 @@ public class DataSourceApi {
                                                                                       request.getAggregators(),
                                                                                       request.getFilters(),
                                                                                       Interval.of(start, end),
-                                                                                      request.getGroupBy()));
+                                                                                      request.getGroupBy(),
+                                                                                      request.getOrderBy()));
     }
 
     @PostMapping("/api/datasource/list")

--- a/server/web-service/src/main/java/org/bithon/server/web/service/api/DataSourceService.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/api/DataSourceService.java
@@ -60,7 +60,7 @@ public class DataSourceService {
         int j = 0;
         TimeSpan start = query.getInterval().getStartTime();
         TimeSpan end = query.getInterval().getEndTime();
-        int step = query.getInterval().getGranularity();
+        int step = query.getInterval().getStepLength();
         for (long bucket = start.toSeconds() / step * step, endBucket = end.toSeconds() / step * step;
              bucket < endBucket;
              bucket += step) {
@@ -103,7 +103,7 @@ public class DataSourceService {
 
         TimeSpan start = query.getInterval().getStartTime();
         TimeSpan end = query.getInterval().getEndTime();
-        int step = query.getInterval().getGranularity();
+        int step = query.getInterval().getStepLength();
         long startSecond = start.toSeconds() / step * step;
         long endSecond = end.toSeconds() / step * step;
         int bucketCount = (int) (endSecond - startSecond) / step;

--- a/server/web-service/src/main/java/org/bithon/server/web/service/api/GroupByQueryRequest.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/api/GroupByQueryRequest.java
@@ -19,6 +19,7 @@ package org.bithon.server.web.service.api;
 import lombok.Data;
 import org.bithon.server.metric.api.IQuerableAggregator;
 import org.bithon.server.metric.storage.DimensionCondition;
+import org.bithon.server.metric.storage.OrderBy;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
@@ -49,4 +50,6 @@ public class GroupByQueryRequest {
     @Valid
     @Size(min = 1)
     private List<String> groupBy;
+
+    private OrderBy orderBy;
 }

--- a/server/web-service/src/main/java/org/bithon/server/web/service/topo/api/TopoApi.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/topo/api/TopoApi.java
@@ -73,7 +73,8 @@ public class TopoApi {
                                                                   new DimensionCondition("srcEndpointType",
                                                                                          new EqualMatcher(EndPointType.APPLICATION.name()))),
                                                     Interval.of(start, end),
-                                                    Arrays.asList("dstEndpoint", "dstEndpointType"));
+                                                    Arrays.asList("dstEndpoint", "dstEndpointType"),
+                                                    null);
         List<Map<String, Object>> callees = metricReader.groupBy(calleeQuery);
 
         int x = 300;
@@ -113,7 +114,8 @@ public class TopoApi {
                                                                   new DimensionCondition("dstEndpointType",
                                                                                          new EqualMatcher(EndPointType.APPLICATION.name()))),
                                                     Interval.of(start, end),
-                                                    Arrays.asList("srcEndpoint", "srcEndpointType"));
+                                                    Arrays.asList("srcEndpoint", "srcEndpointType"),
+                                                    null);
         List<Map<String, Object>> callers = metricReader.groupBy(callerQuery);
 
         y = 300;

--- a/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
@@ -184,7 +184,7 @@ public class TraceService {
                                                     Collections.emptyList());
 
         return new GetTraceDistributionResponse(metricStorage.createMetricReader(schema).timeseries(query),
-                                                interval.getGranularity());
+                                                interval.getStepLength());
     }
 
     static class Bucket {


### PR DESCRIPTION
1. Support OrderBy semantics on GroupBy query
2. Fix the value of interval in GroupBy query

For WebApp
1. Keeps the order state when table content is refreshed
3. Use the default formatter in detailed view if there's no formatter specified