### PR TITLE
Add server side idle support to brpc server

### DIFF
--- a/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
+++ b/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
@@ -108,8 +108,7 @@ public class BrpcClient implements IBrpcChannel, Closeable {
                           @Override
                           public void initChannel(SocketChannel ch) {
                               ChannelPipeline pipeline = ch.pipeline();
-                              pipeline.addLast("frameDecoder",
-                                               new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
+                              pipeline.addLast("frameDecoder", new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
                               pipeline.addLast("frameEncoder", new LengthFieldPrepender(4));
                               pipeline.addLast("decoder", new ServiceMessageInDecoder());
                               pipeline.addLast("encoder", new ServiceMessageOutEncoder(invocationManager));
@@ -242,6 +241,9 @@ public class BrpcClient implements IBrpcChannel, Closeable {
         @Override
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
             BrpcClient.this.channelRef.getAndSet(null);
+
+            // Reset the connection timestamp so that we know that the connection is not connected
+            BrpcClient.this.connectionTimestamp = 0;
             super.channelInactive(ctx);
         }
     }

--- a/component/component-brpc/src/main/java/org/bithon/component/brpc/invocation/InvocationManager.java
+++ b/component/component-brpc/src/main/java/org/bithon/component/brpc/invocation/InvocationManager.java
@@ -163,7 +163,7 @@ public class InvocationManager {
             }
 
             if (!inflightRequest.responseReceived) {
-                throw new TimeoutException(channelWriter.getRemoteAddress().toString(),
+                throw new TimeoutException(remoteEndpoint.toString(),
                                            serviceRequest.getServiceName(),
                                            serviceRequest.getMethodName(),
                                            timeoutMillisecond);

--- a/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcCollectorStarter.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcCollectorStarter.java
@@ -109,11 +109,11 @@ public class BrpcCollectorStarter implements SmartLifecycle, ApplicationContextA
         }
 
         serviceGroups.forEach((port, serviceGroup) -> {
-            BrpcServer channel = new BrpcServer();
+            BrpcServer brpcServer = new BrpcServer();
             if (serviceGroup.isCtrl) {
-                applicationContext.getBean(AgentServer.class).setBrpcServer(channel);
+                applicationContext.getBean(AgentServer.class).setBrpcServer(brpcServer);
             }
-            serviceGroup.channel = channel;
+            serviceGroup.brpcServer = brpcServer;
             serviceGroup.start(port);
         });
 
@@ -157,14 +157,14 @@ public class BrpcCollectorStarter implements SmartLifecycle, ApplicationContextA
     static class ServiceGroup {
         private final List<ServiceProvider> services = new ArrayList<>();
         private boolean isCtrl;
-        private BrpcServer channel;
+        private BrpcServer brpcServer;
         private int port;
 
         public void start(Integer port) {
             for (ServiceProvider service : services) {
-                channel.bindService(service.getImplementation());
+                brpcServer.bindService(service.getImplementation());
             }
-            channel.start(port);
+            brpcServer.start(port);
             this.port = port;
         }
 
@@ -176,7 +176,7 @@ public class BrpcCollectorStarter implements SmartLifecycle, ApplicationContextA
             // close channel first
             log.info("Closing channel hosting on {}", port);
             try {
-                channel.close();
+                brpcServer.close();
             } catch (Exception ignored) {
             }
 


### PR DESCRIPTION
A lots of sessions are observed by executing diagnosis SQL on an instance what is deployed in remote DC region. Might be caused by broken connections. So server side idle processing is necessary.