### PR TITLE
Improve the memory usage

### DIFF
--- a/server/collector/src/main/java/org/bithon/server/collector/http/TraceHttpCollector.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/http/TraceHttpCollector.java
@@ -18,11 +18,12 @@ package org.bithon.server.collector.http;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.UTF8StreamJsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.bithon.component.commons.concurrency.NamedThreadFactory;
 import org.bithon.component.commons.utils.ReflectionUtils;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.pipeline.tracing.ITraceProcessor;
@@ -39,6 +40,9 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -52,12 +56,23 @@ import java.util.zip.InflaterInputStream;
 public class TraceHttpCollector {
 
     private final ObjectMapper om;
+    private final TraceHttpCollectorConfig config;
+    private final ThreadPoolExecutor executor;
 
     @Setter
     private ITraceProcessor processor;
 
-    public TraceHttpCollector(ObjectMapper om) {
-        this.om = om;
+    public TraceHttpCollector(TraceHttpCollectorConfig config,
+                              ObjectMapper objectMapper) {
+        this.config = config;
+        this.om = objectMapper;
+        this.executor = new ThreadPoolExecutor(1,
+                                               4,
+                                               1L,
+                                               TimeUnit.MINUTES,
+                                               new LinkedBlockingQueue<>(8),
+                                               NamedThreadFactory.of("trace-http-processor"),
+                                               new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
     @PostMapping("/api/collector/trace")
@@ -82,13 +97,29 @@ public class TraceHttpCollector {
             }
         }
 
-        List<TraceSpan> spans;
+        List<TraceSpan> spans = new ArrayList<>(256);
 
-        // create parser manually so that this parser can be accessed in the catch handler
+        // Create parser manually so that this parser can be accessed in the catch handler
         try (JsonParser parser = om.createParser(is)) {
             try {
-                spans = om.readValue(parser, new TypeReference<ArrayList<TraceSpan>>() {
-                });
+                JsonToken token = parser.nextToken();
+                if (token != JsonToken.START_ARRAY) {
+                    return;
+                }
+
+                // JSONArray format
+                while (parser.nextToken() == JsonToken.START_OBJECT) {
+                    spans.add(om.readValue(parser, TraceSpan.class));
+
+                    // This controls the size of content reading from HTTP,
+                    // to avoid excessive memory pressure at the collector side
+                    if (spans.size() >= config.getMaxRowsPerBatch()) {
+                        process(spans);
+
+                        // Create a new array to hold the next batch
+                        spans = new ArrayList<>(256);
+                    }
+                }
             } catch (IOException e) {
                 String message = StringUtils.format("Invalid input from [%s]: %s", request.getRemoteAddr(), e.getMessage());
                 log.error(message, e);
@@ -112,10 +143,14 @@ public class TraceHttpCollector {
                 return;
             }
         }
+
+        process(spans);
+    }
+
+    private void process(List<TraceSpan> spans) {
         if (spans.isEmpty()) {
             return;
         }
-
-        this.processor.process("trace", spans);
+        this.executor.execute(() -> this.processor.process("trace", spans));
     }
 }

--- a/server/collector/src/main/java/org/bithon/server/collector/http/TraceHttpCollectorConfig.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/http/TraceHttpCollectorConfig.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.collector.http;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Frank Chen
+ * @date 31/3/24 6:04 pm
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "bithon.receivers.traces.http")
+public class TraceHttpCollectorConfig {
+    private boolean enabled;
+    private int maxRowsPerBatch = 5000;
+}

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/event/exporter/KafkaEventExporter.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/event/exporter/KafkaEventExporter.java
@@ -20,18 +20,22 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.OptBoolean;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.bithon.component.commons.utils.Preconditions;
 import org.bithon.server.storage.event.EventMessage;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +46,7 @@ import java.util.Map;
 @Slf4j
 public class KafkaEventExporter implements IEventExporter {
 
-    private final KafkaTemplate<String, String> producer;
+    private final KafkaTemplate<String, byte[]> producer;
     private final ObjectMapper objectMapper;
     private final String topic;
 
@@ -54,40 +58,30 @@ public class KafkaEventExporter implements IEventExporter {
 
         this.producer = new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(props,
                                                                               new StringSerializer(),
-                                                                              new StringSerializer()),
+                                                                              new ByteArraySerializer()),
                                             ImmutableMap.of(ProducerConfig.CLIENT_ID_CONFIG, "event"));
-        this.objectMapper = objectMapper;
+        this.objectMapper = objectMapper.copy()
+                                        .configure(SerializationFeature.FLUSH_AFTER_WRITE_VALUE, true);
     }
 
     @Override
     public void process(String messageType, List<EventMessage> messages) {
-        String key = null;
-
-        StringBuilder messageText = new StringBuilder(512);
-        messageText.append('[');
-        for (EventMessage eventMessage : messages) {
-
-            // Sink receives messages from an agent, it's safe to use instance name of first item
-            if (key == null) {
-                key = messageType + "/" + eventMessage.getAppName() + "/" + eventMessage.getInstanceName();
+        ByteArrayOutputStream bao = new ByteArrayOutputStream(512);
+        try {
+            JsonGenerator generator = objectMapper.createGenerator(bao);
+            for (EventMessage eventMessage : messages) {
+                try {
+                    objectMapper.writeValue(generator, eventMessage);
+                } catch (IOException ignored) {
+                }
+                generator.writeRaw('\n');
             }
+            bao.flush();
 
-            // deserialization
-            try {
-                messageText.append(objectMapper.writeValueAsString(eventMessage));
-            } catch (JsonProcessingException ignored) {
-            }
-
-            messageText.append(",\n");
-        }
-        if (messageText.length() > 2) {
-            // Remove last separator
-            messageText.delete(messageText.length() - 2, messageText.length());
-        }
-        messageText.append(']');
-        if (key != null) {
-            ProducerRecord<String, String> record = new ProducerRecord<>(this.topic, key, messageText.toString());
+            ProducerRecord<String, byte[]> record = new ProducerRecord<>(this.topic, null, bao.toByteArray());
             producer.send(record);
+        } catch (IOException e) {
+            log.error("Failed to serialize event message", e);
         }
     }
 

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/event/exporter/KafkaEventExporter.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/event/exporter/KafkaEventExporter.java
@@ -98,6 +98,6 @@ public class KafkaEventExporter implements IEventExporter {
 
     @Override
     public String toString() {
-        return "to-kafka";
+        return "export-event-to-kafka";
     }
 }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/event/exporter/ToEventStorageExporter.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/event/exporter/ToEventStorageExporter.java
@@ -58,6 +58,6 @@ public class ToEventStorageExporter implements IEventExporter {
 
     @Override
     public String toString() {
-        return "to-event-storage";
+        return "export-event-to-storage";
     }
 }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/ToKafkaExporter.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/ToKafkaExporter.java
@@ -99,18 +99,18 @@ public class ToKafkaExporter implements IMetricExporter {
 
         FixedSizeBuffer messageBuffer = this.bufferThreadLocal.get();
         messageBuffer.reset();
-        messageBuffer.writeChar('{');
+        messageBuffer.writeAsciiChar('{');
         if (message.getSchema() != null) {
             try {
                 messageBuffer.writeString("\"schema\":");
                 messageBuffer.writeBytes(this.objectMapper.writeValueAsBytes(message.getSchema()));
-                messageBuffer.writeChar(',');
+                messageBuffer.writeAsciiChar(',');
             } catch (JsonProcessingException ignored) {
             }
         }
         messageBuffer.writeString("\"metrics\": [");
 
-        int metricStartOffset = messageBuffer.getOffset();
+        int metricStartOffset = messageBuffer.getPosition();
 
         for (IInputRow metric : message.getMetrics()) {
             byte[] metricBytes;
@@ -134,7 +134,7 @@ public class ToKafkaExporter implements IMetricExporter {
             }
 
             messageBuffer.writeBytes(metricBytes);
-            messageBuffer.writeChar(',');
+            messageBuffer.writeAsciiChar(',');
         }
 
         send(header, messageKey, messageBuffer);
@@ -149,8 +149,8 @@ public class ToKafkaExporter implements IMetricExporter {
         messageBuffer.deleteFromEnd(1);
 
         // Close JSON objects
-        messageBuffer.writeChar(']');
-        messageBuffer.writeChar('}');
+        messageBuffer.writeAsciiChar(']');
+        messageBuffer.writeAsciiChar('}');
 
         ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, messageKey.array(), messageBuffer.toBytes());
         record.headers().add(header);

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/ToKafkaExporter.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/ToKafkaExporter.java
@@ -98,7 +98,7 @@ public class ToKafkaExporter implements IMetricExporter {
         RecordHeader header = new RecordHeader("type", messageType.getBytes(StandardCharsets.UTF_8));
 
         FixedSizeBuffer messageBuffer = this.bufferThreadLocal.get();
-        messageBuffer.reset();
+        messageBuffer.clear();
         messageBuffer.writeAsciiChar('{');
         if (message.getSchema() != null) {
             try {
@@ -127,7 +127,7 @@ public class ToKafkaExporter implements IMetricExporter {
                                                                             new Header[]{header});
 
             // plus 3 to leave 3 bytes as margin
-            if (currentSize + metricBytes.length + 3 > messageBuffer.limit()) {
+            if (currentSize + metricBytes.length + 3 > messageBuffer.capacity()) {
                 send(header, messageKey, messageBuffer);
 
                 messageBuffer.reset(metricStartOffset);
@@ -165,6 +165,11 @@ public class ToKafkaExporter implements IMetricExporter {
     public void close() {
         this.producer.destroy();
         this.bufferThreadLocal.remove();
+    }
+
+    @Override
+    public String toString() {
+        return "export-metric-to-kafka";
     }
 }
 

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/ToMetricStorageExporter.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/ToMetricStorageExporter.java
@@ -104,6 +104,6 @@ public class ToMetricStorageExporter implements IMetricExporter {
 
     @Override
     public String toString() {
-        return "to-metric-storage";
+        return "export-metric-to-storage";
     }
 }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/input/MetricInputSourceManager.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/input/MetricInputSourceManager.java
@@ -44,29 +44,19 @@ public class MetricInputSourceManager implements SchemaManager.ISchemaChangedLis
     private final Map<String, IMetricInputSource> inputSources = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper;
     private final SchemaManager schemaManager;
-    private final boolean enabled;
     private final Map<String, Class<? extends IMetricInputSource>> subTypes = new HashMap<>();
     private boolean suppressListener;
 
-    public MetricInputSourceManager(boolean enabled,
-                                    SchemaManager schemaManager,
+    public MetricInputSourceManager(SchemaManager schemaManager,
                                     ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
         this.schemaManager = schemaManager;
-        this.enabled = enabled;
-        if (this.enabled) {
-            this.schemaManager.addListener(this);
-        }
+        this.schemaManager.addListener(this);
         this.suppressListener = false;
     }
 
     @Override
     public void start(Class<? extends IMetricInputSource> inputSourceClazz) {
-        if (!enabled) {
-            log.warn("Metric log storage is NOT configured to be enabled by property 'bithon.storage.metric.enabled', the input source [{}] does not take effect.", inputSourceClazz.getSimpleName());
-            return;
-        }
-
         // Find the registered 'type' property
         AnnotatedClass superType = AnnotatedClassResolver.resolveWithoutSuperTypes(this.objectMapper.getSerializationConfig(), IMetricInputSource.class);
         Collection<NamedType> registeredSubtypes = this.objectMapper.getSubtypeResolver()

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/input/MetricInputSourceManagerStub.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/input/MetricInputSourceManagerStub.java
@@ -1,0 +1,31 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.pipeline.metrics.input;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Frank Chen
+ * @date 31/3/24 7:20 pm
+ */
+@Slf4j
+public class MetricInputSourceManagerStub implements IMetricInputSourceManager {
+    @Override
+    public void start(Class<? extends IMetricInputSource> inputSourceClazz) {
+        log.warn("Starting of input source {} failed due to metric store is not enabled", inputSourceClazz.getSimpleName());
+    }
+}

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/exporter/ToTraceStorageExporter.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/exporter/ToTraceStorageExporter.java
@@ -112,6 +112,6 @@ public class ToTraceStorageExporter implements ITraceExporter {
 
     @Override
     public String toString() {
-        return "to-trace-storage";
+        return "export-trace-to-storage";
     }
 }

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/receiver/KafkaTraceReceiver.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/tracing/receiver/KafkaTraceReceiver.java
@@ -32,7 +32,6 @@ import org.slf4j.event.Level;
 import org.springframework.context.ApplicationContext;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,6 @@ import java.util.Map;
 public class KafkaTraceReceiver extends AbstractKafkaConsumer implements ITraceReceiver {
     private static final RateLimitLogger LOG = new RateLimitLogger(log).config(Level.ERROR, 1);
 
-    private static final byte[] JSON_EACH_ROW_FORMAT = "JSONEachRow".getBytes(StandardCharsets.UTF_8);
     private final Map<String, Object> props;
     private ITraceProcessor processor;
 

--- a/server/server-starter/src/main/resources/application-pipeline-to-kafka.yml
+++ b/server/server-starter/src/main/resources/application-pipeline-to-kafka.yml
@@ -1,6 +1,6 @@
 # This configuration demonstrates the pipeline that consumes messages from brpc to Kafka.
-# In large data scale environment, this is the optimal deployment that separates the receivers and data processing.
-# In such deployment, another application that uses the 'pipeline-from-kafka'
+# In a large data scale environment, this is the optimal deployment that separates the receivers and data processing.
+# In such a deployment, another application that uses the 'pipeline-from-kafka'
 # is deployed to consume messages from Kafka and do data processing.
 bithon:
   pipelines:


### PR DESCRIPTION
Fixes #724 
Fixes #646

1. change the format of kafka message from json array to json each row
2. limit the size of spans deserialized
3. limit the size of spans that are wrapped into one kafka message

This leads to increasing of kafka messages but reduced the overhead at the receiver side