### PR TITLE
Support to log HTTP Response headers

### DIFF
--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/config/GatewayFilterConfigs.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/config/GatewayFilterConfigs.java
@@ -30,6 +30,10 @@ import java.util.Map;
 public class GatewayFilterConfigs extends HashMap<String, GatewayFilterConfigs.Filter> {
     public static class Filter {
         private String mode;
+
+        /**
+         * defines which attributes on the {@link import org.springframework.web.server.ServerWebExchange} object should be recorded to the span log
+         */
         private Map<String, String> attributes = Collections.emptyMap();
 
         public String getMode() {

--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/config/ResponseConfigs.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/config/ResponseConfigs.java
@@ -1,0 +1,39 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.spring.webflux.config;
+
+import org.bithon.agent.core.config.ConfigurationProperties;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Frank Chen
+ * @date 24/3/22 12:25 PM
+ */
+@ConfigurationProperties(prefix = "agent.plugin.spring.webflux.response")
+public class ResponseConfigs {
+    private Map<String, String> headers = Collections.emptyMap();
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+}

--- a/doc/configuration/agent-plugin/spring-webflux.md
+++ b/doc/configuration/agent-plugin/spring-webflux.md
@@ -1,0 +1,28 @@
+
+## Example Configurations
+
+```yml
+agent:
+  plugin:
+    spring:
+      webflux:
+        response:
+          headers:
+            HEADER_NAME: TAG_NAME_IN_SPAN
+        gateway:
+          org.springframework.cloud.gateway.filter.AdaptCachedBodyGlobalFilter:
+            mode: before
+          org.springframework.cloud.gateway.filter.NettyRoutingFilter:
+            mode: around
+```
+
+- agent.plugin.spring.webflux.gateway
+
+    This configuration configures users' Spring Gateway Filter classes to be instrumented
+
+- agent.plugin.spring.webflux.response.headers
+
+    A map that specifies which headers in the HTTP Response should be logged in the `tags` of span log.
+    
+    - key, the HEADER name in the HTTP response.
+    - val, the tag name in the span log.

--- a/doc/configuration/configuration-agent.md
+++ b/doc/configuration/configuration-agent.md
@@ -45,3 +45,4 @@ Plugin configuration locates each plugin's resource directory with the name 'plu
 # Plugin Configurations
 
 - [Alibaba Druid](agent-plugin/jdbc-druid.md)
+- [Spring WebFlux](agent-plugin/spring-webflux.md)


### PR DESCRIPTION
Supports the #321 

Allows to configure which headers in the responses should be logged to the `tags` of a span log. Currently WebFlux is supported to minimize the work. 

By doing this, the span logs can contain some users' customized headers in the span log so that these headers values can be searched in the span log from the metrics data.