### PR TITLE
Add default value for min/max

### DIFF
--- a/agent/agent-sdk/src/main/java/org/bithon/agent/sdk/metric/aggregator/LongMax.java
+++ b/agent/agent-sdk/src/main/java/org/bithon/agent/sdk/metric/aggregator/LongMax.java
@@ -27,6 +27,16 @@ import java.util.concurrent.atomic.AtomicLong;
 public class LongMax implements IMetricValue {
     private final AtomicLong value = new AtomicLong(Long.MIN_VALUE);
 
+    private final long defaultValue;
+
+    public LongMax() {
+        this(0);
+    }
+
+    public LongMax(long defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
     @Override
     public long update(long value) {
         while (true) {
@@ -43,6 +53,7 @@ public class LongMax implements IMetricValue {
 
     @Override
     public long value() {
-        return value.get();
+        long v = value.get();
+        return v == Long.MIN_VALUE ? this.defaultValue : v;
     }
 }

--- a/agent/agent-sdk/src/main/java/org/bithon/agent/sdk/metric/aggregator/LongMin.java
+++ b/agent/agent-sdk/src/main/java/org/bithon/agent/sdk/metric/aggregator/LongMin.java
@@ -27,6 +27,16 @@ import java.util.concurrent.atomic.AtomicLong;
 public class LongMin implements IMetricValue {
     private final AtomicLong value = new AtomicLong(Long.MAX_VALUE);
 
+    private final long defaultValue;
+
+    public LongMin() {
+        this(0);
+    }
+
+    public LongMin(long defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
     @Override
     public long update(long value) {
         while (true) {
@@ -43,6 +53,7 @@ public class LongMin implements IMetricValue {
 
     @Override
     public long value() {
-        return value.get();
+        long v = value.get();
+        return v == Long.MAX_VALUE ? this.defaultValue : v;
     }
 }


### PR DESCRIPTION
Min/Max aggregator's initial value is LONG.MAX or LONG.MIN, if such aggregator has value provided, these two default values will be reported to the server side. This will cause inaccurate query results.