### PR TITLE
Decoupling filter from webapp and schema definition

### DIFF
--- a/doc/configuration/webapp/configuration-dashboard.md
+++ b/doc/configuration/webapp/configuration-dashboard.md
@@ -1,6 +1,6 @@
 # Dashboard Configuration
 
-## Example - Application Overview
+## Example—Application Overview
 
 ```json
 {
@@ -58,6 +58,58 @@
 
 ### Data Configuration
 
+### Filter Configuration
+
+#### Selector filter example
+
+```json
+{
+  "name": "jvm-metrics",
+  "title": "JVM",
+  "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "jvm-metrics",
+        "fields": [
+          "appName",
+          "instanceName"
+        ]
+      }
+    ]
+  },
+  ...
+}
+```
+
+#### Text input filter example
+
+By setting the `filter.showFilterInput` to `true` to enable the text filter on pages.
+
+```json
+{
+  "name": "exception-metrics",
+  "title": "Exceptions",
+  "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "exception-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "exceptionClass"
+        ]
+      }
+    ],
+    "showFilterInput": true
+  },
+  ...
+}
+```
+
 #### Timeseries
 
 #### groupBy
@@ -72,9 +124,9 @@ This is the ultimate way.
 }
 ```
 
-## Example - Get cardinality of application instances
+## Example—Get cardinality of application instances
 
-To illustrate cardinality of application instances in chart, add following column to columns of a char description file.
+To illustrate the cardinality of application instances in charts, add the following column to columns of a char description file.
 
 ```json
 {

--- a/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcMetricCollector.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcMetricCollector.java
@@ -52,8 +52,8 @@ import java.util.stream.Collectors;
 public class BrpcMetricCollector implements IMetricCollector, AutoCloseable {
 
     private final IMetricMessageSink metricSink;
-    private final IColumn appName = new StringColumn("appName", "appName", true);
-    private final IColumn instanceName = new StringColumn("instanceName", "instanceName", true);
+    private final IColumn appName = new StringColumn("appName", "appName");
+    private final IColumn instanceName = new StringColumn("instanceName", "instanceName");
 
     public BrpcMetricCollector(IMetricMessageSink metricSink) {
         this.metricSink = metricSink;
@@ -80,7 +80,7 @@ public class BrpcMetricCollector implements IMetricCollector, AutoCloseable {
         dimensionSpecs.addAll(message.getSchema()
                                      .getDimensionsSpecList()
                                      .stream()
-                                     .map(dimSpec -> new StringColumn(dimSpec.getName(), dimSpec.getName(), true))
+                                     .map(dimSpec -> new StringColumn(dimSpec.getName(), dimSpec.getName()))
                                      .collect(Collectors.toList()));
 
         DataSourceSchema schema = new DataSourceSchema(message.getSchema().getName(),

--- a/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcMetricCollector.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/source/brpc/BrpcMetricCollector.java
@@ -52,8 +52,8 @@ import java.util.stream.Collectors;
 public class BrpcMetricCollector implements IMetricCollector, AutoCloseable {
 
     private final IMetricMessageSink metricSink;
-    private final IColumn appName = new StringColumn("appName", "appName", "appName", true);
-    private final IColumn instanceName = new StringColumn("instanceName", "instanceName", "instanceName", true);
+    private final IColumn appName = new StringColumn("appName", "appName", true);
+    private final IColumn instanceName = new StringColumn("instanceName", "instanceName", true);
 
     public BrpcMetricCollector(IMetricMessageSink metricSink) {
         this.metricSink = metricSink;
@@ -80,7 +80,7 @@ public class BrpcMetricCollector implements IMetricCollector, AutoCloseable {
         dimensionSpecs.addAll(message.getSchema()
                                      .getDimensionsSpecList()
                                      .stream()
-                                     .map(dimSpec -> new StringColumn(dimSpec.getName(), dimSpec.getName(), dimSpec.getName(), true))
+                                     .map(dimSpec -> new StringColumn(dimSpec.getName(), dimSpec.getName(), true))
                                      .collect(Collectors.toList()));
 
         DataSourceSchema schema = new DataSourceSchema(message.getSchema().getName(),
@@ -89,16 +89,16 @@ public class BrpcMetricCollector implements IMetricCollector, AutoCloseable {
                                                        dimensionSpecs,
                                                        message.getSchema().getMetricsSpecList().stream().map(metricSpec -> {
                                                            if ("longMax".equals(metricSpec.getType())) {
-                                                               return new AggregateLongMaxColumn(metricSpec.getName(), metricSpec.getName(), metricSpec.getName());
+                                                               return new AggregateLongMaxColumn(metricSpec.getName(), metricSpec.getName());
                                                            }
                                                            if ("longMin".equals(metricSpec.getType())) {
-                                                               return new AggregateLongMinColumn(metricSpec.getName(), metricSpec.getName(), metricSpec.getName());
+                                                               return new AggregateLongMinColumn(metricSpec.getName(), metricSpec.getName());
                                                            }
                                                            if ("longSum".equals(metricSpec.getType())) {
-                                                               return new AggregateLongSumColumn(metricSpec.getName(), metricSpec.getName(), metricSpec.getName());
+                                                               return new AggregateLongSumColumn(metricSpec.getName(), metricSpec.getName());
                                                            }
                                                            if ("longLast".equals(metricSpec.getType())) {
-                                                               return new AggregateLongLastColumn(metricSpec.getName(), metricSpec.getName(), metricSpec.getName());
+                                                               return new AggregateLongLastColumn(metricSpec.getName(), metricSpec.getName());
                                                            }
 
                                                            return null;

--- a/server/sink/src/main/resources/schema/sql-metrics.json
+++ b/server/sink/src/main/resources/schema/sql-metrics.json
@@ -81,9 +81,9 @@
     {
       "type": "post",
       "name": "avgResponseTime",
-      "expression": "round(responseTime/1000.0/1000/callCount, 2)",
+      "expression": "round(responseTime * 1.0 /callCount, 2)",
       "displayText": "AVG Response Time",
-      "unit": "millisecond",
+      "unit": "nanosecond",
       "valueType": "double"
     }
   ],

--- a/server/sink/src/test/java/org/bithon/server/sink/metrics/MetricAggregatorTest.java
+++ b/server/sink/src/test/java/org/bithon/server/sink/metrics/MetricAggregatorTest.java
@@ -59,7 +59,7 @@ public class MetricAggregatorTest {
             new TimestampSpec("timestamp", null, null),
             Collections.emptyList(),
             Arrays.asList(new AggregateLongSumColumn("totalCount", "totalCount"),
-                          new AggregateLongMinColumn("minTime", "minTime" ),
+                          new AggregateLongMinColumn("minTime", "minTime"),
                           new AggregateLongMaxColumn("maxTime", "maxTime"))
         );
 

--- a/server/sink/src/test/java/org/bithon/server/sink/metrics/MetricAggregatorTest.java
+++ b/server/sink/src/test/java/org/bithon/server/sink/metrics/MetricAggregatorTest.java
@@ -67,7 +67,7 @@ public class MetricAggregatorTest {
             "one-dimension-table",
             "one-dimension-table",
             new TimestampSpec("timestamp", null, null),
-            Arrays.asList(new StringColumn("appName", "appName", "appName", true)),
+            Arrays.asList(new StringColumn("appName", "appName")),
             Arrays.asList(new AggregateLongSumColumn("totalCount", "totalCount"),
                           new AggregateLongMinColumn("minTime", "minTime"),
                           new AggregateLongMaxColumn("maxTime", "maxTime"))

--- a/server/sink/src/test/java/org/bithon/server/sink/metrics/MetricAggregatorTest.java
+++ b/server/sink/src/test/java/org/bithon/server/sink/metrics/MetricAggregatorTest.java
@@ -58,9 +58,9 @@ public class MetricAggregatorTest {
             "empty-dimension-table",
             new TimestampSpec("timestamp", null, null),
             Collections.emptyList(),
-            Arrays.asList(new AggregateLongSumColumn("totalCount", "totalCount", ""),
-                          new AggregateLongMinColumn("minTime", "minTime", ""),
-                          new AggregateLongMaxColumn("maxTime", "maxTime", ""))
+            Arrays.asList(new AggregateLongSumColumn("totalCount", "totalCount"),
+                          new AggregateLongMinColumn("minTime", "minTime" ),
+                          new AggregateLongMaxColumn("maxTime", "maxTime"))
         );
 
         DataSourceSchema hasDimensionSchema = new DataSourceSchema(
@@ -68,9 +68,9 @@ public class MetricAggregatorTest {
             "one-dimension-table",
             new TimestampSpec("timestamp", null, null),
             Arrays.asList(new StringColumn("appName", "appName", "appName", true)),
-            Arrays.asList(new AggregateLongSumColumn("totalCount", "totalCount", ""),
-                          new AggregateLongMinColumn("minTime", "minTime", ""),
-                          new AggregateLongMaxColumn("maxTime", "maxTime", ""))
+            Arrays.asList(new AggregateLongSumColumn("totalCount", "totalCount"),
+                          new AggregateLongMinColumn("minTime", "minTime"),
+                          new AggregateLongMaxColumn("maxTime", "maxTime"))
         );
 
         return new Object[]{

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricTable.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricTable.java
@@ -64,9 +64,7 @@ public class MetricTable extends TableImpl {
             Field dimensionField = createField(dimension.getName(), dimension.getDataType());
             dimensions.add(dimensionField);
 
-            if (dimension.isVisible()) {
-                indexesFields.add(dimensionField);
-            }
+            indexesFields.add(dimensionField);
         }
 
         for (IColumn metric : schema.getMetricsSpec()) {

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/web/JdbcDashboardStorage.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/web/JdbcDashboardStorage.java
@@ -54,7 +54,6 @@ public class JdbcDashboardStorage implements IDashboardStorage {
     public List<Dashboard> getDashboard(long afterTimestamp) {
         return dslContext.selectFrom(Tables.BITHON_WEB_DASHBOARD)
                          .where(Tables.BITHON_WEB_DASHBOARD.TIMESTAMP.ge(new Timestamp(afterTimestamp).toLocalDateTime()))
-                         .and(Tables.BITHON_WEB_DASHBOARD.DELETED.eq(0))
                          .fetch(this::toDashboard);
     }
 
@@ -117,6 +116,7 @@ public class JdbcDashboardStorage implements IDashboardStorage {
         dashboard.setPayload(record.get(Tables.BITHON_WEB_DASHBOARD.PAYLOAD));
         dashboard.setTimestamp(Timestamp.valueOf(record.get(Tables.BITHON_WEB_DASHBOARD.TIMESTAMP)));
         dashboard.setSignature(record.get(Tables.BITHON_WEB_DASHBOARD.SIGNATURE));
+        dashboard.setDeleted(record.get(Tables.BITHON_WEB_DASHBOARD.DELETED) == 1);
         return dashboard;
     }
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/StorageAutoConfiguration.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/StorageAutoConfiguration.java
@@ -161,14 +161,11 @@ public class StorageAutoConfiguration {
                                     "event",
                                     new TimestampSpec("timestamp", null, null),
                                     Arrays.asList(new StringColumn("appName",
-                                                                   "appName",
-                                                                   null),
+                                                                   "appName"),
                                                   new StringColumn("instanceName",
-                                                                   "instanceName",
-                                                                   null),
+                                                                   "instanceName"),
                                                   new StringColumn("type",
-                                                                   "type",
-                                                                   true)),
+                                                                   "type")),
                                     Collections.singletonList(AggregateCountColumn.INSTANCE));
 
     }
@@ -179,21 +176,16 @@ public class StorageAutoConfiguration {
                                      "trace_span_summary",
                                      new TimestampSpec("timestamp", null, null),
                                      Arrays.asList(new StringColumn("appName",
-                                                                    "appName",
-                                                                    null),
+                                                                    "appName"),
                                                    new StringColumn("instanceName",
-                                                                    "instanceName",
-                                                                    null),
+                                                                    "instanceName"),
                                                    new StringColumn("status",
-                                                                    "status",
-                                                                    true),
-                                                   new StringColumn("name", "name", false),
+                                                                    "status"),
+                                                   new StringColumn("name", "name"),
                                                    new StringColumn("normalizedUrl",
-                                                                    "url",
-                                                                    true),
-                                                   new StringColumn("kind", "kind", false)),
+                                                                    "url"),
+                                                   new StringColumn("kind", "kind")),
                                      Arrays.asList(AggregateCountColumn.INSTANCE,
-
                                                    // microsecond
                                                    new AggregateLongSumColumn("costTimeMs",
                                                                               "costTimeMs")));
@@ -209,7 +201,7 @@ public class StorageAutoConfiguration {
                 Integer indexPos = entry.getValue();
                 dimensionSpecs.add(new StringColumn("f" + indexPos,
                                                     // Alias
-                                                    tagName, null));
+                                                    tagName));
             }
         }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/StorageAutoConfiguration.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/StorageAutoConfiguration.java
@@ -162,14 +162,11 @@ public class StorageAutoConfiguration {
                                     new TimestampSpec("timestamp", null, null),
                                     Arrays.asList(new StringColumn("appName",
                                                                    "appName",
-                                                                   "appName",
                                                                    null),
                                                   new StringColumn("instanceName",
                                                                    "instanceName",
-                                                                   "instanceName",
                                                                    null),
                                                   new StringColumn("type",
-                                                                   "type",
                                                                    "type",
                                                                    true)),
                                     Collections.singletonList(AggregateCountColumn.INSTANCE));
@@ -183,27 +180,22 @@ public class StorageAutoConfiguration {
                                      new TimestampSpec("timestamp", null, null),
                                      Arrays.asList(new StringColumn("appName",
                                                                     "appName",
-                                                                    "appName",
                                                                     null),
                                                    new StringColumn("instanceName",
-                                                                    "instanceName",
                                                                     "instanceName",
                                                                     null),
                                                    new StringColumn("status",
                                                                     "status",
-                                                                    "status",
                                                                     true),
-                                                   new StringColumn("name", "name", "name", false),
+                                                   new StringColumn("name", "name", false),
                                                    new StringColumn("normalizedUrl",
                                                                     "url",
-                                                                    "url",
                                                                     true),
-                                                   new StringColumn("kind", "kind", "kind", false)),
+                                                   new StringColumn("kind", "kind", false)),
                                      Arrays.asList(AggregateCountColumn.INSTANCE,
 
                                                    // microsecond
                                                    new AggregateLongSumColumn("costTimeMs",
-                                                                              null,
                                                                               "costTimeMs")));
         dataSourceSchema.setVirtual(true);
         return dataSourceSchema;
@@ -217,10 +209,7 @@ public class StorageAutoConfiguration {
                 Integer indexPos = entry.getValue();
                 dimensionSpecs.add(new StringColumn("f" + indexPos,
                                                     // Alias
-                                                    tagName,
-                                                    // Display
-                                                    entry.getKey(),
-                                                    null));
+                                                    tagName, null));
             }
         }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/DataSourceSchema.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/DataSourceSchema.java
@@ -103,7 +103,7 @@ public class DataSourceSchema {
     @JsonIgnore
     private boolean isVirtual = false;
 
-    private static final IColumn TIMESTAMP_COLUMN = new LongColumn("timestamp", "timestamp", true);
+    private static final IColumn TIMESTAMP_COLUMN = new LongColumn("timestamp", "timestamp");
 
     public DataSourceSchema(String displayText,
                             String name,
@@ -152,7 +152,7 @@ public class DataSourceSchema {
         if ("timestamp".equals(timestampSpec.getTimestampColumn())) {
             this.columnMap.put(TIMESTAMP_COLUMN.getName(), TIMESTAMP_COLUMN);
         } else {
-            this.columnMap.put(timestampSpec.getTimestampColumn(), new LongColumn(timestampSpec.getTimestampColumn(), timestampSpec.getTimestampColumn(), true));
+            this.columnMap.put(timestampSpec.getTimestampColumn(), new LongColumn(timestampSpec.getTimestampColumn(), timestampSpec.getTimestampColumn()));
         }
     }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/DataSourceSchema.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/DataSourceSchema.java
@@ -103,7 +103,7 @@ public class DataSourceSchema {
     @JsonIgnore
     private boolean isVirtual = false;
 
-    private static final IColumn TIMESTAMP_COLUMN = new LongColumn("timestamp", "timestamp", null, true);
+    private static final IColumn TIMESTAMP_COLUMN = new LongColumn("timestamp", "timestamp", true);
 
     public DataSourceSchema(String displayText,
                             String name,
@@ -152,7 +152,7 @@ public class DataSourceSchema {
         if ("timestamp".equals(timestampSpec.getTimestampColumn())) {
             this.columnMap.put(TIMESTAMP_COLUMN.getName(), TIMESTAMP_COLUMN);
         } else {
-            this.columnMap.put(timestampSpec.getTimestampColumn(), new LongColumn(timestampSpec.getTimestampColumn(), timestampSpec.getTimestampColumn(), null, true));
+            this.columnMap.put(timestampSpec.getTimestampColumn(), new LongColumn(timestampSpec.getTimestampColumn(), timestampSpec.getTimestampColumn(), true));
         }
     }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/AbstractColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/AbstractColumn.java
@@ -39,20 +39,15 @@ public abstract class AbstractColumn implements IColumn {
     /**
      * This is the name that is used at business layer
      * If it's not specified, it's default to {@link #name}.
-     *
+     * <p>
      * Some underlying storage uses some meaningless name, and the business layer maps a business name to that meaningless name.
      */
     @Getter
     private final String alias;
 
-    @Getter
-    private final boolean visible;
-
     public AbstractColumn(@NotNull String name,
-                          @Nullable String alias,
-                          @Nullable Boolean visible) {
+                          @Nullable String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.visible = visible == null ? true : visible;
     }
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/AbstractColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/AbstractColumn.java
@@ -46,19 +46,13 @@ public abstract class AbstractColumn implements IColumn {
     private final String alias;
 
     @Getter
-    @NotNull
-    private final String displayText;
-
-    @Getter
     private final boolean visible;
 
     public AbstractColumn(@NotNull String name,
                           @Nullable String alias,
-                          @NotNull String displayText,
                           @Nullable Boolean visible) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.displayText = displayText;
         this.visible = visible == null ? true : visible;
     }
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ExpressionColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ExpressionColumn.java
@@ -42,9 +42,6 @@ public class ExpressionColumn implements IColumn {
     private final String alias;
 
     @Getter
-    private final String displayText;
-
-    @Getter
     private final String expression;
 
     @Getter
@@ -53,12 +50,10 @@ public class ExpressionColumn implements IColumn {
     @JsonCreator
     public ExpressionColumn(@JsonProperty("name") @NotNull String name,
                             @JsonProperty("alias") @Nullable String alias,
-                            @JsonProperty("displayText") @NotNull String displayText,
                             @JsonProperty("expression") @NotNull String expression,
                             @JsonProperty("valueType") @Nullable String valueType) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.displayText = displayText;
         this.expression = Preconditions.checkArgumentNotNull("expression", expression).trim();
         this.valueType = "long".equalsIgnoreCase(valueType) ? IDataType.LONG : IDataType.DOUBLE;
     }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/IColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/IColumn.java
@@ -67,13 +67,6 @@ public interface IColumn {
     String LONG_MAX = "longMax";
 
     /**
-     * temporarily for compatibility only
-     */
-    default boolean isVisible() {
-        return true;
-    }
-
-    /**
      * the name in the storage.
      * can NOT be null
      */

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/IColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/IColumn.java
@@ -81,8 +81,6 @@ public interface IColumn {
 
     String getAlias();
 
-    String getDisplayText();
-
     default NumberAggregator createAggregator() {
         throw new UnsupportedOperationException(StringUtils.format("createAggregator is not supported on type of " + this.getClass().getSimpleName()));
     }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/LongColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/LongColumn.java
@@ -33,9 +33,8 @@ public class LongColumn extends AbstractColumn {
     @JsonCreator
     public LongColumn(@JsonProperty("name") @NotNull String name,
                       @JsonProperty("alias") @Nullable String alias,
-                      @JsonProperty("displayText") @NotNull String displayText,
                       @JsonProperty("visible") @Nullable Boolean visible) {
-        super(name, alias, displayText, visible);
+        super(name, alias, visible);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/LongColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/LongColumn.java
@@ -32,9 +32,8 @@ public class LongColumn extends AbstractColumn {
 
     @JsonCreator
     public LongColumn(@JsonProperty("name") @NotNull String name,
-                      @JsonProperty("alias") @Nullable String alias,
-                      @JsonProperty("visible") @Nullable Boolean visible) {
-        super(name, alias, visible);
+                      @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/StringColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/StringColumn.java
@@ -32,9 +32,8 @@ public class StringColumn extends AbstractColumn {
 
     @JsonCreator
     public StringColumn(@JsonProperty("name") @NotNull String name,
-                        @JsonProperty("alias") @Nullable String alias,
-                        @JsonProperty("visible") Boolean visible) {
-        super(name, alias, visible);
+                        @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/StringColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/StringColumn.java
@@ -33,9 +33,8 @@ public class StringColumn extends AbstractColumn {
     @JsonCreator
     public StringColumn(@JsonProperty("name") @NotNull String name,
                         @JsonProperty("alias") @Nullable String alias,
-                        @JsonProperty("displayText") @NotNull String displayText,
                         @JsonProperty("visible") Boolean visible) {
-        super(name, alias, displayText, visible);
+        super(name, alias, visible);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/count/AggregateCountColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/count/AggregateCountColumn.java
@@ -54,11 +54,6 @@ public class AggregateCountColumn implements IAggregatableColumn {
     }
 
     @Override
-    public String getDisplayText() {
-        return "次数";
-    }
-
-    @Override
     public IDataType getDataType() {
         return IDataType.LONG;
     }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateDoubleLastColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateDoubleLastColumn.java
@@ -34,9 +34,8 @@ public class AggregateDoubleLastColumn extends AggregateLastColumn {
 
     @JsonCreator
     public AggregateDoubleLastColumn(@JsonProperty("name") @NotNull String name,
-                                     @JsonProperty("alias") @Nullable String alias,
-                                     @JsonProperty("displayText") @NotNull String displayText) {
-        super(name, alias, displayText);
+                                     @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateLastColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateLastColumn.java
@@ -37,18 +37,13 @@ public abstract class AggregateLastColumn implements IAggregatableColumn {
     @Getter
     private final String alias;
 
-    @Getter
-    protected final String displayText;
-
     protected final SimpleAggregateExpression aggregateExpression;
 
     @JsonCreator
     public AggregateLastColumn(String name,
-                               String alias,
-                               String displayText) {
+                               String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.displayText = displayText;
         this.aggregateExpression = new SimpleAggregateExpressions.LastAggregateExpression(name);
     }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateLongLastColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateLongLastColumn.java
@@ -31,9 +31,8 @@ public class AggregateLongLastColumn extends AggregateLastColumn {
 
     @JsonCreator
     public AggregateLongLastColumn(@JsonProperty("name") @NotNull String name,
-                                   @JsonProperty("alias") @Nullable String alias,
-                                   @JsonProperty("displayText") @NotNull String displayText) {
-        super(name, alias, displayText);
+                                   @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/max/AggregateLongMaxColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/max/AggregateLongMaxColumn.java
@@ -33,9 +33,8 @@ public class AggregateLongMaxColumn extends AggregateMaxColumn {
 
     @JsonCreator
     public AggregateLongMaxColumn(@JsonProperty("name") @NotNull String name,
-                                  @JsonProperty("alias") @Nullable String alias,
-                                  @JsonProperty("displayText") @NotNull String displayText) {
-        super(name, alias, displayText);
+                                  @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/max/AggregateMaxColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/max/AggregateMaxColumn.java
@@ -34,17 +34,12 @@ public abstract class AggregateMaxColumn implements IAggregatableColumn {
     @Getter
     private final String alias;
 
-    @Getter
-    protected final String displayText;
-
     protected final SimpleAggregateExpression aggregateExpression;
 
     public AggregateMaxColumn(String name,
-                              String alias,
-                              String displayText) {
+                              String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.displayText = displayText;
         this.aggregateExpression = new SimpleAggregateExpressions.MaxAggregateExpression(name);
     }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/min/AggregateLongMinColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/min/AggregateLongMinColumn.java
@@ -33,9 +33,8 @@ public class AggregateLongMinColumn extends AggregateMinColumn {
 
     @JsonCreator
     public AggregateLongMinColumn(@JsonProperty("name") @NotNull String name,
-                                  @JsonProperty("alias") @Nullable String alias,
-                                  @JsonProperty("displayText") @NotNull String displayText) {
-        super(name, alias, displayText);
+                                  @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/min/AggregateMinColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/min/AggregateMinColumn.java
@@ -35,18 +35,13 @@ public abstract class AggregateMinColumn implements IAggregatableColumn {
     @Getter
     private final String alias;
 
-    @Getter
-    protected final String displayText;
-
     protected final SimpleAggregateExpression aggregateExpression;
 
     @JsonCreator
     public AggregateMinColumn(String name,
-                              String alias,
-                              String displayText) {
+                              String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.displayText = displayText;
 
         // For IMetricSpec, the `name` property is the right text mapped a column in the underlying database,
         // So the two parameters of the following ctor are all `name` properties

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateDoubleSumColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateDoubleSumColumn.java
@@ -33,9 +33,8 @@ public class AggregateDoubleSumColumn extends AggregateSumColumn {
 
     @JsonCreator
     public AggregateDoubleSumColumn(@JsonProperty("name") @NotNull String name,
-                                    @JsonProperty("alias") @Nullable String alias,
-                                    @JsonProperty("displayText") @NotNull String displayText) {
-        super(name, alias, displayText);
+                                    @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateLongSumColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateLongSumColumn.java
@@ -33,9 +33,8 @@ public class AggregateLongSumColumn extends AggregateSumColumn {
 
     @JsonCreator
     public AggregateLongSumColumn(@JsonProperty("name") @NotNull String name,
-                                  @JsonProperty("alias") @Nullable String alias,
-                                  @JsonProperty("displayText") @NotNull String displayText) {
-        super(name, alias, displayText);
+                                  @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateSumColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateSumColumn.java
@@ -35,17 +35,12 @@ public abstract class AggregateSumColumn implements IAggregatableColumn {
     private final String alias;
 
 
-    @Getter
-    protected final String displayText;
-
     protected final SimpleAggregateExpression aggregateExpression;
 
     public AggregateSumColumn(String name,
-                              String alias,
-                              String displayText) {
+                              String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.displayText = displayText;
         this.aggregateExpression = new SimpleAggregateExpressions.SumAggregateExpression(name);
     }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/web/Dashboard.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/web/Dashboard.java
@@ -36,4 +36,5 @@ public class Dashboard {
     private String payload;
     private String signature;
     private Timestamp timestamp;
+    private boolean deleted;
 }

--- a/server/web-app/src/main/java/org/bithon/server/webapp/services/DashboardManager.java
+++ b/server/web-app/src/main/java/org/bithon/server/webapp/services/DashboardManager.java
@@ -81,7 +81,8 @@ public class DashboardManager implements InitializingBean, DisposableBean {
     public void afterPropertiesSet() {
         log.info("Starting schema incremental loader...");
         loaderScheduler.scheduleWithFixedDelay(this::incrementalLoad,
-                                               0, // no delay to execute the first task
+                                               // no delay to execute the first task
+                                               0,
                                                1,
                                                TimeUnit.MINUTES);
     }
@@ -93,7 +94,11 @@ public class DashboardManager implements InitializingBean, DisposableBean {
 
             if (!changedDashboards.isEmpty()) {
                 for (Dashboard dashboard : changedDashboards) {
-                    this.dashboards.put(dashboard.getName(), dashboard);
+                    if (dashboard.isDeleted()) {
+                        this.dashboards.remove(dashboard.getName());
+                    } else {
+                        this.dashboards.put(dashboard.getName(), dashboard);
+                    }
                 }
 
                 onChanged();

--- a/server/web-app/src/main/resources/dashboard/exception-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/exception-metrics.json
@@ -3,6 +3,17 @@
   "title": "Exceptions",
   "folder": "metrics",
   "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "exception-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "exceptionClass"
+        ]
+      }
+    ],
     "showFilterInput": true
   },
   "charts": [

--- a/server/web-app/src/main/resources/dashboard/http-incoming-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/http-incoming-metrics.json
@@ -2,6 +2,21 @@
   "name": "http-incoming-metrics",
   "title": "HTTP Incoming",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "http-incoming-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "method",
+          "uri",
+          "statusCode"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "http-incoming-metrics",

--- a/server/web-app/src/main/resources/dashboard/http-outgoing-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/http-outgoing-metrics.json
@@ -2,6 +2,22 @@
   "name": "http-outgoing-metrics",
   "title": "HTTP Outgoing",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "http-outgoing-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "targetHostPort",
+          "method",
+          "path",
+          "statusCode"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "http-outgoing-metrics",

--- a/server/web-app/src/main/resources/dashboard/jdbc-pool-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/jdbc-pool-metrics.json
@@ -2,6 +2,20 @@
   "name": "jdbc-pool-metrics",
   "title": "JDBC Connection Pool",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "jdbc-pool-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "server",
+          "database"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "jdbc-pool-metrics",

--- a/server/web-app/src/main/resources/dashboard/jvm-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/jvm-metrics.json
@@ -2,6 +2,18 @@
   "name": "jvm-metrics",
   "title": "JVM",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "jvm-metrics",
+        "fields": [
+          "appName",
+          "instanceName"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "jvm-metrics",
@@ -217,7 +229,11 @@
             "dimension": "generation",
             "matcher": {
               "type": "in",
-              "pattern": ["new", "ZGC Cycles", "ZGC Pauses"]
+              "pattern": [
+                "new",
+                "ZGC Cycles",
+                "ZGC Pauses"
+              ]
             }
           }
         }
@@ -250,7 +266,9 @@
           "gcCount",
           "avgGcTime"
         ],
-        "groupBy": ["gcName"],
+        "groupBy": [
+          "gcName"
+        ],
         "filters": {
           "generation": {
             "dimension": "generation",

--- a/server/web-app/src/main/resources/dashboard/kafka-consumer-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/kafka-consumer-metrics.json
@@ -2,6 +2,23 @@
   "name": "kafka-consumer-metrics",
   "title": "Kafka Consumer",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "kafka-consumer-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "cluster",
+          "topic",
+          "partition",
+          "groupId",
+          "clientId"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "kafka-consumer-metrics",

--- a/server/web-app/src/main/resources/dashboard/kafka-network-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/kafka-network-metrics.json
@@ -2,6 +2,24 @@
   "name": "kafka-network-metrics",
   "title": "Kafka Network",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "kafka-network-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "type",
+          "cluster",
+          "nodeId",
+          "groupId",
+          "clientId",
+          "exception"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "kafka-network-metrics",

--- a/server/web-app/src/main/resources/dashboard/kafka-producer-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/kafka-producer-metrics.json
@@ -2,6 +2,22 @@
   "name": "kafka-producer-metrics",
   "title": "Kafka Producer",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "kafka-producer-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "cluster",
+          "nodeId",
+          "topic",
+          "clientId"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "kafka-producer-metrics",

--- a/server/web-app/src/main/resources/dashboard/mongodb-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/mongodb-metrics.json
@@ -2,6 +2,22 @@
   "name": "mongodb-metrics",
   "title": "MongoDb",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "mongodb-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "server",
+          "database",
+          "collection",
+          "command"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "mongodb-metrics",

--- a/server/web-app/src/main/resources/dashboard/quartz-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/quartz-metrics.json
@@ -2,6 +2,21 @@
   "name": "quartz-metrics",
   "title": "Quartz",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "quartz-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "job",
+          "class",
+          "exception"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "quartz-metrics",

--- a/server/web-app/src/main/resources/dashboard/redis-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/redis-metrics.json
@@ -2,6 +2,20 @@
   "name": "redis-metrics",
   "title": "Redis",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "redis-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "uri",
+          "command"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "redis-metrics",

--- a/server/web-app/src/main/resources/dashboard/sql-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/sql-metrics.json
@@ -2,6 +2,20 @@
   "name": "sql-metrics",
   "title": "SQL",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "sql-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "server",
+          "database"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "sql-metrics",
@@ -44,7 +58,7 @@
       "type": "line",
       "yAxis": [
         {
-          "format": "millisecond"
+          "format": "nanoFormatter"
         }
       ],
       "columns": [

--- a/server/web-app/src/main/resources/dashboard/thread-pool-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/thread-pool-metrics.json
@@ -2,6 +2,20 @@
   "name": "thread-pool-metrics",
   "title": "Thread Pool",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "thread-pool-metrics",
+        "fields": [
+          "appName",
+          "instanceName",
+          "executorClass",
+          "poolName"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "thread-pool-metrics",

--- a/server/web-app/src/main/resources/dashboard/web-server-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/web-server-metrics.json
@@ -2,6 +2,18 @@
   "name": "web-server-metrics",
   "title": "Web Server",
   "folder": "metrics",
+  "filter": {
+    "selectors": [
+      {
+        "type": "datasource",
+        "name": "web-server-metrics",
+        "fields": [
+          "appName",
+          "instanceName"
+        ]
+      }
+    ]
+  },
   "charts": [
     {
       "dataSource": "web-server-metrics",

--- a/server/web-app/src/main/resources/static/js/component/app-selector/component.js
+++ b/server/web-app/src/main/resources/static/js/component/app-selector/component.js
@@ -81,8 +81,6 @@ class AppSelector {
         // Note: the first two dimensions MUST be app/instance
         for (let index = 0; index < schema.dimensionsSpec.length; index++) {
             const dimension = schema.dimensionsSpec[index];
-            if (!dimension.visible)
-                continue;
 
             if (index === 0 && dimension.alias === 'appName' && !keepAppFilter) {
                 // for appName filter, createAppSelector should be explicitly called
@@ -101,6 +99,22 @@ class AppSelector {
         }
 
         this.createFilters(filterSpecs);
+    }
+
+    createFilterByFields(datasource, fields) {
+        const filterSpecs = fields.map((field) => {
+            return {
+                filterType: 'select',
+                sourceType: 'datasource',
+                source: datasource,
+                name: field,
+                alias: field,
+                displayText: field,
+                onPreviousFilters: true
+            }
+        });
+        this.createFilters(filterSpecs);
+        return this;
     }
 
     /**

--- a/server/web-app/src/main/resources/static/js/component/app-selector/component.js
+++ b/server/web-app/src/main/resources/static/js/component/app-selector/component.js
@@ -95,7 +95,7 @@ class AppSelector {
                 source: schema.name,
                 name: dimension.name,
                 alias: dimension.alias,
-                displayText: dimension.displayText,
+                displayText: dimension.alias,
                 onPreviousFilters: true
             });
         }

--- a/server/web-app/src/main/resources/static/js/page/event/page.js
+++ b/server/web-app/src/main/resources/static/js/page/event/page.js
@@ -17,7 +17,7 @@ class EventPage {
 
             this.#refreshPage();
         }).createAppSelector(appName)
-          .createFilter('event');
+            .createFilterByFields('event', ['instanceName', 'type']);
 
         const parent = $('#filterBarForm');
 

--- a/server/web-app/src/main/resources/static/js/page/trace/page.js
+++ b/server/web-app/src/main/resources/static/js/page/trace/page.js
@@ -37,7 +37,7 @@ class TracePage {
                 }
                 this.#refreshPage();
             }).createAppSelector(this.mQueryParams['appName'])
-                .createFilter('trace_span_summary');
+                .createFilterByFields('trace_span_summary', ['instanceName', 'status', 'url']);
 
             // View, tag filter
             this.vTagFilter = new AppSelector({

--- a/server/web-app/src/main/resources/templates/app/dashboard.html
+++ b/server/web-app/src/main/resources/templates/app/dashboard.html
@@ -19,8 +19,7 @@
                 (boardConfig) => {
                     const dashboard = new Dashboard('dashboard',
                         dashboardName,
-                        window.queryParams['interval'],
-                        new SchemaApi());
+                        window.queryParams['interval']);
                     dashboard.load(boardConfig);
 
                     $(window).bind('resize', () => {

--- a/server/web-app/src/main/resources/templates/log/detail.html
+++ b/server/web-app/src/main/resources/templates/log/detail.html
@@ -77,7 +77,6 @@
                     const dashboard = new Dashboard('dashboard',
                         logStore,
                         window.queryParams['interval'],
-                        new SchemaApi(),
                         false);
                     dashboard.load(boardConfig);
 


### PR DESCRIPTION
1. selector filters are defined on dashboard instead of defining at the schema level
2. `displayText` and `visible` properties that support the filters are remove from schema definitions