### PR TITLE
Simplifies configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,13 @@ Once the application has started, visit [http://localhost:9897/web/home](http://
 Attach agent to your java agent by adding following VM arguments.
 
 ```bash
--javaagent:<YOUR_PROJECT_DIRECTORY>/agent/agent-distribution/target/agent-distribution/agent-main.jar -Dbithon.application.name=<YOUR_APPLICATION_NAME> -Dbithon.application.env=<YOUR_APPLICATION_ENV>
+-javaagent:<YOUR_PROJECT_DIRECTORY>/agent/agent-distribution/target/agent-distribution/agent-main.jar -Dbithon.application.name=<YOUR_APPLICATION_NAME>
 ```
 
-| Variable               | Description                                                                                                              |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| YOUR_PROJECT_DIRECTORY | the directory where this project saves                                                                                   |
-| YOUR_APPLICATION_NAME  | the name of your application. It could be any string                                                                     |
-| YOUR_APPLICATION_ENV   | the name of your environment to label your application. It could be any string. Usually it could be `dev`, `test`, `prd` |
+| Variable               | Description                                                                                                                                                                                                        |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| YOUR_PROJECT_DIRECTORY | the directory where this project saves                                                                                                                                                                             |
+| YOUR_APPLICATION_NAME  | the name of your application. It could be any string. <br/> Good practice of application name is combining the name and its deployed environment,  for example, `bithon-webserver-dev` or `bithon-webserver-prod`. |
 
 By default, the agent connects collector running at local(127.0.0.1). 
 Collector address could be changed in file `agent/agent-main/src/main/resources/agent.yml`.

--- a/agent/agent-controller/src/main/java/org/bithon/agent/controller/AgentControllerService.java
+++ b/agent/agent-controller/src/main/java/org/bithon/agent/controller/AgentControllerService.java
@@ -74,8 +74,7 @@ public class AgentControllerService implements IAgentService {
         //
         // Start fetcher
         //
-        DynamicConfigurationManager.createInstance(AppInstance.getInstance().getAppName(),
-                                                   AppInstance.getInstance().getEnv(),
+        DynamicConfigurationManager.createInstance(AppInstance.getInstance().getQualifiedAppName(),
                                                    controller);
     }
 

--- a/agent/agent-controller/src/main/java/org/bithon/agent/controller/AgentControllerService.java
+++ b/agent/agent-controller/src/main/java/org/bithon/agent/controller/AgentControllerService.java
@@ -74,7 +74,7 @@ public class AgentControllerService implements IAgentService {
         //
         // Start fetcher
         //
-        DynamicConfigurationManager.createInstance(AppInstance.getInstance().getQualifiedAppName(),
+        DynamicConfigurationManager.createInstance(AppInstance.getInstance().getAppName(),
                                                    controller);
     }
 

--- a/agent/agent-controller/src/main/java/org/bithon/agent/controller/IAgentController.java
+++ b/agent/agent-controller/src/main/java/org/bithon/agent/controller/IAgentController.java
@@ -25,7 +25,6 @@ import java.util.Map;
 public interface IAgentController {
 
     Map<String, String> getAgentConfiguration(String appName,
-                                              String env,
                                               long lastModifiedSince);
 
     /**

--- a/agent/agent-controller/src/main/java/org/bithon/agent/controller/config/DynamicConfigurationManager.java
+++ b/agent/agent-controller/src/main/java/org/bithon/agent/controller/config/DynamicConfigurationManager.java
@@ -48,15 +48,14 @@ public class DynamicConfigurationManager {
     private static DynamicConfigurationManager INSTANCE = null;
 
     private final String appName;
-    private final String env;
+
     private final IAgentController controller;
     private final List<IConfigurationChangedListener> listeners;
 
     private final PeriodicTask updateConfigTask;
 
-    private DynamicConfigurationManager(String appName, String env, IAgentController controller) {
+    private DynamicConfigurationManager(String appName, IAgentController controller) {
         this.appName = appName;
-        this.env = env;
         this.controller = controller;
         this.listeners = Collections.synchronizedList(new ArrayList<>());
         this.updateConfigTask = new UpdateConfigurationTask();
@@ -68,8 +67,8 @@ public class DynamicConfigurationManager {
         this.controller.refreshListener(updateConfigTask::runImmediately);
     }
 
-    public static void createInstance(String appName, String env, IAgentController controller) {
-        INSTANCE = new DynamicConfigurationManager(appName, env, controller);
+    public static void createInstance(String appName, IAgentController controller) {
+        INSTANCE = new DynamicConfigurationManager(appName, controller);
         INSTANCE.updateConfigTask.start();
     }
 
@@ -96,10 +95,10 @@ public class DynamicConfigurationManager {
 
         @Override
         protected void onRun() throws Exception {
-            log.info("Fetch configuration for {}-{}", appName, env);
+            log.info("Fetch configuration for {}-{}", appName);
 
             // Get configuration from remote server
-            Map<String, String> configurations = controller.getAgentConfiguration(appName, env, lastModifiedAt);
+            Map<String, String> configurations = controller.getAgentConfiguration(appName, lastModifiedAt);
             if (CollectionUtils.isEmpty(configurations)) {
                 return;
             }

--- a/agent/agent-core/src/main/java/org/bithon/agent/configuration/Configuration.java
+++ b/agent/agent-core/src/main/java/org/bithon/agent/configuration/Configuration.java
@@ -332,11 +332,13 @@ public class Configuration {
                                      e.getMessage());
         }
 
-        String violation = Validator.validate(value);
-        if (violation != null) {
-            throw new AgentException("Invalid configuration for type of [%s]: %s",
-                                     clazz.getSimpleName(),
-                                     violation);
+        if (!clazz.isPrimitive() && !clazz.equals(String.class)) {
+            String violation = Validator.validate(value);
+            if (violation != null) {
+                throw new AgentException("Invalid configuration for type of [%s]: %s",
+                                         clazz.getSimpleName(),
+                                         violation);
+            }
         }
 
         return value;

--- a/agent/agent-core/src/main/java/org/bithon/agent/starter/AgentStarter.java
+++ b/agent/agent-core/src/main/java/org/bithon/agent/starter/AgentStarter.java
@@ -27,6 +27,8 @@ import org.bithon.agent.instrumentation.loader.AgentClassLoader;
 import org.bithon.agent.instrumentation.utils.AgentDirectory;
 import org.bithon.component.commons.logging.ILogAdaptor;
 import org.bithon.component.commons.logging.LoggerFactory;
+import org.bithon.component.commons.utils.Preconditions;
+import org.bithon.component.commons.utils.StringUtils;
 
 import java.io.File;
 import java.lang.instrument.Instrumentation;
@@ -117,11 +119,19 @@ public class AgentStarter {
     private AopDebugger createAopDebugger() {
         boolean isDebug = ConfigurationManager.getInstance().getConfig(AopConfig.class).isDebug();
 
-        String appName = ConfigurationManager.getInstance().getConfig(ConfigurationManager.BITHON_APPLICATION_NAME, String.class);
-        String env = ConfigurationManager.getInstance().getConfig(ConfigurationManager.BITHON_APPLICATION_ENV, String.class);
+        String appName = Preconditions.checkNotNull(ConfigurationManager.getInstance()
+                                                                        .getConfig(ConfigurationManager.BITHON_APPLICATION_NAME, String.class),
+                                                    "application.name is not configured.");
+
+        String env = ConfigurationManager.getInstance()
+                                         .getConfig(ConfigurationManager.BITHON_APPLICATION_ENV, String.class);
+        if (StringUtils.hasText(env)) {
+            // Compatibility
+            appName += "-" + env;
+        }
         File targetDirectory = AgentDirectory.getSubDirectory(AgentDirectory.TMP_DIR
                                                               + separator
-                                                              + appName + "-" + env
+                                                              + appName
                                                               + separator
                                                               + "classes");
 

--- a/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcAgentController.java
+++ b/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcAgentController.java
@@ -63,7 +63,7 @@ public class BrpcAgentController implements IAgentController {
         brpcClient = BrpcClientBuilder.builder()
                                       .endpointProvider(new RoundRobinEndPointProvider(endpoints))
                                       .workerThreads(2)
-                                      .applicationName(appInstance.getQualifiedAppName())
+                                      .applicationName(appInstance.getAppName())
                                       .maxRetry(3)
                                       .retryInterval(Duration.ofSeconds(2))
                                       .build();

--- a/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcAgentController.java
+++ b/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcAgentController.java
@@ -91,7 +91,7 @@ public class BrpcAgentController implements IAgentController {
     }
 
     @Override
-    public Map<String, String> getAgentConfiguration(String appName, String env, long lastModifiedSince) {
+    public Map<String, String> getAgentConfiguration(String appName, long lastModifiedSince) {
         if (fetcher == null) {
             try {
                 fetcher = brpcClient.getRemoteService(ISettingFetcher.class);
@@ -103,8 +103,8 @@ public class BrpcAgentController implements IAgentController {
 
         AppInstance appInstance = AppInstance.getInstance();
         BrpcMessageHeader header = BrpcMessageHeader.newBuilder()
-                                                    .setAppName(appInstance.getAppName())
-                                                    .setEnv(appInstance.getEnv())
+                                                    .setAppName(appName)
+                                                    .setEnv("")
                                                     .setInstanceName(appInstance.getHostAndPort())
                                                     .setHostIp(appInstance.getHostIp())
                                                     .setPort(appInstance.getPort())

--- a/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcEventMessageChannel.java
+++ b/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcEventMessageChannel.java
@@ -66,7 +66,7 @@ public class BrpcEventMessageChannel implements IMessageChannel {
 
         AppInstance appInstance = AppInstance.getInstance();
         this.header = BrpcMessageHeader.newBuilder()
-                                       .setAppName(appInstance.getQualifiedAppName())
+                                       .setAppName(appInstance.getAppName())
                                        .setEnv(appInstance.getEnv())
                                        .setInstanceName(appInstance.getHostAndPort())
                                        .setHostIp(appInstance.getHostIp())
@@ -74,7 +74,7 @@ public class BrpcEventMessageChannel implements IMessageChannel {
                                        .setAppType(ApplicationType.JAVA)
                                        .build();
         appInstance.addListener(port -> this.header = BrpcMessageHeader.newBuilder()
-                                                                       .setAppName(appInstance.getQualifiedAppName())
+                                                                       .setAppName(appInstance.getAppName())
                                                                        .setEnv(appInstance.getEnv())
                                                                        .setInstanceName(appInstance.getHostAndPort())
                                                                        .setHostIp(appInstance.getHostIp())

--- a/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcMetricMessageChannel.java
+++ b/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcMetricMessageChannel.java
@@ -102,7 +102,7 @@ public class BrpcMetricMessageChannel implements IMessageChannel {
 
         AppInstance appInstance = AppInstance.getInstance();
         this.header = BrpcMessageHeader.newBuilder()
-                                       .setAppName(appInstance.getQualifiedAppName())
+                                       .setAppName(appInstance.getAppName())
                                        .setEnv(appInstance.getEnv())
                                        .setInstanceName(appInstance.getHostAndPort())
                                        .setHostIp(appInstance.getHostIp())
@@ -110,7 +110,7 @@ public class BrpcMetricMessageChannel implements IMessageChannel {
                                        .setAppType(ApplicationType.JAVA)
                                        .build();
         appInstance.addListener(port -> this.header = BrpcMessageHeader.newBuilder()
-                                                                       .setAppName(appInstance.getQualifiedAppName())
+                                                                       .setAppName(appInstance.getAppName())
                                                                        .setEnv(appInstance.getEnv())
                                                                        .setInstanceName(appInstance.getHostAndPort())
                                                                        .setHostIp(appInstance.getHostIp())

--- a/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcTraceMessageChannel.java
+++ b/agent/agent-dispatcher-brpc/src/main/java/org/bithon/agent/dispatcher/brpc/BrpcTraceMessageChannel.java
@@ -67,7 +67,7 @@ public class BrpcTraceMessageChannel implements IMessageChannel {
 
         AppInstance appInstance = AppInstance.getInstance();
         this.header = BrpcMessageHeader.newBuilder()
-                                       .setAppName(appInstance.getQualifiedAppName())
+                                       .setAppName(appInstance.getAppName())
                                        .setEnv(appInstance.getEnv())
                                        .setInstanceName(appInstance.getHostAndPort())
                                        .setHostIp(appInstance.getHostIp())
@@ -75,7 +75,7 @@ public class BrpcTraceMessageChannel implements IMessageChannel {
                                        .setAppType(ApplicationType.JAVA)
                                        .build();
         appInstance.addListener(port -> this.header = BrpcMessageHeader.newBuilder()
-                                                                       .setAppName(appInstance.getQualifiedAppName())
+                                                                       .setAppName(appInstance.getAppName())
                                                                        .setEnv(appInstance.getEnv())
                                                                        .setInstanceName(appInstance.getHostAndPort())
                                                                        .setHostIp(appInstance.getHostIp())

--- a/agent/agent-distribution/resources/agent.yml
+++ b/agent/agent-distribution/resources/agent.yml
@@ -1,7 +1,6 @@
 
 application:
   name:
-  env:
 
 controller:
   servers: 127.0.0.1:9899

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppConfiguration.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppConfiguration.java
@@ -26,7 +26,9 @@ import org.bithon.agent.configuration.validation.NotBlank;
 @ConfigurationProperties(prefix = "application", dynamic = false)
 public class AppConfiguration {
 
-    @NotBlank(message = "'bithon.application.env' should not be blank")
+    /**
+     * Kept for backward compatibility
+     */
     private String env;
 
     @NotBlank(message = "'bithon.application.name' should not be blank")

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
@@ -34,7 +34,7 @@ public class AppInstance {
 
     private static final AppInstance INSTANCE = new AppInstance(ConfigurationManager.getInstance().getConfig(AppConfiguration.class));
 
-    private final String qualifiedAppName;
+    private final String appName;
     private final String hostIp;
 
     private final List<IAppInstanceChangedListener> listeners = Collections.synchronizedList(new ArrayList<>());
@@ -48,7 +48,7 @@ public class AppInstance {
             appName = appName + "-" + appConfiguration.getEnv();
         }
 
-        this.qualifiedAppName = appName;
+        this.appName = appName;
         this.port = appConfiguration.getPort();
 
         if (StringUtils.isEmpty(appConfiguration.getInstance())) {
@@ -68,8 +68,8 @@ public class AppInstance {
         return INSTANCE;
     }
 
-    public String getQualifiedAppName() {
-        return qualifiedAppName;
+    public String getAppName() {
+        return appName;
     }
 
     public int getPort() {

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
@@ -34,18 +34,21 @@ public class AppInstance {
 
     private static final AppInstance INSTANCE = new AppInstance(ConfigurationManager.getInstance().getConfig(AppConfiguration.class));
 
-    private final String appName;
     private final String qualifiedAppName;
     private final String hostIp;
-    private final String env;
+
     private final List<IAppInstanceChangedListener> listeners = Collections.synchronizedList(new ArrayList<>());
     private int port;
     private String hostAndPort;
 
     private AppInstance(AppConfiguration appConfiguration) {
-        this.appName = appConfiguration.getName();
-        this.qualifiedAppName = appName + "-" + appConfiguration.getEnv();
-        this.env = appConfiguration.getEnv();
+        String appName = appConfiguration.getName();
+        if (StringUtils.hasText(appConfiguration.getEnv())) {
+            // Compatibility
+            appName = appName + "-" + appConfiguration.getEnv();
+        }
+
+        this.qualifiedAppName = appName;
         this.port = appConfiguration.getPort();
 
         if (StringUtils.isEmpty(appConfiguration.getInstance())) {
@@ -88,9 +91,6 @@ public class AppInstance {
         }
     }
 
-    public String getAppName() {
-        return appName;
-    }
 
     public String getHostIp() {
         return hostIp;
@@ -100,8 +100,11 @@ public class AppInstance {
         return hostAndPort;
     }
 
+    /**
+     * Kept for backward compatibility
+     */
     public String getEnv() {
-        return env;
+        return "";
     }
 
     public void addListener(IAppInstanceChangedListener listener) {

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
@@ -52,7 +52,8 @@ public class AppInstance {
         this.port = appConfiguration.getPort();
 
         if (StringUtils.isEmpty(appConfiguration.getInstance())) {
-            NetworkUtils.IpAddress ipAddress = NetworkUtils.getIpAddress();
+            // If the bithon.application.instance is not configured, construct the instance by a non loop-back IP
+            NetworkUtils.IpAddress ipAddress = NetworkUtils.getHostIpAddress();
             InetAddress address = null != ipAddress.getInetAddress()
                                   ? ipAddress.getInetAddress()
                                   : ipAddress.getLocalInetAddress();

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/Tracer.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/Tracer.java
@@ -68,7 +68,7 @@ public class Tracer {
                         ISampler sampler = SamplerFactory.createSampler(ConfigurationManager.getInstance()
                                                                                             .getDynamicConfig("tracing.samplingConfigs.default",
                                                                                                               TraceSamplingConfig.class));
-                        INSTANCE = new Tracer(appInstance.getQualifiedAppName(), appInstance.getHostAndPort())
+                        INSTANCE = new Tracer(appInstance.getAppName(), appInstance.getHostAndPort())
                             .propagator(new DefaultPropagator(sampler))
                             .traceIdGenerator(new UUIDGenerator())
                             .spanIdGenerator(new DefaultSpanIdGenerator())

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/utils/NetworkUtils.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/utils/NetworkUtils.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class NetworkUtils {
 
-    public static NetworkUtils.IpAddress getIpAddress() {
+    public static NetworkUtils.IpAddress getHostIpAddress() {
         List<InetAddress> localIPs = new ArrayList<>();
         List<InetAddress> netIPs = new ArrayList<>();
         try {

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,7 +33,7 @@ DOCKER_BUILDKIT=1 docker build -t bithon/server:{TAG} -f docker/Dockerfile-serve
 
 - Run with JVM arguments.
     ```bash
-    docker run -p 9895:9895 -p 9896:9896 -p 9897:9897 -p 9898:9898 -p 9899:9899 -e JAVA_OPTS="-Xmx4g -Dbithon.application.env=test" -itd bithon/server:{TAG} 
+    docker run -p 9895:9895 -p 9896:9896 -p 9897:9897 -p 9898:9898 -p 9899:9899 -e JAVA_OPTS="-Xmx4g" -itd bithon/server:{TAG} 
     ```
 
 - Run with extra JVM arguments in a file.
@@ -42,7 +42,6 @@ DOCKER_BUILDKIT=1 docker build -t bithon/server:{TAG} -f docker/Dockerfile-serve
     It contains some JVM arguments in multiple lines which will be passed to the application running in docker.
 
     ```bash
-    -Dbithon.application.env=test
     -Xms=2g
     -Xmx=4G
     ```
@@ -56,5 +55,5 @@ DOCKER_BUILDKIT=1 docker build -t bithon/server:{TAG} -f docker/Dockerfile-serve
     By default, the process inside the docker will first download agent from [https://repo1.maven.org/](https://repo1.maven.org/).
     If this site is not available for you, you can change this site by specifying an extra environment argument when starting the docker as follows 
     ```bash
-    docker run -p 9895:9895 -p 9896:9896 -p 9897:9897 -p 9898:9898 -p 9899:9899 -e AGENT_URI="YOUR_AGENT_URI" -e JAVA_OPTS="-Dbithon.application.env=test" -itd bithon/server:{TAG} 
+    docker run -p 9895:9895 -p 9896:9896 -p 9897:9897 -p 9898:9898 -p 9899:9899 -e AGENT_URI="YOUR_AGENT_URI" -itd bithon/server:{TAG} 
     ```

--- a/server/collector/src/main/java/org/bithon/server/collector/config/AgentConfigurationService.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/config/AgentConfigurationService.java
@@ -37,7 +37,7 @@ public class AgentConfigurationService {
         this.settingReader = storage.createReader();
     }
 
-    public Map<String, String> getSettings(String appName, String env, long since) {
-        return settingReader.getSettings(appName + "-" + env, since);
+    public Map<String, String> getSettings(String appName, long since) {
+        return settingReader.getSettings(appName, since);
     }
 }

--- a/server/collector/src/main/java/org/bithon/server/collector/config/BrpcSettingFetcher.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/config/BrpcSettingFetcher.java
@@ -43,6 +43,6 @@ public class BrpcSettingFetcher implements ISettingFetcher {
             // Compatibility with old agent protocol
             appName += "-" + env;
         }
-        return configurationService.getSettings(header.getAppName(), 0);
+        return configurationService.getSettings(appName, 0);
     }
 }

--- a/server/collector/src/main/java/org/bithon/server/collector/config/BrpcSettingFetcher.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/config/BrpcSettingFetcher.java
@@ -18,6 +18,7 @@ package org.bithon.server.collector.config;
 
 import org.bithon.agent.rpc.brpc.BrpcMessageHeader;
 import org.bithon.agent.rpc.brpc.setting.ISettingFetcher;
+import org.bithon.component.commons.utils.StringUtils;
 
 import java.util.Map;
 
@@ -27,15 +28,21 @@ import java.util.Map;
  */
 public class BrpcSettingFetcher implements ISettingFetcher {
 
-    private final AgentConfigurationService settingService;
+    private final AgentConfigurationService configurationService;
 
-    public BrpcSettingFetcher(AgentConfigurationService settingService) {
-        this.settingService = settingService;
+    public BrpcSettingFetcher(AgentConfigurationService configurationService) {
+        this.configurationService = configurationService;
     }
 
     @Override
     public Map<String, String> fetch(BrpcMessageHeader header, long lastModifiedSince) {
         // Always fetch all configuration by setting 'since' parameter to 0
-        return settingService.getSettings(header.getAppName(), header.getEnv(), 0);
+        String appName = header.getAppName();
+        String env = header.getEnv();
+        if (StringUtils.hasText(env)) {
+            // Compatibility with old agent protocol
+            appName += "-" + env;
+        }
+        return configurationService.getSettings(header.getAppName(), 0);
     }
 }


### PR DESCRIPTION
Remove `bithon.application.env` from document, no need to configure it. Keep it in code for compatibility