### PR TITLE
Improve thread pool name

### DIFF
--- a/agent/agent-distribution/distribution.xml
+++ b/agent/agent-distribution/distribution.xml
@@ -22,6 +22,7 @@
     -->
     <format>dir</format>
     <format>zip</format>
+    <format>tar</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
 

--- a/agent/agent-distribution/pom.xml
+++ b/agent/agent-distribution/pom.xml
@@ -70,6 +70,7 @@
           <descriptors>
             <descriptor>distribution.xml</descriptor>
           </descriptors>
+          <tarLongFileMode>posix</tarLongFileMode>
           <appendAssemblyId>false</appendAssemblyId>
         </configuration>
         <executions>

--- a/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/GrpcPlugin.java
+++ b/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/GrpcPlugin.java
@@ -21,7 +21,7 @@ import org.bithon.agent.core.aop.descriptor.MethodPointCutDescriptorBuilder;
 import org.bithon.agent.core.aop.matcher.Matchers;
 import org.bithon.agent.core.plugin.IPlugin;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.bithon.agent.core.aop.descriptor.InterceptorDescriptorBuilder.forClass;
@@ -33,13 +33,29 @@ public class GrpcPlugin implements IPlugin {
 
     @Override
     public List<InterceptorDescriptor> getInterceptors() {
-        return Collections.singletonList(
+        return Arrays.asList(
             forClass("io.grpc.stub.AbstractBlockingStub")
                 .methods(
                     // Hook to enhance stub classes
                     MethodPointCutDescriptorBuilder.build()
                                                    .onMethod(Matchers.withName("newStub").and(Matchers.takesArguments(3)))
                                                    .to("org.bithon.agent.plugin.grpc.client.interceptor.AbstractBlockingStub$NewStub")
+                ),
+
+            forClass("io.grpc.stub.AbstractFutureStub")
+                .methods(
+                    // Hook to enhance stub classes
+                    MethodPointCutDescriptorBuilder.build()
+                                                   .onMethod(Matchers.withName("newStub").and(Matchers.takesArguments(3)))
+                                                   .to("org.bithon.agent.plugin.grpc.client.interceptor.AbstractFutureStub$NewStub")
+                ),
+
+            forClass("io.grpc.stub.AbstractAsyncStub")
+                .methods(
+                    // Hook to enhance stub classes
+                    MethodPointCutDescriptorBuilder.build()
+                                                   .onMethod(Matchers.withName("newStub").and(Matchers.takesArguments(3)))
+                                                   .to("org.bithon.agent.plugin.grpc.client.interceptor.AbstractAsyncStub$NewStub")
                 )
         );
     }

--- a/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/interceptor/AbstractAsyncStub$NewStub.java
+++ b/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/interceptor/AbstractAsyncStub$NewStub.java
@@ -36,12 +36,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
- * Intercept {@link io.grpc.stub.AbstractBlockingStub#newStub(AbstractStub.StubFactory, Channel, CallOptions)} to enhance the generated stub classes
+ * Intercept {@link io.grpc.stub.AbstractAsyncStub#newStub(AbstractStub.StubFactory, Channel, CallOptions)} to enhance the generated stub classes
  *
  * @author Frank Chen
  * @date 13/12/22 5:36 pm
  */
-public class AbstractBlockingStub$NewStub extends AbstractInterceptor {
+public class AbstractAsyncStub$NewStub extends AbstractInterceptor {
 
     private static final Set<String> INSTRUMENTED = new ConcurrentSkipListSet<>();
 
@@ -49,11 +49,11 @@ public class AbstractBlockingStub$NewStub extends AbstractInterceptor {
 
     @Override
     public boolean initialize() {
-        String targetAopClassName = AbstractBlockingStub$NewStub.class.getPackage().getName() + ".BlockingStubAop";
+        String targetAopClassName = AbstractAsyncStub$NewStub.class.getPackage().getName() + ".AsyncStubAop";
 
         grpcStubAopClass = AopClassHelper.generateAopClass(IAdviceAopTemplate.class,
                                                            targetAopClassName,
-                                                           AbstractGrpcStubInterceptor.BlockingStubInterceptor.class.getName(),
+                                                           AbstractGrpcStubInterceptor.AsyncStubInterceptor.class.getName(),
                                                            true);
         AopClassHelper.inject(grpcStubAopClass);
 
@@ -74,7 +74,7 @@ public class AbstractBlockingStub$NewStub extends AbstractInterceptor {
 
         // Enhance the stub class
         DynamicInterceptorInstaller.getInstance().installOne(new DynamicInterceptorInstaller.AopDescriptor(clientStubClass.getName(),
-                                                                                                           AbstractGrpcStubInterceptor.BlockingStubInterceptor.class.getName(),
+                                                                                                           AbstractGrpcStubInterceptor.AsyncStubInterceptor.class.getName(),
                                                                                                            Advice.to(grpcStubAopClass.getTypeDescription(), ClassFileLocator.Simple.of(grpcStubAopClass.getAllTypes())),
                                                                                                            Matchers.visibility(Visibility.PUBLIC)));
 

--- a/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/interceptor/AbstractFutureStub$NewStub.java
+++ b/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/interceptor/AbstractFutureStub$NewStub.java
@@ -36,12 +36,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
- * Intercept {@link io.grpc.stub.AbstractBlockingStub#newStub(AbstractStub.StubFactory, Channel, CallOptions)} to enhance the generated stub classes
+ * Intercept {@link io.grpc.stub.AbstractFutureStub#newStub(AbstractStub.StubFactory, Channel, CallOptions)} to enhance the generated stub classes
  *
  * @author Frank Chen
  * @date 13/12/22 5:36 pm
  */
-public class AbstractBlockingStub$NewStub extends AbstractInterceptor {
+public class AbstractFutureStub$NewStub extends AbstractInterceptor {
 
     private static final Set<String> INSTRUMENTED = new ConcurrentSkipListSet<>();
 
@@ -49,11 +49,11 @@ public class AbstractBlockingStub$NewStub extends AbstractInterceptor {
 
     @Override
     public boolean initialize() {
-        String targetAopClassName = AbstractBlockingStub$NewStub.class.getPackage().getName() + ".BlockingStubAop";
+        String targetAopClassName = AbstractFutureStub$NewStub.class.getPackage().getName() + ".FutureStubAop";
 
         grpcStubAopClass = AopClassHelper.generateAopClass(IAdviceAopTemplate.class,
                                                            targetAopClassName,
-                                                           AbstractGrpcStubInterceptor.BlockingStubInterceptor.class.getName(),
+                                                           AbstractGrpcStubInterceptor.FutureStubInterceptor.class.getName(),
                                                            true);
         AopClassHelper.inject(grpcStubAopClass);
 
@@ -74,7 +74,7 @@ public class AbstractBlockingStub$NewStub extends AbstractInterceptor {
 
         // Enhance the stub class
         DynamicInterceptorInstaller.getInstance().installOne(new DynamicInterceptorInstaller.AopDescriptor(clientStubClass.getName(),
-                                                                                                           AbstractGrpcStubInterceptor.BlockingStubInterceptor.class.getName(),
+                                                                                                           AbstractGrpcStubInterceptor.FutureStubInterceptor.class.getName(),
                                                                                                            Advice.to(grpcStubAopClass.getTypeDescription(), ClassFileLocator.Simple.of(grpcStubAopClass.getAllTypes())),
                                                                                                            Matchers.visibility(Visibility.PUBLIC)));
 

--- a/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/interceptor/AbstractGrpcStubInterceptor.java
+++ b/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/interceptor/AbstractGrpcStubInterceptor.java
@@ -26,7 +26,13 @@ import java.lang.reflect.Method;
  * @author Frank Chen
  * @date 13/12/22 6:06 pm
  */
-public class GrpcStubInterceptor implements IAdviceInterceptor {
+public class AbstractGrpcStubInterceptor implements IAdviceInterceptor {
+
+    private final String component;
+
+    protected AbstractGrpcStubInterceptor(String component) {
+        this.component = component;
+    }
 
     @Override
     public Object onMethodEnter(
@@ -34,7 +40,7 @@ public class GrpcStubInterceptor implements IAdviceInterceptor {
         final Object target,
         final Object[] args
     ) {
-        ITraceSpan span = TraceSpanFactory.newSpan("grpc");
+        ITraceSpan span = TraceSpanFactory.newSpan(component);
         if (span == null) {
             return null;
         }
@@ -52,5 +58,23 @@ public class GrpcStubInterceptor implements IAdviceInterceptor {
                                final Object context) {
         ((ITraceSpan) context).tag(exception).finish();
         return returning;
+    }
+
+    public static class BlockingStubInterceptor extends AbstractGrpcStubInterceptor {
+        public BlockingStubInterceptor() {
+            super("grpc-blocking-client");
+        }
+    }
+
+    public static class FutureStubInterceptor extends AbstractGrpcStubInterceptor {
+        public FutureStubInterceptor() {
+            super("grpc-future-client");
+        }
+    }
+
+    public static class AsyncStubInterceptor extends AbstractGrpcStubInterceptor {
+        public AsyncStubInterceptor() {
+            super("grpc-async-client");
+        }
     }
 }

--- a/agent/agent-plugins/jdk-thread/src/main/java/org/bithon/agent/plugin/thread/interceptor/ForkJoinPool$Ctor.java
+++ b/agent/agent-plugins/jdk-thread/src/main/java/org/bithon/agent/plugin/thread/interceptor/ForkJoinPool$Ctor.java
@@ -18,9 +18,9 @@ package org.bithon.agent.plugin.thread.interceptor;
 
 import org.bithon.agent.bootstrap.aop.AbstractInterceptor;
 import org.bithon.agent.bootstrap.aop.AopContext;
-import org.bithon.agent.plugin.thread.ThreadPoolUtils;
 import org.bithon.agent.plugin.thread.metrics.ForkJoinPoolMetrics;
 import org.bithon.agent.plugin.thread.metrics.ThreadPoolMetricRegistry;
+import org.bithon.agent.plugin.thread.utils.ThreadPoolUtils;
 import org.bithon.component.commons.utils.ReflectionUtils;
 
 import java.util.concurrent.ForkJoinPool;

--- a/agent/agent-plugins/jdk-thread/src/main/java/org/bithon/agent/plugin/thread/interceptor/ThreadPoolExecutor$Ctor.java
+++ b/agent/agent-plugins/jdk-thread/src/main/java/org/bithon/agent/plugin/thread/interceptor/ThreadPoolExecutor$Ctor.java
@@ -19,34 +19,72 @@ package org.bithon.agent.plugin.thread.interceptor;
 import org.bithon.agent.bootstrap.aop.AbstractInterceptor;
 import org.bithon.agent.bootstrap.aop.AopContext;
 import org.bithon.agent.bootstrap.expt.AgentException;
-import org.bithon.agent.plugin.thread.ThreadPoolUtils;
 import org.bithon.agent.plugin.thread.metrics.ThreadPoolExecutorMetrics;
 import org.bithon.agent.plugin.thread.metrics.ThreadPoolMetricRegistry;
+import org.bithon.agent.plugin.thread.utils.ThreadPoolUtils;
 import org.bithon.component.commons.logging.ILogAdaptor;
 import org.bithon.component.commons.logging.LoggerFactory;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
+ * {@link java.util.concurrent.ThreadPoolExecutor#ThreadPoolExecutor(int, int, long, TimeUnit, BlockingQueue, ThreadFactory, RejectedExecutionHandler)}
+ *
  * @author frank.chen021@outlook.com
  * @date 2021/2/25 9:10 下午
  */
 public class ThreadPoolExecutor$Ctor extends AbstractInterceptor {
     private static final ILogAdaptor LOG = LoggerFactory.getLogger(ThreadPoolExecutor$Ctor.class);
 
+    /**
+     * Since defaultThreadFactory returns a new object for each call,
+     * in order to reduce unnecessary object creation, we cache its class name
+     */
+    private static final String DEFAULT_THREAD_FACTORY = Executors.defaultThreadFactory().getClass().getName();
+
     @Override
     public void onConstruct(AopContext aopContext) {
         ThreadPoolMetricRegistry registry = ThreadPoolMetricRegistry.getInstance();
-        if (registry != null) {
-            try {
-                ThreadPoolExecutor executor = aopContext.castTargetAs();
-                registry.addThreadPool(executor,
-                                       executor.getClass().getName(),
-                                       ThreadPoolUtils.getThreadPoolName(executor.getThreadFactory()),
-                                       new ThreadPoolExecutorMetrics(executor));
-            } catch (AgentException e) {
-                LOG.warn(e.getMessage());
+        if (registry == null) {
+            return;
+        }
+
+        ThreadPoolExecutor executor = aopContext.castTargetAs();
+        String poolName = detectThreadPoolName(executor);
+        if (poolName != null) {
+            registry.addThreadPool(executor, executor.getClass().getName(), poolName, new ThreadPoolExecutorMetrics(executor));
+        }
+    }
+
+    private String detectThreadPoolName(ThreadPoolExecutor executor) {
+        //
+        // For default thread factory, it's pool name is meaningless
+        // So, we find the caller name as the thread pool name,
+        //
+        ThreadFactory threadFactory = executor.getThreadFactory();
+        if (DEFAULT_THREAD_FACTORY.equals(threadFactory.getClass().getName())) {
+            StackTraceElement[] stackTraceElements = new RuntimeException().getStackTrace();
+
+            // index 0 is current method, skip it
+            for (int i = 1; i < stackTraceElements.length; i++) {
+                StackTraceElement stack = stackTraceElements[i];
+                if (!stack.getClassName().startsWith("java.util.concurrent")
+                && !stack.getClassName().startsWith("org.bithon.agent.plugin.thread")) {
+                    return stack.getClassName();
+                }
             }
+        }
+
+        try {
+            return ThreadPoolUtils.getThreadPoolName(threadFactory);
+        } catch (AgentException e) {
+            LOG.warn(e.getMessage());
+            return null;
         }
     }
 }

--- a/agent/agent-plugins/jdk-thread/src/main/java/org/bithon/agent/plugin/thread/utils/ThreadPoolUtils.java
+++ b/agent/agent-plugins/jdk-thread/src/main/java/org/bithon/agent/plugin/thread/utils/ThreadPoolUtils.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package org.bithon.agent.plugin.thread;
+package org.bithon.agent.plugin.thread.utils;
 
 import org.bithon.agent.bootstrap.expt.AgentException;
 
@@ -42,10 +42,8 @@ public class ThreadPoolUtils {
         THREAD_FACTORY_NAMES.put("1", "name");
         THREAD_FACTORY_NAMES.put("2", "nameFormat");
 
-        /**
-         * com.google.common.util.concurrent.ThreadFactoryBuilder creates an anonymous thread factory,
-         * and java compiles the nameFormat as val$nameFormat
-         */
+        // com.google.common.util.concurrent.ThreadFactoryBuilder creates an anonymous thread factory,
+        // and java compiles the nameFormat as val$nameFormat
         THREAD_FACTORY_NAMES.put("3", "val$nameFormat");
     }
 

--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
@@ -111,6 +111,7 @@ public class ReactorHttpHandlerAdapter$Apply extends AbstractInterceptor {
 
                 traceContext.currentSpan()
                             .component("webflux")
+                            .tag(Tags.REMOTE_ADDR, request.remoteAddress())
                             .tag(Tags.HTTP_URI, request.uri())
                             .tag(Tags.HTTP_METHOD, request.method().name())
                             .tag(Tags.HTTP_VERSION, request.version().text())

--- a/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/HttpChannel$Handle.java
+++ b/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/HttpChannel$Handle.java
@@ -74,6 +74,7 @@ public class HttpChannel$Handle extends AbstractInterceptor {
 
                 traceContext.currentSpan()
                             .component("jetty")
+                            .tag("remote.address", request.getRemoteAddr())
                             .tag(Tags.HTTP_URI, request.getRequestURI())
                             .tag(Tags.HTTP_METHOD, request.getMethod())
                             .tag(Tags.HTTP_VERSION, request.getHttpVersion().toString())

--- a/agent/agent-plugins/webserver-tomcat/src/main/java/org/bithon/agent/plugin/tomcat/interceptor/StandardHostValveInvoke.java
+++ b/agent/agent-plugins/webserver-tomcat/src/main/java/org/bithon/agent/plugin/tomcat/interceptor/StandardHostValveInvoke.java
@@ -77,6 +77,7 @@ public class StandardHostValveInvoke extends AbstractInterceptor {
 
         traceContext.currentSpan()
                     .component("tomcat")
+                    .tag(Tags.REMOTE_ADDR, request.getRemoteAddr())
                     .tag(Tags.HTTP_URI, request.getRequestURI())
                     .tag(Tags.HTTP_METHOD, request.getMethod())
                     .tag(Tags.HTTP_VERSION, request.getProtocol())

--- a/agent/agent-plugins/webserver-undertow/src/main/java/org/bithon/agent/plugin/undertow/interceptor/HttpServerExchangeDispatch.java
+++ b/agent/agent-plugins/webserver-undertow/src/main/java/org/bithon/agent/plugin/undertow/interceptor/HttpServerExchangeDispatch.java
@@ -62,6 +62,7 @@ public class HttpServerExchangeDispatch extends AbstractInterceptor {
 
         final ITraceSpan rootSpan = traceContext.currentSpan()
                                                 .component("undertow")
+                                                .tag(Tags.REMOTE_ADDR, exchange.getConnection().getPeerAddress())
                                                 .tag(Tags.HTTP_URI, exchange.getRequestURI())
                                                 .tag(Tags.HTTP_METHOD, exchange.getRequestMethod().toString())
                                                 .tag(Tags.HTTP_VERSION, exchange.getProtocol().toString())

--- a/component/component-commons/src/main/java/org/bithon/component/commons/tracing/Tags.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/tracing/Tags.java
@@ -40,4 +40,6 @@ public class Tags {
      *  mysql://127.0.0.1:3309
      */
     public static final String TARGET = "target";
+
+    public static final String REMOTE_ADDR = "remote.address";
 }


### PR DESCRIPTION
1.Many business libs does not specify ThreadFactory when creating a thread pool. In such case, `Executors.defaultThreadFactory()` is used internally. This default thread factory initializes a unique name as `pool-{a number}-`. This name is meaningless for observability. We improve it by using the class name of caller which creates the thread pool object.

2. Support remote.address
3. Support async/future stub