### PR TITLE
Allow configuring sanitization/mapping

### DIFF
--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/common/pipeline/AbstractPipeline.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/common/pipeline/AbstractPipeline.java
@@ -92,7 +92,8 @@ public abstract class AbstractPipeline<RECEIVER extends IReceiver, EXPORTER exte
         for (Object transform : pipelineConfig.getProcessors()) {
             try {
                 transformers.add(new ExceptionSafeTransformer(createObject(ITransformer.class, objectMapper, transform)));
-            } catch (IOException ignored) {
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to initialize transformer", e);
             }
         }
         return transformers;

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/mapping/ITraceIdMappingExtractor.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/mapping/ITraceIdMappingExtractor.java
@@ -33,7 +33,7 @@ import java.util.function.BiConsumer;
 })
 public interface ITraceIdMappingExtractor {
     /**
-     * @param callback once a user id is successfully extracted from given span, this callback will be invoked
+     * @param consumer once a user id is successfully extracted from a given span, this callback will be invoked
      */
-    void extract(TraceSpan span, BiConsumer<TraceSpan, String> callback);
+    void extract(TraceSpan span, BiConsumer<TraceSpan, String> consumer);
 }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/mapping/NameValueExtractor.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/mapping/NameValueExtractor.java
@@ -34,23 +34,27 @@ import java.util.function.BiConsumer;
  */
 public class NameValueExtractor implements ITraceIdMappingExtractor {
 
-    private final Collection<String> names;
+    private final Collection<String> tags;
 
-    public NameValueExtractor(@JsonProperty("names") Collection<String> names) {
-        this.names = names;
+    public NameValueExtractor(Collection<String> tags) {
+        this.tags = tags;
     }
 
+    /**
+     * This object is created by deserializing the SpringBoot configuration.
+     * However, it treats the List/Set in the configuration as the type of Map.
+     */
     @JsonCreator
-    public NameValueExtractor(@JsonProperty("names") Map<String, String> names) {
-        this(new ArrayList<>(names.values()));
+    public NameValueExtractor(@JsonProperty("tags") Map<String, String> tags) {
+        this(new ArrayList<>(tags.values()));
     }
 
     @Override
-    public void extract(TraceSpan span, BiConsumer<TraceSpan, String> callback) {
-        for (String name : names) {
-            String value = span.getTags().get(name);
+    public void extract(TraceSpan span, BiConsumer<TraceSpan, String> consumer) {
+        for (String tag : tags) {
+            String value = span.getTags().get(tag);
             if (StringUtils.hasText(value)) {
-                callback.accept(span, value);
+                consumer.accept(span, value);
             }
         }
     }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/mapping/TraceIdMappingConfig.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/mapping/TraceIdMappingConfig.java
@@ -16,21 +16,17 @@
 
 package org.bithon.server.pipeline.tracing.mapping;
 
-import lombok.Data;
-
-import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Extract a user-defined transaction id on a given parameter to trace id
+ * See {@link ITraceIdMappingExtractor} and its implementation
  *
  * - type: xxx
- * - params:
+ * - args:
  *
  * @author frank.chen021@outlook.com
  * @date 10/12/21 3:08 PM
  */
-@Data
-public class TraceIdMappingConfig {
-    private String type;
-    private Map<String, Object> args;
+public class TraceIdMappingConfig extends HashMap<String, Object> {
 }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/transform/sanitization/UrlSanitizeTransformer.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/transform/sanitization/UrlSanitizeTransformer.java
@@ -51,10 +51,6 @@ public class UrlSanitizeTransformer extends AbstractSanitizer {
      */
     private final Map<String, String> sensitiveParameters;
 
-    /**
-     * NOTE: the ctor is passed from configuration which are deserialized from the application yml
-     * The default deserialization treats the list as a LinkedHashMap, so we have to define the ctor as the map
-     */
     @JsonCreator
     public UrlSanitizeTransformer(@JsonProperty("where") String where,
                                   @JsonProperty("sensitiveParameters") Map<String, String> sensitiveParameters) {
@@ -71,7 +67,7 @@ public class UrlSanitizeTransformer extends AbstractSanitizer {
 
             String attribVal = span.getTag(attribName);
             if (StringUtils.hasText(attribVal)) {
-                span.setTag(attribName, UrlUtils.sanitize(attribVal, parameterName, "*HIDDEN*"));
+                span.setTag(attribName, UrlUtils.sanitize(attribVal, parameterName, "***HIDDEN***"));
             }
         }
     }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/transform/sanitization/UrlSanitizeTransformer.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/transform/sanitization/UrlSanitizeTransformer.java
@@ -19,15 +19,12 @@ package org.bithon.server.pipeline.tracing.transform.sanitization;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.bithon.component.commons.tracing.Tags;
 import org.bithon.component.commons.utils.StringUtils;
+import org.bithon.server.commons.utils.UrlUtils;
 import org.bithon.server.storage.datasource.input.IInputRow;
 import org.bithon.server.storage.tracing.TraceSpan;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -43,7 +40,16 @@ import java.util.Map;
  */
 @JsonTypeName("url-sanitize-transform")
 public class UrlSanitizeTransformer extends AbstractSanitizer {
-    private final Collection<String> sensitiveParameters;
+    /**
+     * key - the attribute name in the 'tags'
+     * val - the parameter name
+     * <p>
+     * For example:
+     * key: http.uri
+     * val: password
+     * This means sanitize the 'password' parameter on the 'http.uri' attribute
+     */
+    private final Map<String, String> sensitiveParameters;
 
     /**
      * NOTE: the ctor is passed from configuration which are deserialized from the application yml
@@ -53,60 +59,20 @@ public class UrlSanitizeTransformer extends AbstractSanitizer {
     public UrlSanitizeTransformer(@JsonProperty("where") String where,
                                   @JsonProperty("sensitiveParameters") Map<String, String> sensitiveParameters) {
         super(where);
-        this.sensitiveParameters = new ArrayList<>(sensitiveParameters.values());
+        this.sensitiveParameters = sensitiveParameters == null ? Collections.emptyMap() : sensitiveParameters;
     }
 
     @Override
     protected void sanitize(IInputRow inputRow) {
         TraceSpan span = (TraceSpan) inputRow;
+        for (Map.Entry<String, String> entry : this.sensitiveParameters.entrySet()) {
+            String attribName = entry.getKey();
+            String parameterName = entry.getValue();
 
-        boolean sanitized = false;
-
-        Map<String, String> parameters = span.getUriParameters();
-        for (String sensitiveParameter : sensitiveParameters) {
-            if (parameters.containsKey(sensitiveParameter)) {
-                parameters.put(sensitiveParameter, "***HIDDEN***");
-                sanitized = true;
+            String attribVal = span.getTag(attribName);
+            if (StringUtils.hasText(attribVal)) {
+                span.setTag(attribName, UrlUtils.sanitize(attribVal, parameterName, "*HIDDEN*"));
             }
-        }
-        if (!sanitized) {
-            return;
-        }
-
-        // write back the query parameters to uri
-        String uriText = span.getTag(Tags.Http.URL);
-        if (StringUtils.isBlank(uriText)) {
-            // compatibility
-            uriText = span.getTag("uri");
-        }
-        if (StringUtils.isBlank(uriText)) {
-            return;
-        }
-
-        try {
-            URI uri = new URI(uriText);
-
-            StringBuilder query = new StringBuilder();
-            parameters.forEach((key, val) -> {
-                query.append(key);
-                query.append("=");
-                query.append(val);
-                query.append("&");
-            });
-            query.deleteCharAt(query.length() - 1);
-
-            URI modified = new URI(uri.getScheme(),
-                                   uri.getUserInfo(),
-                                   uri.getHost(),
-                                   uri.getPort(),
-                                   uri.getPath(),
-                                   query.toString(),
-                                   uri.getFragment());
-
-            // for backward compatibility
-            span.getTags().remove("uri");
-            span.setTag(Tags.Http.URL, modified.toString());
-        } catch (URISyntaxException ignored) {
         }
     }
 }

--- a/server/pipeline/src/test/java/org/bithon/server/pipeline/tracing/mapping/URIParameterExtractorTest.java
+++ b/server/pipeline/src/test/java/org/bithon/server/pipeline/tracing/mapping/URIParameterExtractorTest.java
@@ -17,6 +17,7 @@
 package org.bithon.server.pipeline.tracing.mapping;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.bithon.server.storage.tracing.TraceSpan;
 import org.bithon.server.storage.tracing.mapping.TraceIdMapping;
 import org.junit.Assert;
@@ -43,8 +44,7 @@ public class URIParameterExtractorTest {
                                                         "status",
                                                         "200")).build();
 
-        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(Collections.singletonList(
-                "query_id")));
+        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(ImmutableMap.of("uri", ImmutableSet.of("query_id"))));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
         Assert.assertEquals(2, mappings.size());
 
@@ -69,8 +69,7 @@ public class URIParameterExtractorTest {
                                      "status",
                                      "200"));
 
-        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(
-                Collections.singletonList("query_id")));
+        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(ImmutableMap.of("uri", ImmutableSet.of("query_id"))));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
 
         Assert.assertEquals(2, mappings.size());
@@ -96,8 +95,7 @@ public class URIParameterExtractorTest {
                                      "status",
                                      "200"));
 
-        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(
-                Collections.singletonList("query_id")));
+        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(ImmutableMap.of("uri", ImmutableSet.of("query_id"))));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
 
         Assert.assertEquals(2, mappings.size());
@@ -119,8 +117,7 @@ public class URIParameterExtractorTest {
         span.setStartTime(System.currentTimeMillis());
         span.setTags(ImmutableMap.of("uri", "/?query=SELECT+1&query_id====", "status", "200"));
 
-        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(
-                Collections.singletonList("query_id")));
+        Function<Collection<TraceSpan>, List<TraceIdMapping>> extractor = TraceMappingFactory.create(new URIParameterExtractor(ImmutableMap.of("uri", ImmutableSet.of("query_id"))));
         List<TraceIdMapping> mappings = extractor.apply(Collections.singletonList(span));
         Assert.assertEquals(2, mappings.size());
 

--- a/server/pipeline/src/test/java/org/bithon/server/pipeline/tracing/transform/UrlSanitizeTransformTest.java
+++ b/server/pipeline/src/test/java/org/bithon/server/pipeline/tracing/transform/UrlSanitizeTransformTest.java
@@ -1,0 +1,46 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.pipeline.tracing.transform;
+
+import com.google.common.collect.ImmutableMap;
+import org.bithon.server.pipeline.tracing.transform.sanitization.UrlSanitizeTransformer;
+import org.bithon.server.storage.datasource.input.transformer.ITransformer;
+import org.bithon.server.storage.tracing.TraceSpan;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+/**
+ * @author Frank Chen
+ * @date 13/2/24 1:53 pm
+ */
+public class UrlSanitizeTransformTest {
+    @Test
+    public void test() {
+        ITransformer transformer = new UrlSanitizeTransformer(null, ImmutableMap.of("http.url", "password",
+                                                                                    "url", "password"));
+
+        TraceSpan span = TraceSpan.builder()
+                                  .tags(new HashMap<>(ImmutableMap.of("http.url", "/?database=default&user=1&password=123",
+                                                                      "url", "/?database=default&user=1&password=123"))).build();
+        transformer.transform(span);
+
+        Assert.assertEquals("/?database=default&user=1&password=*HIDDEN*", span.getTag("http.url"));
+        Assert.assertEquals("/?database=default&user=1&password=*HIDDEN*", span.getTag("url"));
+    }
+}

--- a/server/server-commons/pom.xml
+++ b/server/server-commons/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/server/server-commons/src/main/java/org/bithon/server/commons/utils/UrlUtils.java
+++ b/server/server-commons/src/main/java/org/bithon/server/commons/utils/UrlUtils.java
@@ -79,4 +79,60 @@ public class UrlUtils {
 
         return variables;
     }
+
+    /**
+     * An in place replacement of value of a given parameter in one URL
+     * <pre>
+     * For example, for the given inputs as follows:
+     *   url: http://localhost/?p1=a&p2=b
+     *   parameter: p1
+     *   replacement: HIDDEN
+     * </pre>
+     * This function returns: http://localhost/?p1=HIDDEN&p2=b
+     */
+    public static String sanitize(String url, String parameter, String replacement) {
+        // Locate the start of query string
+        int queryParameterIndex = url.indexOf('?');
+        if (queryParameterIndex < 0) {
+            return url;
+        }
+
+        int parameterIndex = queryParameterIndex + 1;
+        do {
+            // Locate the start of given parameter name
+            parameterIndex = url.indexOf(parameter, parameterIndex);
+            if (parameterIndex == -1) {
+                break;
+            }
+
+            parameterIndex += parameter.length();
+
+            // After the parameter name, it should be the '='
+            // To make the function robust, we skip any spaces before the '=' character
+            while (parameterIndex < url.length() && url.charAt(parameterIndex) == ' ')
+                parameterIndex++;
+
+            if (parameterIndex < url.length()) {
+                // A '=' is expected.
+                // If it's not, the current match might be a substring, we need to continue to search the left characters
+                if (url.charAt(parameterIndex) == '=') {
+                    if (parameterIndex + 1 == url.length()) {
+                        // A string like 'p1&p2=' where we're searching p2
+                        return url;
+                    }
+
+                    int splitterIndex = url.indexOf('&', parameterIndex);
+                    if (parameterIndex + 1 == splitterIndex) {
+                        // No value for the parameter
+                        return url;
+                    }
+
+                    String before = url.substring(0, parameterIndex);
+                    return before + "=" + replacement + (splitterIndex > 0 ? url.substring(splitterIndex) : "");
+                }
+            }
+        } while (parameterIndex > 0 && parameterIndex < url.length());
+
+        return url;
+    }
 }

--- a/server/server-commons/src/main/java/org/bithon/server/commons/utils/UrlUtils.java
+++ b/server/server-commons/src/main/java/org/bithon/server/commons/utils/UrlUtils.java
@@ -109,8 +109,9 @@ public class UrlUtils {
 
             // After the parameter name, it should be the '='
             // To make the function robust, we skip any spaces before the '=' character
-            while (parameterIndex < url.length() && url.charAt(parameterIndex) == ' ')
+            while (parameterIndex < url.length() && url.charAt(parameterIndex) == ' ') {
                 parameterIndex++;
+            }
 
             if (parameterIndex < url.length()) {
                 // A '=' is expected.

--- a/server/server-commons/src/test/java/org/bithon/server/commons/utils/UrlUtilsTest.java
+++ b/server/server-commons/src/test/java/org/bithon/server/commons/utils/UrlUtilsTest.java
@@ -16,6 +16,7 @@
 
 package org.bithon.server.commons.utils;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,14 +29,14 @@ import java.util.Map;
 public class UrlUtilsTest {
 
     @Test
-    public void testParseParameters_Empty() {
+    public void test_ParseParameters_EmptyQueryString() {
         Assert.assertTrue(UrlUtils.parseURLParameters("http://localhost").isEmpty());
         Assert.assertTrue(UrlUtils.parseURLParameters("http://localhost?").isEmpty());
         Assert.assertTrue(UrlUtils.parseURLParameters("http://localhost?=").isEmpty());
     }
 
     @Test
-    public void test2() {
+    public void test_ParseParameters_EmptyValue() {
         Map<String, String> parameters = UrlUtils.parseURLParameters("http://localhost?m=");
         Assert.assertEquals(1, parameters.size());
         Assert.assertTrue(parameters.containsKey("m"));
@@ -43,7 +44,7 @@ public class UrlUtilsTest {
     }
 
     @Test
-    public void test3() {
+    public void test_ParseParameters_MultipleEmptyValues() {
         Map<String, String> parameters = UrlUtils.parseURLParameters("http://localhost?m=&n=");
         Assert.assertEquals(2, parameters.size());
         Assert.assertEquals("", parameters.get("m"));
@@ -73,12 +74,25 @@ public class UrlUtilsTest {
     }
 
     @Test
-    public void test_Normal() {
+    public void test_ParseParameters_Normal() {
         Map<String, String> parameters = UrlUtils.parseURLParameters("http://localhost?m=1&n=2&l=3&");
         Assert.assertEquals(3, parameters.size());
         Assert.assertEquals("1", parameters.get("m"));
         Assert.assertEquals("2", parameters.get("n"));
         Assert.assertEquals("3", parameters.get("l"));
+    }
+
+    @Test
+    public void test_ParseParameters_WhiteList() {
+        {
+            Map<String, String> parameters = UrlUtils.parseURLParameters("http://localhost?m=1&n=2&l=3&", ImmutableSet.of("n"));
+            Assert.assertEquals(1, parameters.size());
+            Assert.assertEquals("2", parameters.get("n"));
+        }
+        {
+            Map<String, String> parameters = UrlUtils.parseURLParameters("http://localhost?m=1&n=2&l=3&", ImmutableSet.of("x"));
+            Assert.assertEquals(0, parameters.size());
+        }
     }
 
     @Test

--- a/server/server-commons/src/test/java/org/bithon/server/commons/utils/UrlUtilsTest.java
+++ b/server/server-commons/src/test/java/org/bithon/server/commons/utils/UrlUtilsTest.java
@@ -80,4 +80,37 @@ public class UrlUtilsTest {
         Assert.assertEquals("2", parameters.get("n"));
         Assert.assertEquals("3", parameters.get("l"));
     }
+
+    @Test
+    public void test_Sanitize() {
+        // No value after the '='
+        Assert.assertEquals("http://localhost?password=", UrlUtils.sanitize("http://localhost?password=", "password", "HIDDEN"));
+
+        // Value is empty
+        Assert.assertEquals("http://localhost?password=HIDDEN", UrlUtils.sanitize("http://localhost?password=    ", "password", "HIDDEN"));
+
+        // Only one parameter
+        Assert.assertEquals("http://localhost?password=HIDDEN", UrlUtils.sanitize("http://localhost?password=2", "password", "HIDDEN"));
+
+        // More parameters, and it's at the end
+        Assert.assertEquals("http://localhost?user=1&password=HIDDEN", UrlUtils.sanitize("http://localhost?user=1&password=2", "password", "HIDDEN"));
+
+        // More parameters, and it's in the middle
+        Assert.assertEquals("http://localhost?user=1&password=HIDDEN&database=default", UrlUtils.sanitize("http://localhost?user=1&password=2&database=default", "password", "HIDDEN"));
+
+        // No parameters
+        Assert.assertEquals("http://localhost", UrlUtils.sanitize("http://localhost", "localhost", "HIDDEN"));
+
+        // No matched parameter
+        Assert.assertEquals("http://localhost?p=1&q=2&r=3", UrlUtils.sanitize("http://localhost?p=1&q=2&r=3", "localhost", "HIDDEN"));
+
+        // No host
+        Assert.assertEquals("?query=select+1&password=HIDDEN", UrlUtils.sanitize("?query=select+1&password=2", "password", "HIDDEN"));
+
+        // No host
+        Assert.assertEquals("?password1=2&password=HIDDEN", UrlUtils.sanitize("?password1=2&password=3", "password", "HIDDEN"));
+
+        Assert.assertEquals("?p1=1&pass=&p3=3", UrlUtils.sanitize("?p1=1&pass=&p3=3", "pass", "HIDDEN"));
+
+    }
 }

--- a/server/server-starter/src/main/resources/application-pipeline-from-kafka.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-from-kafka.yml
@@ -43,6 +43,14 @@ bithon:
             "[bootstrap.servers]": localhost:9092
             "[fetch.min.bytes]": 1048576
       processors:
+        - type: filter
+          expr: not endsWith(clazz,  'UriNormalizer')
+        - type: url-sanitize-transform
+          sensitiveParameters:
+            "[http.uri]": password
+            "[http.url]": password
+            "uri": password
+        - type: builtin-span-transform
       exporters:
         - type: store
 

--- a/server/server-starter/src/main/resources/application-pipeline-from-kafka.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-from-kafka.yml
@@ -51,6 +51,15 @@ bithon:
             "[http.url]": password
             "uri": password
         - type: builtin-span-transform
+      mapping:
+        - type: uri
+          tags:
+            "[http.uri]": ["query_id"]
+            "[http.url]": ["query_id"]
+            "uri": ["query_id"]
+        - type: name
+          tags:
+            names: ["clickhouse.query_id"]
       exporters:
         - type: store
 

--- a/server/server-starter/src/main/resources/application-pipeline-to-kafka-to-local.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-to-kafka-to-local.yml
@@ -113,6 +113,15 @@ bithon:
             "[http.url]": password
             "uri": password
         - type: builtin-span-transform
+      mapping:
+        - type: uri
+          tags:
+            "[http.uri]": ["query_id"]
+            "[http.url]": ["query_id"]
+            "uri": ["query_id"]
+        - type: name
+          tags:
+            names: ["clickhouse.query_id"]
       exporters:
         - type: store
 

--- a/server/server-starter/src/main/resources/application-pipeline-to-kafka-to-local.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-to-kafka-to-local.yml
@@ -105,6 +105,14 @@ bithon:
             "[bootstrap.servers]": localhost:9092
             "[fetch.min.bytes]": 1048576
       processors:
+        - type: filter
+          expr: not endsWith(clazz,  'UriNormalizer')
+        - type: url-sanitize-transform
+          sensitiveParameters:
+            "[http.uri]": password
+            "[http.url]": password
+            "uri": password
+        - type: builtin-span-transform
       exporters:
         - type: store
 

--- a/server/server-starter/src/main/resources/application-pipeline-to-local.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-to-local.yml
@@ -26,9 +26,9 @@ bithon:
           expr: not endsWith(clazz,  'UriNormalizer')
         - type: url-sanitize-transform
           sensitiveParameters:
-            - "http.uri": password
-            - "http.url": password
-            - "uri": password
+            "[http.uri]": password
+            "[http.url]": password
+            "uri": password
         - type: builtin-span-transform
       exporters:
         - type: store

--- a/server/server-starter/src/main/resources/application-pipeline-to-local.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-to-local.yml
@@ -30,6 +30,14 @@ bithon:
             "[http.url]": password
             "uri": password
         - type: builtin-span-transform
+      mapping:
+        - type: uri
+          tags:
+            "[http.uri]": ["query_id"]
+            "[http.url]": ["query_id"]
+            "uri": ["query_id"]
+        - type: name
+          tags: ["clickhouse.query_id"]
       exporters:
         - type: store
 

--- a/server/server-starter/src/main/resources/application-pipeline-to-local.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-to-local.yml
@@ -26,7 +26,9 @@ bithon:
           expr: not endsWith(clazz,  'UriNormalizer')
         - type: url-sanitize-transform
           sensitiveParameters:
-            - password
+            - "http.uri": password
+            - "http.url": password
+            - "uri": password
         - type: builtin-span-transform
       exporters:
         - type: store

--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceSpan.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceSpan.java
@@ -26,8 +26,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.bithon.component.commons.utils.StringUtils;
-import org.bithon.server.commons.utils.UrlUtils;
 import org.bithon.server.storage.common.ApplicationType;
 import org.bithon.server.storage.datasource.input.IInputRow;
 
@@ -110,9 +108,6 @@ public class TraceSpan implements IInputRow {
     public String normalizedUri = "";
 
     @JsonIgnore
-    private volatile Map<String, String> uriParameters;
-
-    @JsonIgnore
     private Map<String, Object> properties;
 
     public String getTag(String name) {
@@ -121,22 +116,6 @@ public class TraceSpan implements IInputRow {
 
     public void setTag(String name, String value) {
         this.tags.put(name, value);
-    }
-
-    public Map<String, String> getUriParameters() {
-        if (this.uriParameters == null) {
-            synchronized (this) {
-                if (this.uriParameters == null) {
-                    String uri = this.getTag("http.uri");
-                    if (StringUtils.isBlank(uri)) {
-                        // compatibility
-                        uri = this.getTag("uri");
-                    }
-                    this.uriParameters = UrlUtils.parseURLParameters(uri);
-                }
-            }
-        }
-        return this.uriParameters;
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceTableSchema.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceTableSchema.java
@@ -47,6 +47,7 @@ public class TraceTableSchema implements ISchema {
 
     private final IDataStoreSpec dataStoreSpec;
     private final Map<String, IColumn> columnMap = new HashMap<>();
+    private final Map<String, IColumn> aliasMap = new HashMap<>();
 
     TraceTableSchema(String name, ITraceStorage storage, List<IColumn> columns) {
         this.name = name;
@@ -56,7 +57,7 @@ public class TraceTableSchema implements ISchema {
             columnMap.put(column.getName(), column);
 
             if (!column.getAlias().equals(column.getName())) {
-                columnMap.put(column.getAlias(), column);
+                aliasMap.put(column.getAlias(), column);
             }
         });
     }
@@ -78,7 +79,8 @@ public class TraceTableSchema implements ISchema {
 
     @Override
     public IColumn getColumnByName(String name) {
-        return this.columnMap.get(name);
+        IColumn column = this.columnMap.get(name);
+        return column == null ? this.aliasMap.get(name) : column;
     }
 
     @Override

--- a/server/web-app/src/main/resources/static/js/component/selector.js
+++ b/server/web-app/src/main/resources/static/js/component/selector.js
@@ -79,9 +79,11 @@ class AppSelector {
 
         const filterSpecs = [];
         // Note: the first two dimensions MUST be app/instance
-        for (let index = 0; index < schema.dimensionsSpec.length; index++) {
-            const dimension = schema.dimensionsSpec[index];
-
+        for (let index = 0; index < schema.columns.length; index++) {
+            const dimension = schema.columns[index];
+            if (dimension.type !== 'string') {
+                continue;
+            }
             if (index === 0 && dimension.alias === 'appName' && !keepAppFilter) {
                 // for appName filter, createAppSelector should be explicitly called
                 continue;
@@ -93,7 +95,7 @@ class AppSelector {
                 source: schema.name,
                 name: dimension.name,
                 alias: dimension.alias,
-                displayText: dimension.alias,
+                displayText: dimension.alias.startsWith('tags.') ? dimension.alias.substring(5) : dimension.alias,
                 onPreviousFilters: true
             });
         }


### PR DESCRIPTION
Before, the processed tag name is fixed as 'http.uri', now it can be configured.