### PR TITLE
Fix unmatched 'finish' call

### DIFF
--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/TraceContextListener.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/TraceContextListener.java
@@ -41,7 +41,7 @@ public class TraceContextListener {
     public TraceContextListener() {
         TraceConfig config = ConfigurationManager.getInstance().getConfig(TraceConfig.class);
         if (config != null && config.isDebug()) {
-            listeners.add(new SpanEventLogger());
+            listeners.add(new SpanEventDebugLogger());
         }
     }
 
@@ -67,7 +67,7 @@ public class TraceContextListener {
         void onSpanFinished(ITraceSpan span);
     }
 
-    private static class SpanEventLogger implements IListener {
+    private static class SpanEventDebugLogger implements IListener {
         private final ILogAdaptor log = LoggerFactory.getLogger(TraceContextListener.class);
 
         @Override

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/impl/TracingContext.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/impl/TracingContext.java
@@ -40,12 +40,13 @@ import java.util.Stack;
  */
 public class TracingContext implements ITraceContext {
 
+    private static final boolean IS_DEBUG_ENABLED = ConfigurationManager.getInstance().getConfig(TraceConfig.class).isDebug();
+
     private final Stack<ITraceSpan> spanStack = new Stack<>();
     private final List<ITraceSpan> spans = new ArrayList<>();
     private final Clock clock = new Clock();
     private final String traceId;
     private final ISpanIdGenerator spanIdGenerator;
-    private final boolean isDebugEnabled;
     private ITraceReporter reporter;
 
     private boolean finished = false;
@@ -54,7 +55,6 @@ public class TracingContext implements ITraceContext {
                           ISpanIdGenerator spanIdGenerator) {
         this.traceId = traceId;
         this.spanIdGenerator = spanIdGenerator;
-        this.isDebugEnabled = ConfigurationManager.getInstance().getConfig(TraceConfig.class).isDebug();
     }
 
     @Override
@@ -103,7 +103,7 @@ public class TracingContext implements ITraceContext {
     @Override
     public void finish() {
         if (!spanStack.isEmpty()) {
-            if (isDebugEnabled) {
+            if (IS_DEBUG_ENABLED) {
                 LoggerFactory.getLogger(TracingContext.class)
                              .warn(StringUtils.format("TraceContext does not finish correctly. "
                                                       + "[%d] spans are still remained unfinished. This IS a bug.\nRemained spans: \n%s",
@@ -150,7 +150,7 @@ public class TracingContext implements ITraceContext {
         if (spanStack.isEmpty()) {
             TraceContextListener.getInstance().onSpanFinished(span);
 
-            if (isDebugEnabled) {
+            if (IS_DEBUG_ENABLED) {
                 LoggerFactory.getLogger(TracingContext.class)
                              .warn(StringUtils.format("Try to finish a span which is not in the stack. This IS a bug.\nCurrent span: \n%s",
                                                       span),
@@ -166,7 +166,7 @@ public class TracingContext implements ITraceContext {
         if (!spanStack.peek().equals(span)) {
             TraceContextListener.getInstance().onSpanFinished(span);
 
-            if (isDebugEnabled) {
+            if (IS_DEBUG_ENABLED) {
                 LoggerFactory.getLogger(TracingContext.class)
                              .warn(StringUtils.format("Try to finish a span which does not match the span in the stack. This IS a bug.\nCurrent span: \n%s, \n Unfinished Spans:\n%s",
                                                       span,

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/impl/TracingSpan.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/impl/TracingSpan.java
@@ -181,9 +181,10 @@ class TracingSpan implements ITraceSpan {
     @Override
     public void finish() {
         if (this.endTime != 0) {
-
+            // This span has already been closed, this is a bug
             return;
         }
+
         this.endTime = context().clock().currentMicroseconds();
         try {
             this.tracingContext.onSpanFinished(this);

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/impl/TracingSpan.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/impl/TracingSpan.java
@@ -181,6 +181,7 @@ class TracingSpan implements ITraceSpan {
     @Override
     public void finish() {
         if (this.endTime != 0) {
+
             return;
         }
         this.endTime = context().clock().currentMicroseconds();
@@ -201,6 +202,7 @@ class TracingSpan implements ITraceSpan {
                 ", method=" + this.method +
                 ", kind=" + this.kind +
                 ", cost=" + (this.endTime - this.startTime) + "(micro seconds)" +
+                ", exception=" + this.tags.getOrDefault(Tags.Exception.TYPE, "") +
                 "]";
     }
 }

--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/HttpClientFinalizer$ResponseConnection.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/HttpClientFinalizer$ResponseConnection.java
@@ -34,7 +34,7 @@ import reactor.netty.http.client.HttpClientResponse;
 import java.util.function.BiFunction;
 
 /**
- * see reactor.netty.http.client.HttpClientFinalizer#responseConnection
+ * see {@link reactor.netty.http.client.HttpClientFinalizer#responseConnection}
  *
  * @author frank.chen021@outlook.com
  * @date 27/11/21 1:57 pm

--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/HttpClientFinalizer$Send.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/HttpClientFinalizer$Send.java
@@ -33,7 +33,7 @@ import reactor.netty.http.client.HttpClientRequest;
 import java.util.function.BiFunction;
 
 /**
- * see reactor.netty.http.client.HttpClientFinalizer#send
+ * See {@link reactor.netty.http.client.HttpClientFinalizer#send}
  *
  * @author frank.chen021@outlook.com
  * @date 27/11/21 1:57 pm


### PR DESCRIPTION
Fixes #588

This is because when the exception is raised, 'doFinally' hooked by the filter is triggered after the web-server's 'finish'