### PR TITLE
Add profiling page for tracing logs

### DIFF
--- a/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
@@ -108,7 +108,7 @@ public class TraceSpan {
                 // compatibility
                 uri = tags.getOrDefault("uri", "");
             }
-            this.normalizeUri = uriNormalizer.normalize(this.appName, uri).getUri();
+            this.normalizedUri = uriNormalizer.normalize(this.appName, uri).getUri();
         }
     }
 

--- a/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
+++ b/server/sink/src/main/java/org/bithon/server/tracing/sink/TraceSpan.java
@@ -57,7 +57,7 @@ public class TraceSpan {
     public String clazz;
     public String method;
     public String status = "";
-    public String normalizeUri = "";
+    public String normalizedUri = "";
 
     @JsonIgnore
     private Map<String, String> uriParameters;

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/TraceJdbcWriter.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/TraceJdbcWriter.java
@@ -125,7 +125,7 @@ public class TraceJdbcWriter implements ITraceWriter {
                       span.endTime,
                       span.costTime,
                       tags,
-                      span.getNormalizeUri(),
+                      span.getNormalizedUri(),
                       span.getStatus());
         }
         step.execute();

--- a/server/web-app/src/main/java/org/bithon/server/webapp/ui/AppController.java
+++ b/server/web-app/src/main/java/org/bithon/server/webapp/ui/AppController.java
@@ -42,6 +42,10 @@ public class AppController {
         return "app/index";
     }
 
+    /**
+     * use {@link #dashBoardPage}
+     */
+    @Deprecated
     @GetMapping("/web/app/metric/{appName}/{dashboardName}")
     public String webServerPage(@PathVariable("appName") String appName,
                                 @PathVariable("dashboardName") String dashboardName,
@@ -56,6 +60,18 @@ public class AppController {
         return "app/dashboard";
     }
 
+    @GetMapping("/web/metrics/{dashboardName}")
+    public String dashBoardPage(@PathVariable("dashboardName") String dashboardName,
+                                Model model) {
+        model.addAttribute("apiHost", serviceDiscovery.getApiHost());
+        model.addAttribute("dashboardName", dashboardName);
+        return "app/dashboard";
+    }
+
+    /**
+     * use TraceController
+     */
+    @Deprecated
     @GetMapping("/web/app/trace/{appName}")
     public String traceHomePage(@PathVariable("appName") String appName,
                                 Model model) {
@@ -64,6 +80,7 @@ public class AppController {
         return "app/trace";
     }
 
+    @Deprecated
     @GetMapping("/web/app/topo/{appName}")
     public String topoHome(@PathVariable("appName") String appName,
                            Model model) {
@@ -72,10 +89,23 @@ public class AppController {
         return "app/topo";
     }
 
+    @GetMapping("/web/topo")
+    public String topoHome(Model model) {
+        model.addAttribute("apiHost", serviceDiscovery.getApiHost());
+        return "app/topo";
+    }
+
+    @Deprecated
     @GetMapping("/web/app/event/{appName}")
     public String eventHome(@PathVariable("appName") String appName, Model model) {
         model.addAttribute("apiHost", serviceDiscovery.getApiHost());
         model.addAttribute("appName", appName);
+        return "app/event";
+    }
+
+    @GetMapping("/web/event")
+    public String eventHome(Model model) {
+        model.addAttribute("apiHost", serviceDiscovery.getApiHost());
         return "app/event";
     }
 }

--- a/server/web-app/src/main/java/org/bithon/server/webapp/ui/DashboardController.java
+++ b/server/web-app/src/main/java/org/bithon/server/webapp/ui/DashboardController.java
@@ -21,10 +21,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.bithon.server.webapp.services.ServiceDiscovery;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternUtils;
 import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,6 +51,8 @@ import java.util.stream.Collectors;
 @Slf4j
 @RestController
 public class DashboardController {
+
+    private final ServiceDiscovery serviceDiscovery;
 
     @Getter
     @AllArgsConstructor
@@ -125,7 +129,8 @@ public class DashboardController {
         }
     }
 
-    public DashboardController(ObjectMapper om, ResourceLoader resourceLoader) {
+    public DashboardController(ServiceDiscovery serviceDiscovery, ObjectMapper om, ResourceLoader resourceLoader) {
+        this.serviceDiscovery = serviceDiscovery;
         this.dashboardConfigs = new DashboardLoader(om, resourceLoader).loadDashboard();
         this.dashboardNames = this.dashboardConfigs.values()
                                                    .stream()

--- a/server/web-app/src/main/java/org/bithon/server/webapp/ui/DashboardController.java
+++ b/server/web-app/src/main/java/org/bithon/server/webapp/ui/DashboardController.java
@@ -26,7 +26,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternUtils;
 import org.springframework.http.HttpStatus;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;

--- a/server/web-app/src/main/java/org/bithon/server/webapp/ui/TraceController.java
+++ b/server/web-app/src/main/java/org/bithon/server/webapp/ui/TraceController.java
@@ -45,4 +45,10 @@ public class TraceController {
         model.addAttribute("apiHost", serviceDiscovery.getApiHost());
         return "trace/search";
     }
+
+    @GetMapping("/web/trace/profiling")
+    public String profiling(Model model) {
+        model.addAttribute("apiHost", serviceDiscovery.getApiHost());
+        return "trace/profiling";
+    }
 }

--- a/server/web-app/src/main/java/org/bithon/server/webapp/ui/TraceController.java
+++ b/server/web-app/src/main/java/org/bithon/server/webapp/ui/TraceController.java
@@ -34,6 +34,12 @@ public class TraceController {
         this.serviceDiscovery = serviceDiscovery;
     }
 
+    @GetMapping("/web/trace/list")
+    public String traceList(Model model) {
+        model.addAttribute("apiHost", serviceDiscovery.getApiHost());
+        return "app/trace";
+    }
+
     @GetMapping("/web/trace/detail")
     public String traceHome(Model model) {
         model.addAttribute("apiHost", serviceDiscovery.getApiHost());

--- a/server/web-app/src/main/resources/static/js/app-card-component.js
+++ b/server/web-app/src/main/resources/static/js/app-card-component.js
@@ -44,7 +44,7 @@ class AppCardComponent {
 
         card.find('.card').attr('id', appName);
         card.find('.app-name').html('<a href="#">' + appName + '</a>').click(() => {
-            window.location.href = '/web/app/metric/' + appName + '/jvm-metrics';
+            window.location.href = '/web/metrics/jvm-metrics?appName=' + appName;
         });
         this._container.append(card);
     }

--- a/server/web-app/src/main/resources/static/js/component/app-selector/component.js
+++ b/server/web-app/src/main/resources/static/js/component/app-selector/component.js
@@ -22,8 +22,9 @@ class AppSelector {
         this.mSelectedFilters = {};
     }
 
-    createAppSelector(appName) {
-        this.#addFilter("appName", appName);
+    createAppSelector() {
+        g_SelectedApp = window.queryParams['appName'];
+        this.#addFilter("appName", g_SelectedApp);
 
         //
         // create app selector
@@ -38,11 +39,11 @@ class AppSelector {
             });
         });
 
-        this.vAppSelector.append(`<option value="${appName}">${appName}</option>`).change();
+        this.vAppSelector.append(`<option value="${g_SelectedApp}">${g_SelectedApp}</option>`).change();
 
         this.vAppSelector.change((e) => {
             const application = e.target.selectedOptions[0].value;
-
+            g_SelectedApp = application;
             this.#addFilter("appName", application);
             this.#onSelectionChanged('application', application);
         });

--- a/server/web-app/src/main/resources/static/js/component/app-selector/component.js
+++ b/server/web-app/src/main/resources/static/js/component/app-selector/component.js
@@ -17,6 +17,8 @@ class AppSelector {
         this.mQueryCache = [];
         this.mQueryVariablepPrefix = option.queryVariablePrefix || '';
 
+        this.mFilterNames = [];
+
         this.mSelectedFilters = {};
     }
 
@@ -48,17 +50,17 @@ class AppSelector {
         return this;
     }
 
-    createFilter(dataSourceName) {
+    createFilter(dataSourceName, keepAppFilter = false) {
         this.mDataSource = dataSourceName;
         new SchemaApi().getSchema({
             name: dataSourceName,
             async: false,
-            successCallback: (schema) => this.createFilterFromSchema(schema)
+            successCallback: (schema) => this.createFilterFromSchema(schema, keepAppFilter)
         });
         return this;
     }
 
-    createFilterFromSchema(schema) {
+    createFilterFromSchema(schema, keepAppFilter = false) {
         this.mDataSource = schema.name;
         this.mSchema = schema;
 
@@ -68,7 +70,7 @@ class AppSelector {
             if (!dimension.visible)
                 continue;
 
-            if (index === 0 && dimension.alias === 'appName') {
+            if (index === 0 && dimension.alias === 'appName' && !keepAppFilter) {
                 // for appName filter, createAppSelector should be explicitly called
                 continue;
             }
@@ -77,7 +79,13 @@ class AppSelector {
         }
     }
 
+    getFilterName() {
+        return this.mFilterNames;
+    }
+
     #createDimensionFilter(dimensionIndex, dimensionName, displayText) {
+        this.mFilterNames.push(dimensionName);
+
         const filterName = this.mQueryVariablepPrefix + dimensionName;
 
         // create selector

--- a/server/web-app/src/main/resources/static/js/component/dashboard/component.js
+++ b/server/web-app/src/main/resources/static/js/component/dashboard/component.js
@@ -43,11 +43,11 @@ class Dashboard {
         }).registerChangedListener((name, value) => {
             if (name === 'application') {
                 g_SelectedApp = value;
-                window.history.pushState('', '', `/web/app/metric/${value}/${this._dashboardName}?interval=${g_MetricSelectedInterval}`);
+                window.history.pushState('', '', `/web/metrics/${this._dashboardName}?appName=${value}&interval=${g_MetricSelectedInterval}`);
             }
 
             this.refreshDashboard();
-        }).createAppSelector(this._appName);
+        }).createAppSelector();
 
         //
         // dataSource --> Charts
@@ -326,7 +326,7 @@ class Dashboard {
         const startTime = moment(start).local().format('yyyy-MM-DD HH:mm:ss');
         const endTime = moment(end).local().format('yyyy-MM-DD HH:mm:ss');
 
-        let url = `/web/trace/search?appName=${this._appName}&`;
+        let url = `/web/trace/search?appName=${g_SelectedApp}&`;
 
         const instanceFilter = this.vFilter.getSelectedFilter("instanceName");
         if (instanceFilter != null) {

--- a/server/web-app/src/main/resources/static/js/component/sidebar/component.js
+++ b/server/web-app/src/main/resources/static/js/component/sidebar/component.js
@@ -1,7 +1,6 @@
 class MetricSidebar {
     constructor(containerId, appName) {
         this._container = $('#' + containerId);
-        this._appName = appName;
     }
 
     load() {
@@ -20,8 +19,8 @@ class MetricSidebar {
 
     // PRIVATE
     addDashboardItem(item) {
-        const i = $(`<a href="#">${item.text}</a>`).click(() => {
-            let url = `/web/app/metric/${g_SelectedApp}/${item.id}?interval=${g_MetricSelectedInterval}`;
+        const i = $(`<a>${item.text}</a>`).click(() => {
+            let url = `/web/metrics/${item.id}?appName=${g_SelectedApp}&interval=${g_MetricSelectedInterval}`;
             if ( g_SelectedInstance != null ) {
                 url += `&instanceName=${g_SelectedInstance}`;
             }

--- a/server/web-app/src/main/resources/static/js/page/trace/profiling-page.js
+++ b/server/web-app/src/main/resources/static/js/page/trace/profiling-page.js
@@ -1,0 +1,298 @@
+class ProfilingPage {
+    constructor() {
+        // Model
+        this.mStartTime = 0;
+
+        // this View Model
+        this.mInterval = null;
+
+        // View
+        this.vChartComponent = new ChartComponent({
+            containerId: 'profiling',
+            height: '700px',
+            showLegend: false
+        }).header('<b>Profiling</b>');
+        this.vChartComponent.setClickHandler((e) => {
+            this.#onClickChart(e);
+        });
+
+        // View
+        this.vFilters = new AppSelector({
+            parentId: 'filterBar',
+            intervalProvider: () => this.#getInterval()
+        }).registerChangedListener((name, value) => {
+            if (name === 'application') {
+                g_SelectedApp = value;
+            }
+            this.#refreshPage();
+        }).createFilter('trace_span_summary', true);
+
+        // View, tag filter
+        this.vTagFilter = new AppSelector({
+            parentId: 'filterBar',
+            queryVariablePrefix: 'tags.',
+            intervalProvider: () => this.#getInterval()
+        }).registerChangedListener((name, value) => {
+            this.#refreshPage();
+        }).createFilter('trace_span_tag_index');
+
+        const parent = $('#filterBarForm');
+
+        // View - Refresh Button
+        parent.append('<button class="btn btn-outline-secondary" style="border-radius:0;border-color: #ced4da" type="button"><i class="fas fa-sync-alt"></i></button>')
+            .find("button").click(() => {
+            // get new interval
+            this.mInterval = this.vIntervalSelector.getInterval();
+
+            // refresh the page
+            this.#refreshPage();
+        });
+
+        // View
+        this.vIntervalSelector = new TimeInterval(window.queryParams['interval']).childOf(parent).registerIntervalChangedListener((selectedModel) => {
+            this.mInterval = this.vIntervalSelector.getInterval();
+            this.#refreshPage();
+        });
+        this.mInterval = this.vIntervalSelector.getInterval();
+    }
+
+    #getInterval() {
+        return this.mInterval;
+    }
+
+    #getFilters() {
+        let summaryTableFilter = this.vFilters.getSelectedFilters();
+        let tagFilters = this.vTagFilter.getSelectedFilters();
+        return summaryTableFilter.concat(tagFilters);
+    }
+
+    #refreshPage() {
+        this.#refreshChart();
+    }
+
+    #refreshChart() {
+        const filters = this.#getFilters();
+        let isAppSelected = false;
+        let isInstanceSelected = false;
+        for (let i = 0; i < filters.length; i++) {
+            switch (filters[i].dimension) {
+                case 'appName':
+                    isAppSelected = true;
+                    break;
+                case 'instanceName':
+                    isInstanceSelected = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (!isAppSelected) {
+            bootbox.alert('Please select an application.');
+            return;
+        }
+        if (!isInstanceSelected) {
+            bootbox.alert('Please select an instance.');
+            return;
+        }
+
+        const interval = this.#getInterval();
+        this.vChartComponent.load({
+            url: apiHost + '/api/trace/getTraceList',
+            ajaxData: JSON.stringify({
+                startTimeISO8601: interval.start,
+                endTimeISO8601: interval.end,
+                filters: this.#getFilters(),
+                orderBy: 'startTime',
+                order: 'asc',
+                pageNumber: 0,
+                pageSize: 1000
+            }),
+            processResult: (data) => {
+                const ret = this.#toProfilingLogs(data.rows);
+                this._data = ret.spans;
+
+                const categories = [];
+                for (let i = 0; i < ret.rows; i++) {
+                    categories.push(i);
+                }
+                const op = this.getDefaultChartOption();
+                op.yAxis = {
+                    data: categories
+                };
+                //op.xAxis = {data: timeLabels, type: 'category'};
+                op.series[0].data = this._data;
+                return op;
+            }
+        });
+    }
+
+    #toProfilingLogs(spans) {
+        const rows = [];
+
+        this.mStartTime = spans.length > 0 ? spans[0].startTime : 0;
+        for (let i = 0; i < spans.length; i++) {
+            const span = spans[i];
+
+            // always search the row from index 0 so that the latest rows are used
+            let found = -1;
+            for (let j = 0; j < rows.length; j++) {
+                if (span.startTime > rows[j].endTime) {
+                    // this span can be put in this row
+                    found = j;
+                    break;
+                }
+            }
+            if (found === -1) {
+                // add a new layer
+                rows.push({
+                    index: rows.length,
+                    endTime: span.endTime
+                });
+                found = rows.length - 1;
+            }
+            rows[found].endTime = span.endTime;
+
+            span.value = [
+                found,
+                span.startTime - this.mStartTime,
+                span.endTime - this.mStartTime,
+                span.costTime / 1000
+            ];
+
+            // apply item style
+            this.#applySpanLogStyle(span);
+        }
+
+        return {
+            spans: spans,
+            rows: rows.length
+        };
+    }
+
+    #applySpanLogStyle(span) {
+        if (span.status !== '200') {
+            let color = '';
+            switch (span.status.charAt(0)) {
+                case '4':
+                    color = 'orange';
+                    break;
+                case '5':
+                    color = 'red';
+                    break;
+                default:
+                    color = 'yellow';
+                    break;
+            }
+            span.itemStyle = {
+                normal: {
+                    color: color
+                }
+            };
+        }
+    }
+
+    #format(obj, name, formatter = (v) => v) {
+        const val = obj[name];
+        if (val !== undefined) {
+            return `<b>${name}</b> : ${formatter(val)}<br/>`;
+        }
+        return '';
+    }
+
+    // PRIVATE
+    getDefaultChartOption() {
+        return {
+            tooltip: {
+                formatter: (params) => {
+                    const span = params.data;
+                    if (span.tooltip === undefined) {
+                        let tooltip = this.#format(span, 'normalizedUri');
+                        tooltip += this.#format(span, 'status');
+                        tooltip += this.#format(span, 'startTime', (v) => new Date(v / 1000).format('MM-dd hh:mm:ss'));
+                        tooltip += this.#format(span, 'costTime', microFormat);
+
+                        const filterNames = this.vTagFilter.getFilterName();
+                        for (let i = 0; i < filterNames; i++) {
+                            tooltip += this.#format(span, filterNames[i]);
+                        }
+
+                        span.tooltip = tooltip;
+                    }
+                    return span.tooltip;
+                }
+            },
+            dataZoom: [
+                {
+                    type: 'slider',
+                    filterMode: 'weakFilter',
+                    showDataShadow: false,
+                    bottom: 20,
+                    labelFormatter: ''
+                },
+                {
+                    type: 'inside',
+                    filterMode: 'weakFilter'
+                }
+            ],
+            grid: {
+                height: 550,
+                left: 50,
+                right: 80
+            },
+            xAxis: {
+                min: 0,
+                scale: true,
+                axisLabel: {
+                    formatter: (val) => microFormat(val) + '\n' + new Date(this.mStartTime / 1000 + val).format('MM-dd hh:mm:ss')
+                }
+            },
+            series: [
+                {
+                    type: 'custom',
+                    renderItem: this.#renderItem,
+                    itemStyle: {
+                        opacity: 0.8
+                    },
+                    encode: {
+                        x: [1, 2],
+                        y: 0
+                    }
+                }
+            ]
+        };
+    }
+
+    #renderItem(params, api) {
+        const categoryIndex = api.value(0);
+        const start = api.coord([api.value(1), categoryIndex]);
+        const end = api.coord([api.value(2), categoryIndex]);
+        const height = api.size([0, 1])[1] * 0.6;
+        const rectShape = echarts.graphic.clipRectByRect(
+            {
+                x: start[0],
+                y: start[1] - height / 2,
+                width: end[0] - start[0],
+                height: height
+            },
+            {
+                x: params.coordSys.x,
+                y: params.coordSys.y,
+                width: params.coordSys.width,
+                height: params.coordSys.height
+            }
+        );
+        return (
+            rectShape && {
+                type: 'rect',
+                transition: ['shape'],
+                shape: rectShape,
+                style: api.style()
+            }
+        );
+    }
+
+    #onClickChart(e) {
+        const span = this._data[e.dataIndex];
+        window.open(`/web/trace/detail/?id=${span.traceId}`);
+    }
+}

--- a/server/web-app/src/main/resources/static/js/page/trace/profiling-page.js
+++ b/server/web-app/src/main/resources/static/js/page/trace/profiling-page.js
@@ -243,7 +243,7 @@ class ProfilingPage {
                 min: 0,
                 scale: true,
                 axisLabel: {
-                    formatter: (val) => microFormat(val) + '\n' + new Date(this.mStartTime / 1000 + val).format('MM-dd hh:mm:ss')
+                    formatter: (val) => microFormat(val) + '\n' + new Date((this.mStartTime + val) / 1000).format('MM-dd hh:mm:ss')
                 }
             },
             series: [

--- a/server/web-app/src/main/resources/static/js/utils/location.js
+++ b/server/web-app/src/main/resources/static/js/utils/location.js
@@ -20,6 +20,13 @@ function toQueryParameters(query) {
         parameters[name] = value;
     }
 
+    if (parameters['appName'] != null) {
+        g_SelectedApp = parameters['appName'];
+    }
+    if(parameters['instanceName'] != null) {
+        g_SelectedInstance = parameters['instanceName'];
+    }
+
     return parameters;
 }
 

--- a/server/web-app/src/main/resources/templates/app/app-layout.html
+++ b/server/web-app/src/main/resources/templates/app/app-layout.html
@@ -60,9 +60,9 @@
 
     <script th:inline="javascript">
         const apiHost = [[${apiHost}]];
-        let g_SelectedApp = [[${appName}]];
+        let g_SelectedApp = window.queryParams['appName'];
         let g_SelectedInstance = window.queryParams['instanceName'];
-        let g_MetricSelectedInterval = [[${interval} ?: '5m']];
+        let g_MetricSelectedInterval = window.queryParams['interval'];
     </script>
     <script th:src="@{/js/api-client/schema-api.js}"></script>
     <script th:src="@{/js/component/dashboard/component.js}"></script>
@@ -76,14 +76,19 @@
     <script th:src="@{/js/component/time-interval/component.js}"></script>
     <script th:src="@{/js/component/app-selector/component.js}"></script>
 
+    <style>
+        li a {
+            cursor: pointer
+        }
+    </style>
     <script>
-        function redirect(module, submodule) {
-            let url = `/web/app/${module}/${g_SelectedApp}`;
-            if (submodule !== undefined) {
-                url += `/${submodule}`;
+        function redirect(url) {
+            url += '/?';
+            if (g_SelectedApp != null) {
+                url += 'appName=' + g_SelectedApp;
             }
             if (g_SelectedInstance != null) {
-                url += `?instanceName=${g_SelectedInstance}`;
+                url += `&instanceName=${g_SelectedInstance}`;
             }
             window.location = url;
         }
@@ -98,18 +103,18 @@
             <div class=" sidebar-item sidebar-menu">
                 <ul>
                     <li class="sidebar">
-                        <a th:href="@{'/web/app/topo/' + ${appName}}">
+                        <a href="#" onclick="redirect('/web/topo/')">
                             <i class="fa fa-tachometer-alt"></i>
                             <span class="menu-text">Topo</span>
                         </a>
                     </li>
-                    <li class="sidebar-dropdown active">
-                        <a href="#">
+                    <li class="sidebar-dropdown">
+                        <a class="metrics-anchor" href="#">
                             <i class="fa fa-tachometer-alt"></i>
                             <span class="menu-text">Metrics</span>
                             <!--                            <span class="badge badge-pill badge-warning">New</span>-->
                         </a>
-                        <div class="sidebar-submenu" style="display:block">
+                        <div class="sidebar-submenu">
                             <ul>
                                 <li id="metricSidebar">
                                 </li>
@@ -117,25 +122,25 @@
                         </div>
                     </li>
 
-                    <li class="sidebar-dropdown">
-                        <a href="#">
+                    <li class="sidebar-dropdown tracing">
+                        <a class="tracing-anchor" href="#">
                             <i class="far fa-gem"></i>
                             <span class="menu-text">Tracing</span>
                         </a>
                         <div class="sidebar-submenu">
                             <ul>
                                 <li>
-                                    <a href="#" onclick="javascript:redirect('trace')">Span Logs</a>
+                                    <a onclick="redirect('/web/trace/list')">Log View</a>
                                 </li>
                                 <li>
-                                    <a href="#" onclick="">Profile</a>
+                                    <a onclick="redirect('/web/trace/profiling')">Profiling View</a>
                                 </li>
                             </ul>
                         </div>
                     </li>
 
                     <li class="sidebar">
-                        <a href="#" onclick="javascript:redirect('event')">
+                        <a onclick="redirect('/web/event')">
                             <i class="fa fa-shopping-cart"></i>
                             <span class="menu-text">Event</span>
                         </a>
@@ -350,6 +355,11 @@
 </body>
 <script th:inline="javascript">
     $(document).ready(() => {
+        if (window.location.href.indexOf('/web/metrics/') > 0) {
+            $('.metrics-anchor').click();
+        } else if (window.location.href.indexOf('/web/trace/') > 0) {
+            $('.tracing-anchor').click();
+        }
         $('.page-wrapper').bind('pinned', () => {
             const handler = window.setInterval(() => {
                 $(window).trigger('resize');

--- a/server/web-app/src/main/resources/templates/app/app-layout.html
+++ b/server/web-app/src/main/resources/templates/app/app-layout.html
@@ -116,13 +116,24 @@
                             </ul>
                         </div>
                     </li>
-                    <li class="sidebar">
-                        <a href="#" onclick="javascript:redirect('trace')">
-                            <i class="fa fa-shopping-cart"></i>
-                            <span class="menu-text">Trace</span>
-                            <!--                            <span class="badge badge-pill badge-danger">3</span>-->
+
+                    <li class="sidebar-dropdown">
+                        <a href="#">
+                            <i class="far fa-gem"></i>
+                            <span class="menu-text">Tracing</span>
                         </a>
+                        <div class="sidebar-submenu">
+                            <ul>
+                                <li>
+                                    <a href="#" onclick="javascript:redirect('trace')">Span Logs</a>
+                                </li>
+                                <li>
+                                    <a href="#" onclick="">Profile</a>
+                                </li>
+                            </ul>
+                        </div>
                     </li>
+
                     <li class="sidebar">
                         <a href="#" onclick="javascript:redirect('event')">
                             <i class="fa fa-shopping-cart"></i>

--- a/server/web-app/src/main/resources/templates/app/dashboard.html
+++ b/server/web-app/src/main/resources/templates/app/dashboard.html
@@ -6,7 +6,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.ultraq.net.nz/thymeleaf/layout ">
 <head>
-    <title>Bithon</title>
+    <title>Bithon Metrics Dashboard</title>
 </head>
 <body>
 
@@ -20,7 +20,7 @@
                     const dashboard = new Dashboard('dashboard',
                         [[${appName}]],
                         dashboardName,
-                        g_MetricSelectedInterval,
+                        window.queryParams['interval'],
                         new SchemaApi());
                     dashboard.load(boardConfig);
 

--- a/server/web-app/src/main/resources/templates/app/event.html
+++ b/server/web-app/src/main/resources/templates/app/event.html
@@ -4,7 +4,7 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{app/app-layout}">
 <head>
-    <title>Bithon</title>
+    <title>Bithon Events</title>
     <script th:src="@{/lib/bootstrap-table/extensions/treegrid/bootstrap-table-treegrid.min.js}"></script>
 
     <script th:src="@{/js/page/event/page.js}"></script>

--- a/server/web-app/src/main/resources/templates/app/topo.html
+++ b/server/web-app/src/main/resources/templates/app/topo.html
@@ -4,7 +4,7 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{app/app-layout}">
 <head>
-    <title>Bithon</title>
+    <title>Bithon Application Topo</title>
     <script th:src="@{/lib/bootstrap-table/extensions/treegrid/bootstrap-table-treegrid.min.js}"></script>
 </head>
 <body>

--- a/server/web-app/src/main/resources/templates/trace/profiling.html
+++ b/server/web-app/src/main/resources/templates/trace/profiling.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html lang="zh_CN"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{app/app-layout}">
+<head>
+    <title>Bithon Tracing Profiling</title>
+    <script th:src="@{/js/page/trace/profiling-page.js}"></script>
+</head>
+<body>
+
+<div layout:fragment="content">
+    <div id="profiling"></div>
+    <script>
+        $(document).ready(() => {
+            new ProfilingPage(window.queryParams);
+        });
+    </script>
+</div>
+</body>
+</html>

--- a/server/web-app/src/main/resources/templates/trace/profiling.html
+++ b/server/web-app/src/main/resources/templates/trace/profiling.html
@@ -13,6 +13,8 @@
     <div id="profiling"></div>
     <script>
         $(document).ready(() => {
+            g_SelectedApp = window.queryParams['appName'];
+            
             new ProfilingPage(window.queryParams);
         });
     </script>


### PR DESCRIPTION
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/6525742/161380274-bc08120e-9d46-4fa5-885b-900ec1df3009.png">

A profiling view helps to analyze the concurrent requests going to a specific instance.
Each rect on the chart is clickable to navigate to the full logs of that request
