### PR TITLE
Prevent NPE from InstrumentationCommand in case interceptor fails to load

### DIFF
--- a/agent/agent-controller/src/main/java/org/bithon/agent/controller/cmd/InstrumentationCommand.java
+++ b/agent/agent-controller/src/main/java/org/bithon/agent/controller/cmd/InstrumentationCommand.java
@@ -45,12 +45,13 @@ public class InstrumentationCommand implements IInstrumentationCommand, IAgentCo
                     InstrumentedMethod m = new InstrumentedMethod();
                     m.interceptor = method.getInterceptor();
                     m.clazzLoader = clazzLoaderId;
-                    m.hitCount = supplier.isInitialized() ? supplier.get().getHitCount() : 0;
+                    m.hitCount = supplier.get() == null ? -1 : supplier.get().getHitCount();
                     m.clazzName = method.getType();
                     m.returnType = method.getReturnType();
                     m.methodName = method.getMethodName();
                     m.isStatic = method.isStatic();
                     m.parameters = method.getParameters();
+                    m.exception = supplier.getException();
                     returning.add(m);
                 }
             } else {

--- a/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/InterceptorSupplier.java
+++ b/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/InterceptorSupplier.java
@@ -104,7 +104,7 @@ public class InterceptorSupplier implements Supplier<AbstractInterceptor> {
         StringWriter stackTrace = new StringWriter(256);
         while (throwable != null) {
             try (PrintWriter pw = new PrintWriter(stackTrace)) {
-                pw.format(Locale.ENGLISH, "%s:%s\n", throwable.getClass().getName(), throwable.getMessage());
+                pw.format(Locale.ENGLISH, "%s:%s%n", throwable.getClass().getName(), throwable.getMessage());
                 throwable.printStackTrace(pw);
             }
             throwable = throwable.getCause();

--- a/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/InterceptorSupplier.java
+++ b/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/InterceptorSupplier.java
@@ -20,6 +20,8 @@ import org.bithon.agent.instrumentation.aop.interceptor.declaration.AbstractInte
 import org.bithon.agent.instrumentation.loader.PluginClassLoaderManager;
 import org.bithon.agent.instrumentation.logging.LoggerFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Locale;
 import java.util.function.Supplier;
 
@@ -32,8 +34,16 @@ public class InterceptorSupplier implements Supplier<AbstractInterceptor> {
     private ClassLoader classLoader;
 
     private volatile AbstractInterceptor interceptor;
+
+    /**
+     * The exception that the interceptor fails to load
+     */
+    private String exception;
+
+    /**
+     * The index of this supplier in the {@link InterceptorManager}
+     */
     private final int index;
-    private boolean initialized = false;
 
     public InterceptorSupplier(int index,
                                String interceptorClassName,
@@ -47,13 +57,12 @@ public class InterceptorSupplier implements Supplier<AbstractInterceptor> {
         return index;
     }
 
-    public boolean isInitialized() {
-        return initialized;
-    }
-
+    /**
+     * The return can be NULL
+     */
     @Override
     public AbstractInterceptor get() {
-        if (interceptor != null) {
+        if (interceptor != null || exception != null) {
             return interceptor;
         }
 
@@ -69,7 +78,6 @@ public class InterceptorSupplier implements Supplier<AbstractInterceptor> {
                 this.classLoader = null;
                 this.interceptorClassName = null;
             }
-            initialized = true;
             return interceptor;
         }
     }
@@ -82,11 +90,29 @@ public class InterceptorSupplier implements Supplier<AbstractInterceptor> {
 
             return (AbstractInterceptor) interceptorClass.getConstructor().newInstance();
         } catch (Throwable e) {
+            this.exception = getStackTrace(e);
+
             LoggerFactory.getLogger(InterceptorManager.class).error(String.format(Locale.ENGLISH,
-                                                                                  "Failed to load interceptor[%s] due to %s",
-                                                                                  interceptorClassName,
-                                                                                  e.getMessage()), e);
+                    "Failed to load interceptor[%s] due to %s",
+                    interceptorClassName,
+                    e.getMessage()), e);
             return null;
         }
+    }
+
+    private static String getStackTrace(Throwable throwable) {
+        StringWriter stackTrace = new StringWriter(256);
+        while (throwable != null) {
+            try (PrintWriter pw = new PrintWriter(stackTrace)) {
+                pw.format(Locale.ENGLISH, "%s:%s\n", throwable.getClass().getName(), throwable.getMessage());
+                throwable.printStackTrace(pw);
+            }
+            throwable = throwable.getCause();
+        }
+        return stackTrace.toString();
+    }
+
+    public String getException() {
+        return exception;
     }
 }

--- a/agent/agent-plugins/logging-log4j2/src/main/java/org/bithon/agent/plugin/log4j2/Log4j2Plugin.java
+++ b/agent/agent-plugins/logging-log4j2/src/main/java/org/bithon/agent/plugin/log4j2/Log4j2Plugin.java
@@ -34,11 +34,6 @@ public class Log4j2Plugin implements IPlugin {
     @Override
     public List<InterceptorDescriptor> getInterceptors() {
         return Arrays.asList(
-            /**
-             * {@link org.apache.logging.log4j.core.Logger#logMessage(String, org.apache.logging.log4j.Level, org.apache.logging.log4j.Marker, String, Throwable)}
-             * {@link org.apache.logging.log4j.core.Logger#logMessage(String, org.apache.logging.log4j.Level, org.apache.logging.log4j.Marker, Object, Throwable)}
-             * {@link org.apache.logging.log4j.core.Logger#logMessage(String, org.apache.logging.log4j.Level, org.apache.logging.log4j.Marker, CharSequence, Throwable)}
-             */
             forClass("org.apache.logging.log4j.core.Logger")
                 .methods(
                     MethodPointCutDescriptorBuilder.build()

--- a/agent/agent-plugins/logging-log4j2/src/main/java/org/bithon/agent/plugin/log4j2/interceptor/Logger$LogMessage.java
+++ b/agent/agent-plugins/logging-log4j2/src/main/java/org/bithon/agent/plugin/log4j2/interceptor/Logger$LogMessage.java
@@ -23,6 +23,10 @@ import org.bithon.agent.instrumentation.aop.interceptor.declaration.BeforeInterc
 import org.bithon.agent.observability.event.ExceptionCollector;
 
 /**
+ * {@link org.apache.logging.log4j.core.Logger#logMessage(String, org.apache.logging.log4j.Level, org.apache.logging.log4j.Marker, String, Throwable)}
+ * {@link org.apache.logging.log4j.core.Logger#logMessage(String, org.apache.logging.log4j.Level, org.apache.logging.log4j.Marker, Object, Throwable)}
+ * {@link org.apache.logging.log4j.core.Logger#logMessage(String, org.apache.logging.log4j.Level, org.apache.logging.log4j.Marker, CharSequence, Throwable)}
+ *
  * @author frankchen
  */
 public class Logger$LogMessage extends BeforeInterceptor {

--- a/component/agent-rpc-brpc/src/main/java/org/bithon/agent/rpc/brpc/cmd/IInstrumentationCommand.java
+++ b/component/agent-rpc-brpc/src/main/java/org/bithon/agent/rpc/brpc/cmd/IInstrumentationCommand.java
@@ -37,13 +37,14 @@ public interface IInstrumentationCommand {
         public String methodName;
         public boolean isStatic;
         public String parameters;
+        public String exception;
 
         /**
          * Return the object in an object array.
          * The sequence of the values in the array MUST be in accordance with the sequence of fields
          */
         public Object[] toObjects() {
-            return new Object[]{interceptor, clazzLoader, hitCount, clazzName, returnType, methodName, isStatic, parameters};
+            return new Object[]{interceptor, clazzLoader, hitCount, clazzName, returnType, methodName, isStatic, parameters, exception};
         }
     }
 

--- a/component/component-commons/src/main/java/org/bithon/component/commons/logging/LoggerFactory.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/logging/LoggerFactory.java
@@ -22,6 +22,8 @@ import org.bithon.component.commons.logging.adaptor.log4j2.Log4j2LogAdaptorFacto
 import org.bithon.component.commons.logging.adaptor.logback.LogbackAdaptorFactory;
 import org.bithon.component.commons.logging.adaptor.slf4j.Slf4jLogAdaptorFactory;
 
+import java.lang.reflect.InvocationTargetException;
+
 
 public class LoggerFactory {
 
@@ -46,11 +48,12 @@ public class LoggerFactory {
             };
             for (Class<?> factoryClass : factoryClassList) {
                 try {
-                    ILogAdaptorFactory factory = (ILogAdaptorFactory) factoryClass.newInstance();
+                    ILogAdaptorFactory factory = (ILogAdaptorFactory) factoryClass.getDeclaredConstructor().newInstance();
                     factory.newLogger("default").info("Using [{}] as logging framework", factory.getClass().getSimpleName());
                     LoggerFactory.adaptorFactory = factory;
                     break;
-                } catch (NoClassDefFoundError | InstantiationException | IllegalAccessException ignored) {
+                } catch (NoClassDefFoundError | InstantiationException | IllegalAccessException |
+                         NoSuchMethodException | InvocationTargetException ignored) {
                 }
             }
         }


### PR DESCRIPTION
This also prevents periodically instantiate the interceptor once it fails to instantiate. 

One case is that the Kafka plugin targets the 2.5 or higher, some lower kafka clients miss some classes referenced by the 2.5 which are indirectly referenced by the interceptors.