### PR TITLE
Use thread executor per metric

### DIFF
--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
@@ -26,13 +26,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.bithon.component.commons.collection.IteratorableCollection;
+import org.bithon.component.commons.utils.CollectionUtils;
 import org.bithon.server.sink.metrics.IMetricMessageSink;
 import org.bithon.server.storage.datasource.input.IInputRow;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -57,8 +58,8 @@ public class KafkaMetricSink implements IMetricMessageSink {
     }
 
     @Override
-    public void process(String messageType, IteratorableCollection<IInputRow> messages) {
-        if (!messages.hasNext()) {
+    public void process(String messageType, List<IInputRow> messages) {
+        if (CollectionUtils.isEmpty(messages)) {
             return;
         }
 
@@ -71,9 +72,7 @@ public class KafkaMetricSink implements IMetricMessageSink {
         // but I don't think it has advantages over the way below
         //
         StringBuilder messageText = new StringBuilder();
-        while (messages.hasNext()) {
-            IInputRow metricMessage = messages.next();
-
+        for (IInputRow metricMessage : messages) {
             // Sink receives messages from an agent, it's safe to use instance name of first item
             key = metricMessage.getColAsString("instanceName");
 

--- a/server/server-starter/pom.xml
+++ b/server/server-starter/pom.xml
@@ -29,6 +29,10 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.bithon</groupId>

--- a/server/sink/src/main/java/org/bithon/server/kafka/KafkaMetricConsumer.java
+++ b/server/sink/src/main/java/org/bithon/server/kafka/KafkaMetricConsumer.java
@@ -17,7 +17,6 @@
 package org.bithon.server.kafka;
 
 import org.bithon.component.commons.collection.CloseableIterator;
-import org.bithon.component.commons.collection.IteratorableCollection;
 import org.bithon.server.sink.metrics.LocalMetricSink;
 import org.bithon.server.sink.metrics.MetricMessage;
 import org.bithon.server.storage.datasource.input.IInputRow;
@@ -52,13 +51,12 @@ public class KafkaMetricConsumer extends AbstractKafkaConsumer<MetricMessage> {
 
     @Override
     protected void onMessage(String type, CloseableIterator<MetricMessage> msg) {
-        //TODO: eliminate IteratorCollection
         List<IInputRow> rows = new ArrayList<>();
         while (msg.hasNext()) {
             rows.add(msg.next());
         }
 
-        metricSink.process(type, IteratorableCollection.of(rows.iterator()));
+        metricSink.process(type, rows);
     }
 
     @Override

--- a/server/sink/src/main/java/org/bithon/server/sink/event/EventsMessageHandler.java
+++ b/server/sink/src/main/java/org/bithon/server/sink/event/EventsMessageHandler.java
@@ -50,7 +50,7 @@ public class EventsMessageHandler extends AbstractThreadPoolMessageHandler<Itera
     final ObjectMapper objectMapper;
 
     public EventsMessageHandler(ApplicationContext applicationContext) throws IOException {
-        super("event", 1, 5, Duration.ofMinutes(3), 1024);
+        super("event-message-handler", 1, 5, Duration.ofMinutes(3), 1024);
         this.eventWriter = applicationContext.getBean(IEventStorage.class).createWriter();
         this.objectMapper = applicationContext.getBean(ObjectMapper.class);
 

--- a/server/sink/src/main/java/org/bithon/server/sink/metrics/IMetricMessageSink.java
+++ b/server/sink/src/main/java/org/bithon/server/sink/metrics/IMetricMessageSink.java
@@ -18,8 +18,9 @@ package org.bithon.server.sink.metrics;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.bithon.component.commons.collection.IteratorableCollection;
 import org.bithon.server.storage.datasource.input.IInputRow;
+
+import java.util.List;
 
 /**
  * @author Frank Chen
@@ -30,5 +31,5 @@ import org.bithon.server.storage.datasource.input.IInputRow;
     @JsonSubTypes.Type(name = "local", value = LocalMetricSink.class),
 })
 public interface IMetricMessageSink extends AutoCloseable {
-    void process(String messageType, IteratorableCollection<IInputRow> message);
+    void process(String messageType, List<IInputRow> message);
 }

--- a/server/sink/src/main/java/org/bithon/server/sink/metrics/SchemaMetricMessage.java
+++ b/server/sink/src/main/java/org/bithon/server/sink/metrics/SchemaMetricMessage.java
@@ -20,9 +20,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.bithon.component.commons.collection.IteratorableCollection;
 import org.bithon.server.storage.datasource.DataSourceSchema;
 import org.bithon.server.storage.datasource.input.IInputRow;
+
+import java.util.List;
 
 /**
  * @author Frank Chen
@@ -34,5 +35,5 @@ import org.bithon.server.storage.datasource.input.IInputRow;
 @AllArgsConstructor
 public class SchemaMetricMessage {
     private DataSourceSchema schema;
-    private IteratorableCollection<IInputRow> metrics;
+    private List<IInputRow> metrics;
 }

--- a/server/sink/src/main/java/org/bithon/server/sink/tracing/TraceMessageHandler.java
+++ b/server/sink/src/main/java/org/bithon/server/sink/tracing/TraceMessageHandler.java
@@ -47,7 +47,7 @@ public class TraceMessageHandler extends AbstractThreadPoolMessageHandler<List<T
     private final TagIndexGenerator tagIndexBuilder;
 
     public TraceMessageHandler(ApplicationContext applicationContext) {
-        super("trace", 2, 10, Duration.ofMinutes(1), 2048);
+        super("trace-message-handler", 2, 10, Duration.ofMinutes(1), 1024);
         this.traceWriter = applicationContext.getBean(ITraceStorage.class).createWriter();
 
         this.mappingExtractor = TraceMappingFactory.create(applicationContext);

--- a/server/sink/src/main/java/org/bithon/server/sink/tracing/metrics/MetricOverSpanInputSource.java
+++ b/server/sink/src/main/java/org/bithon/server/sink/tracing/metrics/MetricOverSpanInputSource.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.bithon.component.commons.collection.IteratorableCollection;
 import org.bithon.component.commons.utils.Preconditions;
 import org.bithon.server.commons.time.Period;
 import org.bithon.server.sink.metrics.IMessageSink;
@@ -42,7 +41,6 @@ import org.bithon.server.storage.datasource.input.TransformSpec;
 import org.bithon.server.storage.tracing.TraceSpan;
 
 import javax.validation.constraints.NotNull;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -116,10 +114,10 @@ public class MetricOverSpanInputSource implements IInputSource {
             //
             // transform the spans to target metrics
             //
-            Collection<IInputRow> metricRows = spans.stream()
-                                                    .filter(transformSpec::transform)
-                                                    .map(this::spanToMetrics)
-                                                    .collect(Collectors.toList());
+            List<IInputRow> metricRows = spans.stream()
+                                              .filter(transformSpec::transform)
+                                              .map(this::spanToMetrics)
+                                              .collect(Collectors.toList());
             if (metricRows.isEmpty()) {
                 return;
             }
@@ -139,7 +137,7 @@ public class MetricOverSpanInputSource implements IInputSource {
             //
             metricSink.process(schema.getName(), SchemaMetricMessage.builder()
                                                                     .schema(schema)
-                                                                    .metrics(IteratorableCollection.of(metricRows.iterator()))
+                                                                    .metrics(metricRows)
                                                                     .build());
         }
 


### PR DESCRIPTION
1. This is a revert and is not the best solution to support hundreds and thousands different types of metrics processing. For large amount of different metrics, should be one queue per metric and a shared executor to schedule the processing.
2. Update calling of batch interface of jOOQ to simplify the SQL
3. Add actuator