### PR TITLE
Remove time interval from search bar

### DIFF
--- a/server/web-app/src/main/resources/static/js/component/searchbar/component.js
+++ b/server/web-app/src/main/resources/static/js/component/searchbar/component.js
@@ -19,15 +19,6 @@ class SearchBar {
             '            <form class="d-inline" style="width: 40%">\n' +
             '                <div class="input-group">\n' +
             '                    <input type="text" class="form-control" placeholder="trace id/query id">\n' +
-            '                    <div class="col-sm-3" style="padding: 0">' +
-            '                       <select class="form-control">' +
-            '                          <option selected>Today</option>' +
-            '                          <option>Yesterday</option>' +
-            '                          <option>This Week</option>' +
-            '                          <option>Last Week</option>' +
-            '                          <option>All</option>' +
-            '                       </select>' +
-            '                    </div>' +
             '                    <span class="input-group-append">\n' +
             '                        <button class="btn btn-outline-secondary" type="button"><i class=\'fa fa-search\'></i></button>\n' +
             '                    </span>\n' +
@@ -41,9 +32,6 @@ class SearchBar {
                 event.preventDefault();
             }
         );
-        this._vIntervalSelect = navbar.find("select").change((event) => {
-            this._timeRange = event.target.selectedIndex;
-        });
 
         //
         // Binding input to view and model
@@ -58,51 +46,16 @@ class SearchBar {
         if (id === '') {
             return;
         }
-        if (id === this._mInputId && this._vIntervalSelect.val() === this._mInputInterval) {
+        if (id === this._mInputId) {
             // no change
             return;
         }
 
-        const interval = this.getInterval();
-        const uri = `/web/trace/detail?id=${id}&type=auto&interval=${encodeURI(interval.start + "/" + interval.end)}`;
+        const uri = `/web/trace/detail?id=${id}&type=auto`;
         if (this._mOpenNewWindow) {
             window.open(uri);
         } else {
             window.location.href = uri;
-        }
-    }
-
-    getInterval() {
-        switch (this._vIntervalSelect.prop('selectedIndex')) {
-            case 0://today
-                return {
-                    start: moment().utc().local().startOf('day').toISOString(),
-                    end: moment().utc().local().toISOString()
-                }
-            case 1://yesterday
-                const start = moment().utc().local().startOf('day').subtract(1, 'day');
-                return {
-                    start: start.toISOString(),
-                    end: start.add(1, 'day').toISOString()
-                };
-            case 2://This Week
-                return {
-                    start: moment().utc().local().startOf('week').toISOString(),
-                    end: moment().utc().local().toISOString()
-                };
-            case 3://Last Week
-            {
-                const start = moment().utc().local().startOf('week').subtract(7, 'day');
-                return {
-                    start: start.toISOString(),
-                    end: start.add(7, 'day').toISOString()
-                };
-            }
-            default:
-                return {
-                    start: "2022-01-01T00:00:00.000Z",
-                    end: "2099-12-31T00:00:00.000Z"
-                };
         }
     }
 }


### PR DESCRIPTION
Fixes #359 

No changes on the server side although this would make the search less efficient.

The reason is how to determine the interval? Let's say if we search in [now - 1d, now] interval, what if there're some logs outside that range, for example in the range of [now -1d - xSecond, now - 1d]?

So, to simply the logic, the less efficient logic would give us correct result on the edge cases.