### PR TITLE
bump mysql-connector-java

### DIFF
--- a/agent/agent-plugins/mysql-5.x-6.x/pom.xml
+++ b/agent/agent-plugins/mysql-5.x-6.x/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.38</version>
+      <version>5.1.49</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/agent/agent-plugins/mysql-8.x/pom.xml
+++ b/agent/agent-plugins/mysql-8.x/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.28</version>
+      <version>8.0.30</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
To eliminate warnings reported by dependent bot. Although agent only declares these dependencies as 'provided'