### PR TITLE
Add trace mode to response

### DIFF
--- a/agent/agent-distribution/resources/agent.yml
+++ b/agent/agent-distribution/resources/agent.yml
@@ -55,4 +55,4 @@ tracing:
       samplingRate: 1
     kafka-consumer:
       samplingRate: 1
-  traceIdInResponse: "X-Bithon-TraceId"
+  traceModeResponseHeader: "X-Bithon-Trace"

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/config/TraceConfig.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/config/TraceConfig.java
@@ -17,6 +17,8 @@
 package org.bithon.agent.observability.tracing.config;
 
 import org.bithon.agent.configuration.ConfigurationProperties;
+import org.bithon.component.commons.utils.StringUtils;
+import org.bithon.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Collections;
 import java.util.List;
@@ -74,15 +76,32 @@ public class TraceConfig {
     /**
      * If this field is set, the trace id (if the current request has) will be added to the header of response.
      * The header name is the value of this field, header value is the trace id.
+     * For example, X-Bithon-TraceId
      */
-    private String traceIdInResponse;
+    private String traceResponseHeader = "X-Bithon-Trace";
 
-    public String getTraceIdInResponse() {
-        return traceIdInResponse;
+    @JsonIgnore
+    private String traceIdResponseHeader = "X-Bithon-Trace-Id";
+
+    @JsonIgnore
+    private String traceModeResponseHeader = "X-Bithon-Trace-Mode";
+
+    public String getTraceIdResponseHeader() {
+        return traceIdResponseHeader;
     }
 
-    public void setTraceIdInResponse(String traceIdInResponse) {
-        this.traceIdInResponse = traceIdInResponse;
+    public String getTraceModeResponseHeader() {
+        return traceModeResponseHeader;
+    }
+
+    public String getTraceResponseHeader() {
+        return traceResponseHeader;
+    }
+
+    public void setTraceResponseHeader(String traceResponseHeader) {
+        this.traceResponseHeader = traceResponseHeader;
+        this.traceIdResponseHeader = StringUtils.hasText(traceResponseHeader) ? traceResponseHeader + "-Id" : null;
+        this.traceModeResponseHeader = StringUtils.hasText(traceResponseHeader) ? traceResponseHeader + "-Mode" : null;
     }
 
     /**

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/TraceMode.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/TraceMode.java
@@ -24,11 +24,22 @@ public enum TraceMode {
     /**
      * Trace current request
      */
-    TRACING,
+    TRACING("tracing"),
 
     /**
      * Generate a unique trace id and print the id in the log for current request.
      * The trace id will be also duplicated across threads for this request.
      */
-    LOGGING
+    LOGGING("logging");
+
+
+    private final String text;
+
+    public String text() {
+        return text;
+    }
+
+    TraceMode(String text) {
+        this.text = text;
+    }
 }

--- a/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
+++ b/agent/agent-plugins/spring-webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
@@ -29,7 +29,6 @@ import org.bithon.agent.observability.tracing.config.TraceConfig;
 import org.bithon.agent.observability.tracing.context.ITraceContext;
 import org.bithon.agent.observability.tracing.context.ITraceSpan;
 import org.bithon.agent.observability.tracing.context.TraceContextHolder;
-import org.bithon.agent.observability.tracing.context.TraceMode;
 import org.bithon.agent.observability.tracing.context.propagation.ITracePropagator;
 import org.bithon.agent.plugin.spring.webflux.config.ResponseConfigs;
 import org.bithon.agent.plugin.spring.webflux.context.HttpServerContext;
@@ -123,14 +122,16 @@ public class ReactorHttpHandlerAdapter$Apply extends AroundInterceptor {
                                 .start();
 
                     // Put the trace id in the header so that the applications have a chance to know whether this request is being sampled
-                    if (traceContext.traceMode().equals(TraceMode.TRACING)) {
+                    {
                         request.requestHeaders().set("X-Bithon-TraceId", traceContext.traceId());
+                        request.requestHeaders().set("X-Bithon-TraceMode", traceContext.traceMode().text());
 
                         // Add trace id to response
-                        String traceIdHeader = traceConfig.getTraceIdInResponse();
+                        final HttpServerResponse response = aopContext.getArgAs(1);
+                        String traceIdHeader = traceConfig.getTraceIdResponseHeader();
                         if (StringUtils.hasText(traceIdHeader)) {
-                            final HttpServerResponse response = aopContext.getArgAs(1);
                             response.addHeader(traceIdHeader, traceContext.traceId());
+                            response.addHeader(traceConfig.getTraceModeResponseHeader(), traceContext.traceMode().text());
                         }
                     }
 

--- a/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/HttpChannel$Handle.java
+++ b/agent/agent-plugins/webserver-jetty/src/main/java/org/bithon/agent/plugin/jetty/interceptor/HttpChannel$Handle.java
@@ -27,7 +27,6 @@ import org.bithon.agent.observability.tracing.Tracer;
 import org.bithon.agent.observability.tracing.config.TraceConfig;
 import org.bithon.agent.observability.tracing.context.ITraceContext;
 import org.bithon.agent.observability.tracing.context.TraceContextHolder;
-import org.bithon.agent.observability.tracing.context.TraceMode;
 import org.bithon.agent.plugin.jetty.context.RequestContext;
 import org.bithon.component.commons.tracing.Components;
 import org.bithon.component.commons.tracing.SpanKind;
@@ -84,12 +83,14 @@ public class HttpChannel$Handle extends AroundInterceptor {
                             .start();
 
                 // put the trace id in the header so that the applications have a chance to know whether this request is being sampled
-                if (traceContext.traceMode().equals(TraceMode.TRACING)) {
+                {
                     request.setAttribute("X-Bithon-TraceId", traceContext.traceId());
+                    request.setAttribute("X-Bithon-TraceMode", traceContext.traceMode());
 
-                    String traceIdHeader = traceConfig.getTraceIdInResponse();
+                    String traceIdHeader = traceConfig.getTraceIdResponseHeader();
                     if (StringUtils.hasText(traceIdHeader)) {
                         httpChannel.getResponse().addHeader(traceIdHeader, traceContext.traceId());
+                        httpChannel.getResponse().addHeader(traceConfig.getTraceModeResponseHeader(), traceContext.traceMode().text());
                     }
                 }
             }

--- a/agent/agent-plugins/webserver-tomcat/src/main/java/org/bithon/agent/plugin/tomcat/interceptor/StandardHostValve$Invoke.java
+++ b/agent/agent-plugins/webserver-tomcat/src/main/java/org/bithon/agent/plugin/tomcat/interceptor/StandardHostValve$Invoke.java
@@ -28,7 +28,6 @@ import org.bithon.agent.observability.tracing.Tracer;
 import org.bithon.agent.observability.tracing.config.TraceConfig;
 import org.bithon.agent.observability.tracing.context.ITraceContext;
 import org.bithon.agent.observability.tracing.context.TraceContextHolder;
-import org.bithon.agent.observability.tracing.context.TraceMode;
 import org.bithon.component.commons.tracing.Components;
 import org.bithon.component.commons.tracing.SpanKind;
 import org.bithon.component.commons.tracing.Tags;
@@ -87,7 +86,7 @@ public class StandardHostValve$Invoke extends AroundInterceptor {
         TraceContextHolder.set(traceContext);
 
         // Put the trace id in the header so that the applications have a chance to know whether this request is being sampled
-        if (traceContext.traceMode().equals(TraceMode.TRACING)) {
+        {
             //
             // Here, we do not use request.getRequest().setAttribute()
             // This is because request.getRequest returns an instance of javax.servlet.HttpServletRequest or jakarta.servlet.HttpServletRequest depending on the tomcat server,
@@ -95,10 +94,12 @@ public class StandardHostValve$Invoke extends AroundInterceptor {
             // On tomcat 10, which requires jakarta.servlet.HttpServletRequest, this request.getRequest() call fails
             //
             request.setAttribute("X-Bithon-TraceId", traceContext.traceId());
+            request.setAttribute("X-Trace-Mode", traceContext.traceMode().text());
 
-            String traceIdHeader = traceConfig.getTraceIdInResponse();
+            String traceIdHeader = traceConfig.getTraceIdResponseHeader();
             if (StringUtils.hasText(traceIdHeader)) {
                 request.getResponse().addHeader(traceIdHeader, traceContext.traceId());
+                request.getResponse().addHeader(traceConfig.getTraceModeResponseHeader(), traceContext.traceMode().text());
             }
         }
 

--- a/agent/agent-plugins/webserver-undertow/src/main/java/org/bithon/agent/plugin/undertow/interceptor/HttpServerExchangeDispatch.java
+++ b/agent/agent-plugins/webserver-undertow/src/main/java/org/bithon/agent/plugin/undertow/interceptor/HttpServerExchangeDispatch.java
@@ -82,7 +82,7 @@ public class HttpServerExchangeDispatch extends BeforeInterceptor {
                 String traceIdHeader = traceConfig.getTraceIdResponseHeader();
                 if (StringUtils.hasText(traceIdHeader)) {
                     exchange.getResponseHeaders().add(HttpString.tryFromString(traceIdHeader), traceContext.traceId());
-                    exchange.getResponseHeaders().add(HttpString.tryFromString(traceIdHeader + "-Mode"), traceContext.traceMode().text());
+                    exchange.getResponseHeaders().add(HttpString.tryFromString(traceConfig.getTraceModeResponseHeader()), traceContext.traceMode().text());
                 }
             }
         }

--- a/agent/agent-plugins/webserver-undertow/src/main/java/org/bithon/agent/plugin/undertow/interceptor/HttpServerExchangeDispatch.java
+++ b/agent/agent-plugins/webserver-undertow/src/main/java/org/bithon/agent/plugin/undertow/interceptor/HttpServerExchangeDispatch.java
@@ -28,7 +28,6 @@ import org.bithon.agent.observability.metric.domain.web.HttpIncomingMetricsRegis
 import org.bithon.agent.observability.tracing.Tracer;
 import org.bithon.agent.observability.tracing.config.TraceConfig;
 import org.bithon.agent.observability.tracing.context.ITraceContext;
-import org.bithon.agent.observability.tracing.context.TraceMode;
 import org.bithon.agent.observability.tracing.context.propagation.ITracePropagator;
 import org.bithon.component.commons.tracing.Components;
 import org.bithon.component.commons.tracing.SpanKind;
@@ -75,13 +74,15 @@ public class HttpServerExchangeDispatch extends BeforeInterceptor {
                         .kind(SpanKind.SERVER)
                         .start();
 
-            if (traceContext.traceMode().equals(TraceMode.TRACING)) {
+            {
                 ServletRequestContext servletRequestContext = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
                 servletRequestContext.getServletRequest().setAttribute("X-Bithon-TraceId", traceContext.traceId());
+                servletRequestContext.getServletRequest().setAttribute("X-Trace-Mode", traceContext.traceMode().text());
 
-                String traceIdHeader = traceConfig.getTraceIdInResponse();
+                String traceIdHeader = traceConfig.getTraceIdResponseHeader();
                 if (StringUtils.hasText(traceIdHeader)) {
                     exchange.getResponseHeaders().add(HttpString.tryFromString(traceIdHeader), traceContext.traceId());
+                    exchange.getResponseHeaders().add(HttpString.tryFromString(traceIdHeader + "-Mode"), traceContext.traceMode().text());
                 }
             }
         }


### PR DESCRIPTION
Some applications do not trace all requests. For these un-traced requests, a trace id is still generated for logging purpose. In such case, the trace id, trace mode in the response is still meaningful.