### PR TITLE
Fix query generation bug

### DIFF
--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/CountMetricSpec.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/CountMetricSpec.java
@@ -50,7 +50,7 @@ public class CountMetricSpec implements IMetricSpec {
                            @JsonProperty("field") @Nullable String field) {
         this.name = name;
         this.field = field;
-        this.queryStageAggregator = new QueryStageAggregators.CountAggregator(name, field);
+        this.queryStageAggregator = new QueryStageAggregators.CountAggregator(name, name);
     }
 
     @JsonIgnore

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/gauge/GaugeMetricSpec.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/gauge/GaugeMetricSpec.java
@@ -61,7 +61,7 @@ public abstract class GaugeMetricSpec implements IMetricSpec {
         this.displayText = displayText;
         this.unit = unit;
         this.visible = visible == null ? true : visible;
-        this.queryStageAggregator = new QueryStageAggregators.LastAggregator(name, field);
+        this.queryStageAggregator = new QueryStageAggregators.LastAggregator(name, name);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/max/MaxMetricSpec.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/max/MaxMetricSpec.java
@@ -58,7 +58,7 @@ public abstract class MaxMetricSpec implements IMetricSpec {
         this.displayText = displayText;
         this.unit = unit;
         this.visible = visible == null ? true : visible;
-        this.queryStageAggregator = new QueryStageAggregators.MaxAggregator(name, field);
+        this.queryStageAggregator = new QueryStageAggregators.MaxAggregator(name, name);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/min/MinMetricSpec.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/min/MinMetricSpec.java
@@ -58,7 +58,10 @@ public abstract class MinMetricSpec implements IMetricSpec {
         this.displayText = displayText;
         this.unit = unit;
         this.visible = visible == null ? true : visible;
-        this.queryStageAggregator = new QueryStageAggregators.MinAggregator(name, field);
+
+        // For IMetricSpec, the `name` property is the right text mapped a column in underlying database,
+        // So the two parameters of following ctor are all `name` properties
+        this.queryStageAggregator = new QueryStageAggregators.MinAggregator(name, name);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/sum/SumMetricSpec.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/spec/sum/SumMetricSpec.java
@@ -56,7 +56,7 @@ public abstract class SumMetricSpec implements IMetricSpec {
         this.displayText = displayText;
         this.unit = unit;
         this.visible = visible == null ? true : visible;
-        this.queryStageAggregator = new QueryStageAggregators.SumAggregator(name, field);
+        this.queryStageAggregator = new QueryStageAggregators.SumAggregator(name, name);
     }
 
     @Override


### PR DESCRIPTION
For `IMetricSpec`, `name` property should always used when querying instead of using `field`