### PR TITLE
Sink Improvement

### DIFF
--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/FixedSizeBuffer.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/FixedSizeBuffer.java
@@ -38,6 +38,10 @@ class FixedSizeBuffer {
         return buf.length;
     }
 
+    public int size() {
+        return size;
+    }
+
     boolean isEmpty() {
         return size == 0;
     }

--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/FixedSizeBuffer.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/FixedSizeBuffer.java
@@ -38,12 +38,8 @@ class FixedSizeBuffer {
         return buf.length;
     }
 
-    public int size() {
+    int size() {
         return size;
-    }
-
-    boolean isEmpty() {
-        return size == 0;
     }
 
     void writeBytes(byte[] value) {
@@ -63,7 +59,7 @@ class FixedSizeBuffer {
         writeBytes(bytes);
     }
 
-    public void deleteFromEnd(int length) {
+    void deleteFromEnd(int length) {
         if (size >= length) {
             size -= length;
         }

--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMessage.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMessage.java
@@ -1,0 +1,103 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.collector.sink.kafka;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Frank Chen
+ * @date 3/1/23 11:41 am
+ */
+class KafkaMessage {
+    private byte[] buf;
+    private int size;
+
+    KafkaMessage(int limit) {
+        this.buf = new byte[limit];
+        this.size = 0;
+    }
+
+    int capacity() {
+        return buf.length;
+    }
+
+    boolean isEmpty() {
+        return size == 0;
+    }
+
+    void writeBytes(byte[] buf) {
+        ensureCapacity(buf.length);
+        System.arraycopy(buf, 0, this.buf, this.size, buf.length);
+        this.size += buf.length;
+    }
+
+    void writeChar(char chr) {
+        ensureCapacity(1);
+        this.buf[this.size++] = (byte) chr;
+    }
+
+    void writeString(String str) {
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+        ensureCapacity(bytes.length);
+        writeBytes(bytes);
+    }
+
+    public void deleteFromEnd(int length) {
+        if (size >= length) {
+            size -= length;
+        }
+    }
+
+    byte[] toBytes() {
+        if (size == this.buf.length) {
+            return this.buf;
+        } else {
+            byte[] d = new byte[this.size];
+            System.arraycopy(this.buf, 0, d, 0, this.size);
+            return d;
+        }
+    }
+
+    ByteBuffer toByteBuffer() {
+        return ByteBuffer.wrap(this.buf, 0, this.size);
+    }
+
+    public void reset() {
+        this.size = 0;
+    }
+
+    public void reset(int offset) {
+        this.size = offset;
+    }
+
+    public int getOffset() {
+        return this.size;
+    }
+
+    private void ensureCapacity(int extraSize) {
+        int newSize = buf.length;
+        while (this.size + extraSize > newSize) {
+            newSize *= 2;
+        }
+        if (newSize != buf.length) {
+            byte[] newBuff = new byte[newSize];
+            System.arraycopy(this.buf, 0, newBuff, 0, this.size);
+            this.buf = newBuff;
+        }
+    }
+}

--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
@@ -161,7 +161,7 @@ public class KafkaMetricSink implements IMetricMessageSink {
         try {
             producer.send(record);
         } catch (Exception e) {
-            log.error("Error to send metric [{}]", new String(header.value()), e);
+            log.error("Error to send metric [{}]", new String(header.value(), StandardCharsets.UTF_8), e);
         }
     }
 

--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
@@ -24,17 +24,24 @@ import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.record.AbstractRecords;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.bithon.component.commons.utils.CollectionUtils;
 import org.bithon.component.commons.utils.Preconditions;
 import org.bithon.server.sink.metrics.IMetricMessageSink;
 import org.bithon.server.sink.metrics.SchemaMetricMessage;
+import org.bithon.server.storage.datasource.input.IInputRow;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -47,12 +54,15 @@ import java.util.Map;
  * @author frank.chen021@outlook.com
  * @date 2021/3/15
  */
+@Slf4j
 @JsonTypeName("kafka")
 public class KafkaMetricSink implements IMetricMessageSink {
 
-    private final KafkaTemplate<String, byte[]> producer;
+    private final KafkaTemplate<byte[], byte[]> producer;
     private final ObjectMapper objectMapper;
     private final String topic;
+    private final ThreadLocal<KafkaMessage> bufferThreadLocal;
+    private final CompressionType compressionType;
 
     @JsonCreator
     public KafkaMetricSink(@JsonProperty("props") Map<String, Object> props,
@@ -60,8 +70,12 @@ public class KafkaMetricSink implements IMetricMessageSink {
         this.topic = (String) props.remove("topic");
         Preconditions.checkNotNull(topic, "topic is not configured for metrics sink");
 
+        int maxSizePerMessage = (int) props.getOrDefault(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1024 * 1024);
+        this.compressionType = CompressionType.forName((String) props.getOrDefault(ProducerConfig.COMPRESSION_TYPE_CONFIG, "none"));
+        this.bufferThreadLocal = ThreadLocal.withInitial(() -> new KafkaMessage(maxSizePerMessage));
+
         this.producer = new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(props,
-                                                                              new StringSerializer(),
+                                                                              new ByteArraySerializer(),
                                                                               new ByteArraySerializer()),
                                             ImmutableMap.of(ProducerConfig.CLIENT_ID_CONFIG, "metrics"));
 
@@ -79,22 +93,79 @@ public class KafkaMetricSink implements IMetricMessageSink {
         if (appName == null || instanceName == null) {
             return;
         }
+        byte[] messageKey = (messageType + "/" + appName + "/" + instanceName).getBytes(StandardCharsets.UTF_8);
 
+        RecordHeader header = new RecordHeader("type", messageType.getBytes(StandardCharsets.UTF_8));
+
+        KafkaMessage kafkaMessage = this.bufferThreadLocal.get();
+        kafkaMessage.reset();
+        kafkaMessage.writeChar('{');
+        if (message.getSchema() != null) {
+            try {
+                byte[] schemaBytes = this.objectMapper.writeValueAsBytes(message.getSchema());
+                kafkaMessage.writeString("\"schema\":");
+                kafkaMessage.writeBytes(schemaBytes);
+                kafkaMessage.writeChar(',');
+            } catch (JsonProcessingException ignored) {
+            }
+        }
+        kafkaMessage.writeString("\"metrics\": [");
+
+        int metricStartOffset = kafkaMessage.getOffset();
+
+        for (IInputRow row : message.getMetrics()) {
+            byte[] metricBytes;
+            try {
+                metricBytes = objectMapper.writeValueAsBytes(row);
+            } catch (JsonProcessingException ignored) {
+                continue;
+            }
+
+            int currentSize = AbstractRecords.estimateSizeInBytesUpperBound(RecordBatch.CURRENT_MAGIC_VALUE,
+                                                                            this.compressionType,
+                                                                            ByteBuffer.wrap(messageKey),
+                                                                            kafkaMessage.toByteBuffer(),
+                                                                            new Header[]{header});
+
+            // plus 3 to leave 3 bytes as margin
+            if (currentSize + metricBytes.length + 3 > kafkaMessage.capacity()) {
+                send(header, messageKey, kafkaMessage);
+
+                kafkaMessage.reset(metricStartOffset);
+            }
+
+            kafkaMessage.writeBytes(metricBytes);
+            kafkaMessage.writeChar(',');
+        }
+
+        send(header, messageKey, kafkaMessage);
+    }
+
+    private void send(RecordHeader header, byte[] key, KafkaMessage kafkaMessage) {
+        if (kafkaMessage.isEmpty()) {
+            return;
+        }
+
+        // Remove last separator
+        kafkaMessage.deleteFromEnd(1);
+
+        // Close JSON objects
+        kafkaMessage.writeChar(']');
+        kafkaMessage.writeChar('}');
+
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, key, kafkaMessage.toBytes());
+        record.headers().add(header);
         try {
-            byte[] messageText = this.objectMapper.writeValueAsBytes(message);
-
-            String key = messageType + "/" + appName + "/" + instanceName;
-            ProducerRecord<String, byte[]> record = new ProducerRecord<>(this.topic, key, messageText);
-            record.headers().add("type", messageType.getBytes(StandardCharsets.UTF_8));
-
-            this.producer.send(record);
-        } catch (JsonProcessingException ignored) {
+            producer.send(record);
+        } catch (Exception e) {
+            log.error("Error to send metric [{}]", new String(header.value()), e);
         }
     }
 
     @Override
     public void close() {
         this.producer.destroy();
+        this.bufferThreadLocal.remove();
     }
 }
 

--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaMetricSink.java
@@ -97,8 +97,8 @@ public class KafkaMetricSink implements IMetricMessageSink {
         if (appName == null || instanceName == null) {
             return;
         }
-        byte[] messageKey = (messageType + "/" + appName + "/" + instanceName).getBytes(StandardCharsets.UTF_8);
 
+        byte[] messageKey = (messageType + "/" + appName + "/" + instanceName).getBytes(StandardCharsets.UTF_8);
         RecordHeader header = new RecordHeader("type", messageType.getBytes(StandardCharsets.UTF_8));
 
         FixedSizeBuffer messageBuffer = this.bufferThreadLocal.get();
@@ -145,7 +145,7 @@ public class KafkaMetricSink implements IMetricMessageSink {
     }
 
     private void send(RecordHeader header, byte[] key, FixedSizeBuffer messageBuffer) {
-        if (messageBuffer.isEmpty()) {
+        if (messageBuffer.size() <= 1) {
             return;
         }
 

--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaTraceSink.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaTraceSink.java
@@ -132,7 +132,7 @@ public class KafkaTraceSink implements ITraceMessageSink {
     }
 
     private void send(byte[] key, FixedSizeBuffer messageBuffer) {
-        if (messageBuffer.isEmpty()) {
+        if (messageBuffer.size() <= 1) {
             return;
         }
 

--- a/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaTraceSink.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/sink/kafka/KafkaTraceSink.java
@@ -145,7 +145,7 @@ public class KafkaTraceSink implements ITraceMessageSink {
         try {
             producer.send(record);
         } catch (Exception e) {
-            log.error("Error to send trace from {}", new String(messageKey.array()), e);
+            log.error("Error to send trace from {}", new String(messageKey.array(), StandardCharsets.UTF_8), e);
         }
     }
 

--- a/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcCollectorStarter.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcCollectorStarter.java
@@ -65,42 +65,42 @@ public class BrpcCollectorStarter implements SmartLifecycle, ApplicationContextA
         // group services by their listening ports
         //
         for (Map.Entry<String, Integer> entry : config.getPort().entrySet()) {
-            String service = entry.getKey();
+            String type = entry.getKey();
             Integer port = entry.getValue();
 
             boolean isCtrl = false;
-            Class<?> clazz = null;
-            Object serviceProvider = null;
-            switch (service) {
+            Class<?> serviceDefinition = null;
+            Object serviceImplementation = null;
+            switch (type) {
                 case "metric":
-                    clazz = IMetricCollector.class;
-                    serviceProvider = new BrpcMetricCollector(applicationContext.getBean(IMetricMessageSink.class));
+                    serviceDefinition = IMetricCollector.class;
+                    serviceImplementation = new BrpcMetricCollector(applicationContext.getBean(IMetricMessageSink.class));
                     break;
 
                 case "event":
-                    clazz = IEventCollector.class;
-                    serviceProvider = new BrpcEventCollector(applicationContext.getBean(IEventMessageSink.class));
+                    serviceDefinition = IEventCollector.class;
+                    serviceImplementation = new BrpcEventCollector(applicationContext.getBean(IEventMessageSink.class));
                     break;
 
                 case "tracing":
-                    clazz = ITraceCollector.class;
-                    serviceProvider = new BrpcTraceCollector(applicationContext.getBean("trace-sink-collector", ITraceMessageSink.class),
-                                                             applicationContext.getBean(UriNormalizer.class));
+                    serviceDefinition = ITraceCollector.class;
+                    serviceImplementation = new BrpcTraceCollector(applicationContext.getBean("trace-sink-collector", ITraceMessageSink.class),
+                                                                   applicationContext.getBean(UriNormalizer.class));
                     break;
 
                 case "ctrl":
                     isCtrl = true;
-                    clazz = ISettingFetcher.class;
-                    serviceProvider = new BrpcSettingFetcher(applicationContext.getBean(AgentSettingService.class));
+                    serviceDefinition = ISettingFetcher.class;
+                    serviceImplementation = new BrpcSettingFetcher(applicationContext.getBean(AgentSettingService.class));
                     break;
 
                 default:
                     break;
             }
-            if (serviceProvider != null) {
+            if (serviceImplementation != null) {
                 ServiceGroup serviceGroup = serviceGroups.computeIfAbsent(port, key -> new ServiceGroup());
                 serviceGroup.isCtrl = isCtrl;
-                serviceGroup.getServices().add(new ServiceProvider(service, clazz, serviceProvider));
+                serviceGroup.addService(type, serviceDefinition, serviceImplementation);
             }
         }
 
@@ -162,6 +162,10 @@ public class BrpcCollectorStarter implements SmartLifecycle, ApplicationContextA
             }
             channel.start(port);
             this.port = port;
+        }
+
+        public void addService(String type, Class<?> serviceDefinition, Object serviceImplementation) {
+            this.services.add(new ServiceProvider(type, serviceDefinition, serviceImplementation));
         }
 
         public void close() {

--- a/server/sink/src/main/java/org/bithon/server/sink/tracing/ITraceMessageSink.java
+++ b/server/sink/src/main/java/org/bithon/server/sink/tracing/ITraceMessageSink.java
@@ -31,5 +31,9 @@ import java.util.List;
     @JsonSubTypes.Type(name = "local", value = LocalTraceSink.class),
 })
 public interface ITraceMessageSink extends AutoCloseable {
+    /**
+     * process messages.
+     * If it's closing, this process method won't be called again
+     */
     void process(String messageType, List<TraceSpan> messages);
 }

--- a/server/sink/src/main/java/org/bithon/server/sink/tracing/TraceBatchWriter.java
+++ b/server/sink/src/main/java/org/bithon/server/sink/tracing/TraceBatchWriter.java
@@ -26,7 +26,9 @@ import org.bithon.server.storage.tracing.mapping.TraceIdMapping;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author frank.chen021@outlook.com
@@ -35,7 +37,11 @@ import java.util.List;
 @Slf4j
 public class TraceBatchWriter implements ITraceWriter {
     private final List<TraceSpan> traceSpans = new ArrayList<>();
-    private final List<TraceIdMapping> traceIdMappings = new ArrayList<>();
+
+    /**
+     * Use set to deduplication for different batches
+     */
+    private final Set<TraceIdMapping> traceIdMappings = new HashSet<>();
     private final List<TagIndex> tagIndexes = new ArrayList<>();
 
     private final ITraceWriter writer;

--- a/server/sink/src/test/java/org/bithon/server/sink/tracing/mapping/URIParameterExtractorTest.java
+++ b/server/sink/src/test/java/org/bithon/server/sink/tracing/mapping/URIParameterExtractorTest.java
@@ -43,14 +43,20 @@ public class URIParameterExtractorTest {
                                                         "status",
                                                         "200")).build();
 
-
         Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(Collections.singletonList(
             "query_id")));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
-        Assert.assertEquals(1, mappings.size());
-        Assert.assertEquals("123456", mappings.get(0).getUserId());
+        Assert.assertEquals(2, mappings.size());
+
+        // Trace Id
+        Assert.assertEquals("1", mappings.get(0).getUserId());
         Assert.assertEquals("1", mappings.get(0).getTraceId());
         Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(0).getTimestamp());
+
+        // User Id
+        Assert.assertEquals("123456", mappings.get(1).getUserId());
+        Assert.assertEquals("1", mappings.get(1).getTraceId());
+        Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(1).getTimestamp());
     }
 
     @Test
@@ -66,10 +72,18 @@ public class URIParameterExtractorTest {
         Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(
             Collections.singletonList("query_id")));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
-        Assert.assertEquals(1, mappings.size());
-        Assert.assertEquals("C0A802F1fbe7b9768c2949738cbb5ce383e21d5f", mappings.get(0).getUserId());
+
+        Assert.assertEquals(2, mappings.size());
+
+        // Trace Id
+        Assert.assertEquals("1", mappings.get(0).getUserId());
         Assert.assertEquals("1", mappings.get(0).getTraceId());
         Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(0).getTimestamp());
+
+        // User Id
+        Assert.assertEquals("C0A802F1fbe7b9768c2949738cbb5ce383e21d5f", mappings.get(1).getUserId());
+        Assert.assertEquals("1", mappings.get(1).getTraceId());
+        Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(1).getTimestamp());
     }
 
     @Test
@@ -85,10 +99,17 @@ public class URIParameterExtractorTest {
         Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(
             Collections.singletonList("query_id")));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
-        Assert.assertEquals(1, mappings.size());
-        Assert.assertEquals("C0A802F1fbe7b9768c2949738cbb5ce383e21d5f", mappings.get(0).getUserId());
+
+        Assert.assertEquals(2, mappings.size());
+        // Trace Id
+        Assert.assertEquals("1", mappings.get(0).getUserId());
         Assert.assertEquals("1", mappings.get(0).getTraceId());
         Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(0).getTimestamp());
+
+        // User Id
+        Assert.assertEquals("C0A802F1fbe7b9768c2949738cbb5ce383e21d5f", mappings.get(1).getUserId());
+        Assert.assertEquals("1", mappings.get(1).getTraceId());
+        Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(1).getTimestamp());
     }
 
     @Test
@@ -101,9 +122,16 @@ public class URIParameterExtractorTest {
         Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(
             Collections.singletonList("query_id")));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
-        Assert.assertEquals(1, mappings.size());
-        Assert.assertEquals("===", mappings.get(0).getUserId());
+        Assert.assertEquals(2, mappings.size());
+
+        // Trace Id
+        Assert.assertEquals("1", mappings.get(0).getUserId());
         Assert.assertEquals("1", mappings.get(0).getTraceId());
         Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(0).getTimestamp());
+
+        // User Id
+        Assert.assertEquals("===", mappings.get(1).getUserId());
+        Assert.assertEquals("1", mappings.get(1).getTraceId());
+        Assert.assertEquals(span.getStartTime() / 1000L, mappings.get(1).getTimestamp());
     }
 }

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/TraceStorage.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/TraceStorage.java
@@ -99,7 +99,7 @@ public class TraceStorage extends TraceJdbcStorage {
 
     @Override
     public ITraceReader createReader() {
-        return new TraceJdbcReader(this.dslContext, this.objectMapper, traceSpanSchema, this.traceTagIndexSchema, this.traceSinkConfig, this.traceStorageConfig) {
+        return new TraceJdbcReader(this.dslContext, this.objectMapper, traceSpanSchema, this.traceTagIndexSchema, this.traceStorageConfig) {
             @Override
             public List<Histogram> getTraceDistribution(List<IFilter> filters, Timestamp start, Timestamp end) {
                 BithonTraceSpanSummary summaryTable = Tables.BITHON_TRACE_SPAN_SUMMARY;

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/TraceJdbcStorage.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/TraceJdbcStorage.java
@@ -103,7 +103,6 @@ public class TraceJdbcStorage implements ITraceStorage {
                                    this.objectMapper,
                                    this.traceSpanSchema,
                                    this.traceTagIndexSchema,
-                                   this.traceSinkConfig,
                                    this.traceStorageConfig);
     }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/ITraceReader.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/ITraceReader.java
@@ -19,6 +19,7 @@ package org.bithon.server.storage.tracing;
 import lombok.Data;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.storage.metrics.IFilter;
+import org.bithon.server.storage.tracing.mapping.TraceIdMapping;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -46,7 +47,10 @@ public interface ITraceReader {
 
     List<TraceSpan> getTraceByParentSpanId(String parentSpanId);
 
-    String getTraceIdByMapping(String id);
+    /**
+     * Get id mapping by given user id
+     */
+    TraceIdMapping getTraceIdByMapping(String userId);
 
     @Data
     class Histogram {

--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/mapping/TraceIdMapping.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/mapping/TraceIdMapping.java
@@ -20,7 +20,11 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 /**
+ * Mapping a user specified id in spans to the traceId of that span
+ *
  * @author frank.chen021@outlook.com
  * @date 10/12/21 3:27 PM
  */
@@ -28,7 +32,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TraceIdMapping {
-    private long timestamp;
+    /**
+     * key
+     */
     private String userId;
+
+    private long timestamp;
     private String traceId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TraceIdMapping that = (TraceIdMapping) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId);
+    }
 }

--- a/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
@@ -21,6 +21,7 @@ import org.bithon.server.storage.metrics.IFilter;
 import org.bithon.server.storage.tracing.ITraceReader;
 import org.bithon.server.storage.tracing.ITraceStorage;
 import org.bithon.server.storage.tracing.TraceSpan;
+import org.bithon.server.storage.tracing.mapping.TraceIdMapping;
 import org.bithon.server.web.service.WebServiceModuleEnabler;
 import org.bithon.server.web.service.tracing.api.TraceSpanBo;
 import org.springframework.beans.BeanUtils;
@@ -73,7 +74,8 @@ public class TraceService {
         int m = hour % step;
         int hourPerStep = (hour / step + (m > 0 ? 1 : 0));
 
-        int length = hourPerStep * step * 3600 / 60; // the last 60 is the max bucket number
+        // the last 60 is the max bucket number
+        int length = hourPerStep * step * 3600 / 60;
         int mod = seconds % length;
         return new Bucket(seconds / length + (mod > 0 ? 1 : 0), length);
     }
@@ -87,17 +89,26 @@ public class TraceService {
                                              String startTimeISO8601,
                                              String endTimeISO8601,
                                              boolean asTree) {
+        TimeSpan start = StringUtils.hasText(startTimeISO8601) ? TimeSpan.fromISO8601(startTimeISO8601) : null;
+        TimeSpan end = StringUtils.hasText(endTimeISO8601) ? TimeSpan.fromISO8601(endTimeISO8601) : null;
+
         if (!"trace".equals(type)) {
             // check if the id has a user mapping
-            String traceId = traceReader.getTraceIdByMapping(txId);
-            if (traceId != null) {
-                txId = traceId;
+            TraceIdMapping mapping = traceReader.getTraceIdByMapping(txId);
+            if (mapping != null) {
+                txId = mapping.getTraceId();
+
+                // Set the time range to narrow down the search range
+                if (start == null) {
+                    start = TimeSpan.of(mapping.getTimestamp() - 2 * 3600 * 1000L);
+                }
+                if (end == null) {
+                    end = TimeSpan.of(mapping.getTimestamp() + 2 * 3600 * 1000L);
+                }
             }
             // if there's no mapping, try to search this id as trace id
         }
 
-        TimeSpan start = StringUtils.hasText(startTimeISO8601) ? TimeSpan.fromISO8601(startTimeISO8601) : null;
-        TimeSpan end = StringUtils.hasText(endTimeISO8601) ? TimeSpan.fromISO8601(endTimeISO8601) : null;
         List<TraceSpan> spans = traceReader.getTraceByTraceId(txId, start, end);
 
         return asTree ? asTree(spans) : spans;


### PR DESCRIPTION
1. Split messages for metrics when sending to kafka
2. Use timestamp of mapped id to search tracing in order to gain better query performance
3. Save tx id in mapped id so that if an id is not found no further search will be performed