### PR TITLE
Use map access syntax for tags search

### DIFF
--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/IDataType.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/IDataType.java
@@ -265,7 +265,102 @@ public enum IDataType {
         public Number scaleTo(Number value, int scale) {
             return null;
         }
-    };
+    },
+
+    OBJECT {
+        @Override
+        public boolean canCastFrom(IDataType dataType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String format(Number value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isGreaterThan(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isGreaterThanOrEqual(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isLessThan(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isLessThanOrEqual(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isEqual(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Number diff(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Number scaleTo(Number value, int scale) {
+            throw new UnsupportedOperationException();
+        }
+    },
+
+    ARRAY {
+        @Override
+        public boolean canCastFrom(IDataType dataType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String format(Number value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isGreaterThan(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isGreaterThanOrEqual(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isLessThan(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isLessThanOrEqual(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isEqual(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Number diff(Number left, Number right) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Number scaleTo(Number value, int scale) {
+            throw new UnsupportedOperationException();
+        }
+    }
+    ;
 
 
     public abstract boolean canCastFrom(IDataType dataType);

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/IDataType.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/IDataType.java
@@ -359,9 +359,7 @@ public enum IDataType {
         public Number scaleTo(Number value, int scale) {
             throw new UnsupportedOperationException();
         }
-    }
-    ;
-
+    };
 
     public abstract boolean canCastFrom(IDataType dataType);
 

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/MapAccessExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/MapAccessExpression.java
@@ -27,11 +27,11 @@ import java.util.Map;
 public class MapAccessExpression implements IExpression {
 
     private IExpression map;
-    private final String prop;
+    private String key;
 
-    public MapAccessExpression(IExpression map, String prop) {
+    public MapAccessExpression(IExpression map, String key) {
         this.map = map;
-        this.prop = prop;
+        this.key = key;
     }
 
     public IExpression getMap() {
@@ -42,13 +42,17 @@ public class MapAccessExpression implements IExpression {
         this.map = map;
     }
 
-    public String getProp() {
-        return prop;
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
     }
 
     @Override
     public IDataType getDataType() {
-        // Not accurate, but suppose it's STRING now.
+        // Not accurate, but suppose it is STRING now.
         return IDataType.STRING;
     }
 
@@ -62,9 +66,9 @@ public class MapAccessExpression implements IExpression {
     public Object evaluate(IEvaluationContext context) {
         Object obj = map.evaluate(context);
         if (obj instanceof Map) {
-            return ((Map) obj).get(this.prop);
+            return ((Map) obj).get(this.key);
         }
-        return ReflectionUtils.getFieldValue(obj, this.prop);
+        return ReflectionUtils.getFieldValue(obj, this.key);
     }
 
     @Override

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
@@ -175,7 +175,7 @@ public class ExpressionSerializer implements IExpressionVisitor {
         expression.getMap().accept(this);
         sb.append('[');
         sb.append('\'');
-        sb.append(expression.getProp());
+        sb.append(expression.getKey());
         sb.append('\'');
         sb.append(']');
         return false;

--- a/server/server-starter/src/main/resources/application-storage-h2.yml
+++ b/server/server-starter/src/main/resources/application-storage-h2.yml
@@ -11,6 +11,10 @@ bithon:
         enabled: true
         ttl: P1D
         cleanPeriod: PT1M
+      indexes:
+        # A demo of how the index works, can be removed in production
+        map:
+          "[http.method]": 1
     metric:
       provider: h2-local
       enabled: true

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/HasTokenFunctionOptimizer.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/HasTokenFunctionOptimizer.java
@@ -31,18 +31,6 @@ import java.util.List;
  * @date 02/05/24 22:11pm
  */
 public class HasTokenFunctionOptimizer extends ExpressionOptimizer.AbstractOptimizer {
-    @Override
-    public IExpression visit(LogicalExpression expression) {
-        expression.getOperands().replaceAll(iExpression -> iExpression.accept(this));
-        return expression;
-    }
-
-    @Override
-    public IExpression visit(ConditionalExpression expression) {
-        expression.setLeft(expression.getLeft().accept(this));
-        expression.setRight(expression.getRight().accept(this));
-        return expression;
-    }
 
     @Override
     public IExpression visit(FunctionExpression expression) {

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
@@ -17,7 +17,6 @@
 package org.bithon.server.storage.jdbc.h2;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IExpression;
@@ -30,6 +29,7 @@ import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.storage.datasource.builtin.Functions;
 import org.bithon.server.storage.datasource.query.ast.SimpleAggregateExpressions;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
 
 import java.util.Arrays;
 
@@ -102,16 +102,7 @@ public class H2SqlDialect implements ISqlDialect {
                     return super.visit(expression);
                 }
 
-                MapAccessExpression mapAccessExpression = (MapAccessExpression) expression.getLeft();
-                String mapName = ((IdentifierExpression) mapAccessExpression.getMap()).getIdentifier();
-                String key = mapAccessExpression.getKey();
-                String value = ((LiteralExpression) expression.getRight()).getValue().toString();
-
-                if (expression instanceof ComparisonExpression.EQ) {
-                    return new ConditionalExpression.Like(new IdentifierExpression(mapName),
-                                                          LiteralExpression.create("%\"" + key + "\":\"" + value + "\"%"));
-                }
-                return super.visit(expression);
+                return MapAccessExpressionTransformer.transform(expression);
             }
 
             @Override

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
@@ -103,9 +103,9 @@ public class H2SqlDialect implements ISqlDialect {
                 }
 
                 MapAccessExpression mapAccessExpression = (MapAccessExpression) expression.getLeft();
-                String mapName = ((IdentifierExpression)mapAccessExpression.getMap()).getIdentifier();
+                String mapName = ((IdentifierExpression) mapAccessExpression.getMap()).getIdentifier();
                 String key = mapAccessExpression.getKey();
-                String value = ((LiteralExpression)expression.getRight()).getValue().toString();
+                String value = ((LiteralExpression) expression.getRight()).getValue().toString();
 
                 if (expression instanceof ComparisonExpression.EQ) {
                     return new ConditionalExpression.Like(new IdentifierExpression(mapName),

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
@@ -17,7 +17,6 @@
 package org.bithon.server.storage.jdbc.mysql;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IExpression;
@@ -30,6 +29,7 @@ import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.storage.datasource.builtin.Functions;
 import org.bithon.server.storage.datasource.query.ast.SimpleAggregateExpressions;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
 
 import java.util.Arrays;
 
@@ -86,7 +86,7 @@ public class MySQLSqlDialect implements ISqlDialect {
     @Override
     public boolean useWindowFunctionAsAggregator(String aggregator) {
         return SimpleAggregateExpressions.FirstAggregateExpression.TYPE.equals(aggregator)
-            || SimpleAggregateExpressions.LastAggregateExpression.TYPE.equals(aggregator);
+               || SimpleAggregateExpressions.LastAggregateExpression.TYPE.equals(aggregator);
     }
 
     @Override
@@ -102,16 +102,7 @@ public class MySQLSqlDialect implements ISqlDialect {
                     return super.visit(expression);
                 }
 
-                MapAccessExpression mapAccessExpression = (MapAccessExpression) expression.getLeft();
-                String mapName = ((IdentifierExpression) mapAccessExpression.getMap()).getIdentifier();
-                String key = mapAccessExpression.getKey();
-                String value = ((LiteralExpression) expression.getRight()).getValue().toString();
-
-                if (expression instanceof ComparisonExpression.EQ) {
-                    return new ConditionalExpression.Like(new IdentifierExpression(mapName),
-                                                          LiteralExpression.create("%\"" + key + "\":\"" + value + "\"%"));
-                }
-                return super.visit(expression);
+                return MapAccessExpressionTransformer.transform(expression);
             }
 
             @Override

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
@@ -17,11 +17,13 @@
 package org.bithon.server.storage.jdbc.mysql;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
+import org.bithon.component.commons.expression.MapAccessExpression;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
@@ -90,6 +92,28 @@ public class MySQLSqlDialect implements ISqlDialect {
     @Override
     public IExpression transform(IExpression expression) {
         return expression.accept(new ExpressionOptimizer.AbstractOptimizer() {
+            /**
+             * MYSQL does not support Map, the JSON formatted string is stored in the column.
+             * So we turn the MapAccessExpression into a LIKE expression
+             */
+            @Override
+            public IExpression visit(ConditionalExpression expression) {
+                if (!(expression.getLeft() instanceof MapAccessExpression)) {
+                    return super.visit(expression);
+                }
+
+                MapAccessExpression mapAccessExpression = (MapAccessExpression) expression.getLeft();
+                String mapName = ((IdentifierExpression) mapAccessExpression.getMap()).getIdentifier();
+                String key = mapAccessExpression.getKey();
+                String value = ((LiteralExpression) expression.getRight()).getValue().toString();
+
+                if (expression instanceof ComparisonExpression.EQ) {
+                    return new ConditionalExpression.Like(new IdentifierExpression(mapName),
+                                                          LiteralExpression.create("%\"" + key + "\":\"" + value + "\"%"));
+                }
+                return super.visit(expression);
+            }
+
             @Override
             public IExpression visit(FunctionExpression expression) {
                 if ("startsWith".equals(expression.getName())) {

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/MapAccessExpressionTransformer.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/MapAccessExpressionTransformer.java
@@ -1,0 +1,56 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.storage.jdbc.common.dialect;
+
+import org.bithon.component.commons.expression.ComparisonExpression;
+import org.bithon.component.commons.expression.ConditionalExpression;
+import org.bithon.component.commons.expression.IExpression;
+import org.bithon.component.commons.expression.IdentifierExpression;
+import org.bithon.component.commons.expression.LiteralExpression;
+import org.bithon.component.commons.expression.MapAccessExpression;
+import org.bithon.component.commons.utils.StringUtils;
+
+/**
+ * @author frank.chen021@outlook.com
+ * @date 2024/5/9 21:54
+ */
+public class MapAccessExpressionTransformer {
+
+    /**
+     * This transformer turns the map access expression into a LIKE comparator for those stores Map object as plain text.
+     * It's used by H2, MySQL dialects
+     */
+    public static IExpression transform(ConditionalExpression expression) {
+        MapAccessExpression mapAccessExpression = (MapAccessExpression) expression.getLeft();
+        if (!(mapAccessExpression.getMap() instanceof IdentifierExpression)) {
+            throw new UnsupportedOperationException(StringUtils.format("Map access expression [%s] only allows on identifier", mapAccessExpression.serializeToText()));
+        }
+
+        String mapName = ((IdentifierExpression) mapAccessExpression.getMap()).getIdentifier();
+        String key = mapAccessExpression.getKey();
+        String value = ((LiteralExpression) expression.getRight()).getValue().toString();
+
+        if (!(expression instanceof ComparisonExpression.EQ)) {
+            // Since we store JSON formatted string in H2, it's hard to implement other operators except EQ
+            // And because these DBs now are only for test, we simplify disallow other operators
+            throw new UnsupportedOperationException(StringUtils.format("H2 does not support operators other than EQ on column [%s]", mapName));
+        }
+
+        return new ConditionalExpression.Like(new IdentifierExpression(mapName),
+                                              LiteralExpression.create("%\"" + key + "\":\"" + value + "\"%"));
+    }
+}

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
@@ -133,12 +133,6 @@ public class TraceJdbcReader implements ITraceReader {
                                                           filter));
         }
 
-        if (CollectionUtils.isNotEmpty(nonIndexedTagFilters)) {
-            listQuery = listQuery.and(nonIndexedTagFilters.stream()
-                                                          .map(this::getTagPredicate)
-                                                          .collect(Collectors.joining(" AND ")));
-        }
-
         // Build the tag query
         if (CollectionUtils.isNotEmpty(indexedTagFilter)) {
             SelectConditionStep<Record1<String>> indexedTagQuery = new IndexedTagQueryBuilder(this.sqlDialect)
@@ -208,13 +202,6 @@ public class TraceJdbcReader implements ITraceReader {
                                                   filter));
         }
 
-        if (CollectionUtils.isNotEmpty(nonIndexedTagFilters)) {
-            sqlBuilder.append(" AND ");
-            sqlBuilder.append(nonIndexedTagFilters.stream()
-                                                  .map(this::getTagPredicate)
-                                                  .collect(Collectors.joining(" AND ")));
-        }
-
         // Build the indexed tag sub query
         if (CollectionUtils.isNotEmpty(indexedTagFilter)) {
             SelectConditionStep<Record1<String>> indexedTagQuery = new IndexedTagQueryBuilder(this.sqlDialect)
@@ -260,12 +247,6 @@ public class TraceJdbcReader implements ITraceReader {
             countQuery = countQuery.and(Expression2Sql.from((isOnSummaryTable ? Tables.BITHON_TRACE_SPAN_SUMMARY : Tables.BITHON_TRACE_SPAN).getName(),
                                                             sqlDialect,
                                                             filter));
-        }
-
-        if (CollectionUtils.isNotEmpty(nonIndexedTagFilters)) {
-            countQuery = countQuery.and(nonIndexedTagFilters.stream()
-                                                            .map(this::getTagPredicate)
-                                                            .collect(Collectors.joining(" AND ")));
         }
 
         // Build the indexed tag query

--- a/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
@@ -32,6 +32,7 @@ import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.ExpressionList;
 import org.bithon.component.commons.expression.FunctionExpression;
+import org.bithon.component.commons.expression.IDataType;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
@@ -43,6 +44,7 @@ import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.component.commons.expression.validation.ExpressionValidator;
 import org.bithon.component.commons.expression.validation.IIdentifier;
 import org.bithon.component.commons.expression.validation.IIdentifierProvider;
+import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.datasource.ast.ExpressionBaseVisitor;
 import org.bithon.server.datasource.ast.ExpressionLexer;
 import org.bithon.server.datasource.ast.ExpressionParser;
@@ -361,12 +363,22 @@ public class ExpressionASTBuilder {
 
         @Override
         public IExpression visitArrayAccessExpression(ExpressionParser.ArrayAccessExpressionContext ctx) {
-            return new ArrayAccessExpression(ctx.expression().accept(this), Integer.parseInt(ctx.INTEGER_LITERAL().getText()));
+            IExpression expr = ctx.expression().accept(this);
+            if (!IDataType.ARRAY.equals(expr.getDataType())) {
+                throw new InvalidExpressionException(StringUtils.format("Expression [%s] is not type of array, array access is not allowed.", ctx.expression().getText()));
+            }
+
+            return new ArrayAccessExpression(expr, Integer.parseInt(ctx.INTEGER_LITERAL().getText()));
         }
 
         @Override
         public IExpression visitMapAccessExpression(ExpressionParser.MapAccessExpressionContext ctx) {
-            return new MapAccessExpression(ctx.expression().accept(this), getUnQuotedString(ctx.STRING_LITERAL().getSymbol()));
+            IExpression expr = ctx.expression().accept(this);
+            if (!IDataType.OBJECT.equals(expr.getDataType())) {
+                throw new InvalidExpressionException(StringUtils.format("Expression [%s] is not type of object, object access is not allowed.", ctx.expression().getText()));
+            }
+
+            return new MapAccessExpression(expr, getUnQuotedString(ctx.STRING_LITERAL().getSymbol()));
         }
 
         @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
@@ -374,8 +374,10 @@ public class ExpressionASTBuilder {
         @Override
         public IExpression visitMapAccessExpression(ExpressionParser.MapAccessExpressionContext ctx) {
             IExpression expr = ctx.expression().accept(this);
-            if (!IDataType.OBJECT.equals(expr.getDataType())) {
-                throw new InvalidExpressionException(StringUtils.format("Expression [%s] is not type of object, object access is not allowed.", ctx.expression().getText()));
+            if (expr.getDataType() != null && !IDataType.OBJECT.equals(expr.getDataType())) {
+                throw new InvalidExpressionException(StringUtils.format("Expression [%s] is type of [%s], but required OBJECT to perform map access.",
+                                                                        ctx.expression().getText(),
+                                                                        expr.getDataType().name()));
             }
 
             return new MapAccessExpression(expr, getUnQuotedString(ctx.STRING_LITERAL().getSymbol()));

--- a/server/storage/src/main/java/org/bithon/server/storage/common/expression/IdentifierProvider.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/common/expression/IdentifierProvider.java
@@ -37,26 +37,6 @@ class IdentifierProvider implements IIdentifierProvider {
     public IIdentifier getIdentifier(String identifier) {
         IColumn column = schema.getColumnByName(identifier);
         if (column == null) {
-            // A special and ugly check.
-            // For indexed tags filter, when querying the dimensions, we need to convert its alias to its field name.
-            // However, when searching spans with tag filters, the schema here does not contain the tags.
-            // We need to ignore this case.
-            // The ignored tags will be processed later in the trace module.
-            /*
-            if (identifier.startsWith("tags.")) {
-                return new IIdentifier() {
-                    @Override
-                    public String getName() {
-                        return identifier;
-                    }
-
-                    @Override
-                    public IDataType getDataType() {
-                        return IDataType.STRING;
-                    }
-                };
-            }*/
-
             throw new ExpressionValidationException("Identifier [%s] not defined in schema [%s]",
                                                     identifier,
                                                     schema.getName());

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ObjectColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ObjectColumn.java
@@ -1,0 +1,47 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.storage.datasource.column;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.bithon.component.commons.expression.IDataType;
+import org.bithon.server.storage.datasource.query.ast.ResultColumn;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * @author frank.chen021@outlook.com
+ * @date 2024/5/9 15:38
+ */
+public class ObjectColumn extends AbstractColumn {
+
+    @JsonCreator
+    public ObjectColumn(@JsonProperty("name") @NotNull String name,
+                        @JsonProperty("alias") @Nullable String alias) {
+        super(name, alias);
+    }
+
+    @Override
+    public IDataType getDataType() {
+        return IDataType.OBJECT;
+    }
+
+    public ResultColumn getResultColumn() {
+        return new ResultColumn(getName());
+    }
+}

--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/ITraceReader.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/ITraceReader.java
@@ -35,7 +35,6 @@ public interface ITraceReader extends IDataSourceReader {
     List<TraceSpan> getTraceByTraceId(String traceId, TimeSpan start, TimeSpan end);
 
     List<TraceSpan> getTraceList(IExpression filter,
-                                 List<IExpression> nonIndexedTagFilters,
                                  List<IExpression> indexedTagFilters,
                                  Timestamp start,
                                  Timestamp end,
@@ -45,14 +44,12 @@ public interface ITraceReader extends IDataSourceReader {
                                  int pageSize);
 
     List<Map<String, Object>> getTraceDistribution(IExpression filter,
-                                                   List<IExpression> nonIndexedTagFilters,
                                                    List<IExpression> indexedTagFilters,
                                                    Timestamp start,
                                                    Timestamp end,
                                                    int interval);
 
     int getTraceListSize(IExpression filter,
-                         List<IExpression> nonIndexedTagFilters,
                          List<IExpression> indexedTagFilters,
                          Timestamp start,
                          Timestamp end);

--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceTableSchema.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceTableSchema.java
@@ -22,6 +22,7 @@ import org.bithon.server.commons.time.Period;
 import org.bithon.server.storage.datasource.ISchema;
 import org.bithon.server.storage.datasource.TimestampSpec;
 import org.bithon.server.storage.datasource.column.IColumn;
+import org.bithon.server.storage.datasource.column.ObjectColumn;
 import org.bithon.server.storage.datasource.column.StringColumn;
 import org.bithon.server.storage.datasource.column.aggregatable.count.AggregateCountColumn;
 import org.bithon.server.storage.datasource.column.aggregatable.sum.AggregateLongSumColumn;
@@ -135,6 +136,7 @@ public class TraceTableSchema implements ISchema {
                                                   new StringColumn("normalizedUrl",
                                                                    "url"),
                                                   new StringColumn("kind", "kind"),
+                                                  new ObjectColumn("attributes", "tags"),
 
                                                   AggregateCountColumn.INSTANCE,
                                                   // microsecond
@@ -147,7 +149,7 @@ public class TraceTableSchema implements ISchema {
         List<IColumn> dimensionSpecs = new ArrayList<>();
         if (tagIndexConfig != null) {
             for (Map.Entry<String, Integer> entry : tagIndexConfig.getMap().entrySet()) {
-                String tagName = "tags." + entry.getKey();
+                String tagName = entry.getKey();
                 Integer indexPos = entry.getValue();
                 dimensionSpecs.add(new StringColumn("f" + indexPos,
                                                     // Alias

--- a/server/web-app/src/main/resources/dashboard/http-outgoing-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/http-outgoing-metrics.json
@@ -64,8 +64,8 @@
         },
         "tracing": {
           "mappings": {
-            "targetHostPort": "tags.net.peer",
-            "method": "tags.http.method",
+            "targetHostPort": "tags['net.peer']",
+            "method": "tags['http.method']",
             "path": "url",
             "statusCode": "status"
           },
@@ -122,8 +122,8 @@
         },
         "tracing": {
           "mappings": {
-            "targetHostPort": "tags.net.peer",
-            "method": "tags.http.method",
+            "targetHostPort": "tags['net.peer']",
+            "method": "tags['http.method']",
             "path": "url",
             "statusCode": "status"
           },
@@ -175,8 +175,8 @@
         },
         "tracing": {
           "mappings": {
-            "targetHostPort": "tags.net.peer",
-            "method": "tags.http.method",
+            "targetHostPort": "tags['net.peer']",
+            "method": "tags['http.method']",
             "path": "url",
             "statusCode": "status"
           },

--- a/server/web-app/src/main/resources/dashboard/kafka-consumer-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/kafka-consumer-metrics.json
@@ -84,9 +84,9 @@
         },
         "tracing": {
           "mappings": {
-            "cluster": "tags.net.peer",
-            "topic": "tags.messaging.kafka.topic",
-            "groupId": "tags.messaging.kafka.consumer.group"
+            "cluster": "tags['net.peer']",
+            "topic": "tags['messaging.kafka.topic']",
+            "groupId": "tags['messaging.kafka.consumer.group']"
           },
           "filter": "name= 'kafka' AND kind = 'CONSUMER'"
         }
@@ -157,9 +157,9 @@
         },
         "tracing": {
           "mappings": {
-            "cluster": "tags.net.peer",
-            "topic": "tags.messaging.kafka.topic",
-            "groupId": "tags.messaging.kafka.consumer.group"
+            "cluster": "tags['net.peer']",
+            "topic": "tags['messaging.kafka.topic']",
+            "groupId": "tags['messaging.kafka.consumer.group']"
           },
           "filter": "name= 'kafka' AND kind = 'CONSUMER'"
         }

--- a/server/web-app/src/main/resources/dashboard/kafka-producer-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/kafka-producer-metrics.json
@@ -53,9 +53,9 @@
         },
         "tracing": {
           "mappings": {
-            "cluster": "tags.net.peer",
-            "topic": "tags.messaging.kafka.topic",
-            "clientId": "tags.messaging.kafka.client_id"
+            "cluster": "tags['net.peer']",
+            "topic": "tags['messaging.kafka.topic']",
+            "clientId": "tags['messaging.kafka.client_id']"
           },
           "filter": "name= 'kafka' AND kind = 'PRODUCER'"
         }

--- a/server/web-app/src/main/resources/dashboard/redis-metrics.json
+++ b/server/web-app/src/main/resources/dashboard/redis-metrics.json
@@ -59,10 +59,10 @@
         },
         "tracing": {
           "mappings": {
-            "uri": "tags.net.peer",
-            "command": "tags.db.operation"
+            "uri": "tags['net.peer']",
+            "command": "tags['db.operation']"
           },
-          "filter": "kind = 'CLIENT' AND tags.db.system='redis'"
+          "filter": "kind = 'CLIENT' AND tags['db.system']='redis'"
         }
       }
     },

--- a/server/web-app/src/main/resources/static/js/page/trace/page.js
+++ b/server/web-app/src/main/resources/static/js/page/trace/page.js
@@ -55,6 +55,7 @@ class TracePage {
             .childOf(parent)
             .registerIntervalChangedListener((selectedModel) => {
                 this.mInterval = this.vIntervalSelector.getInterval();
+                this.#updatePageURL(this.filterExpression);
                 this.#refreshPage();
             });
         this.mInterval = this.vIntervalSelector.getInterval();
@@ -84,14 +85,14 @@ class TracePage {
         });
 
         // If the tag filters are not selectable, add them to the filterExpression
-        const tagFilters = {};
+        const selectableTags = {};
         if (this.vTagFilter !== null) {
             $.each(this.vTagFilter.getFilterName(), (index, name) => {
-                tagFilters["tags." + name] = true;
+                selectableTags["tags." + name] = true;
             });
         }
         $.each(options.queryParams, (name, value) => {
-            if (name.startsWith("tags.") && tagFilters[name] === undefined) {
+            if (name.startsWith("tags.") && selectableTags[name] === undefined) {
                 if (this.filterExpression.length > 0) {
                     this.filterExpression += ' AND ';
                 }
@@ -102,8 +103,13 @@ class TracePage {
         $("#filter-input")
             .val(this.filterExpression)
             .on('keydown', (event) => {
-                this.filterExpression = event.target.value;
+                const newFilterExpression = event.target.value;
                 if (event.keyCode === 13) {
+                    if (newFilterExpression !== this.filterExpression) {
+                        this.#updatePageURL(newFilterExpression);
+                    }
+
+                    this.filterExpression = newFilterExpression;
                     this.#refreshPage();
                 }
             })
@@ -326,5 +332,12 @@ class TracePage {
         }
 
         this.vIntervalSelector.setInterval(startTimestamp, endTimestamp);
+    }
+
+    #updatePageURL(filterExpression){
+        let url = window.location.pathname + '?';
+        url += `interval=${this.mInterval.id}&`;
+        url += `filter=${encodeURIComponent(filterExpression)}`;
+        window.history.pushState('updated' /*state*/, '', url);
     }
 }

--- a/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
@@ -299,10 +299,6 @@ public class TraceService {
                 }
                 String mapColumnName = ((IdentifierExpression) mapContainerExpression).getIdentifier();
 
-                if (!(expression instanceof ComparisonExpression.EQ)) {
-                    throw new UnsupportedOperationException(StringUtils.format("Only EQ operator is supported on map column [%s].", mapColumnName));
-                }
-
                 IColumn mapColumn = this.summaryTableSchema.getColumnByName(mapColumnName);
                 if (!(mapColumn instanceof ObjectColumn)) {
                     throw new HttpMappableException(HttpStatus.BAD_REQUEST.value(),

--- a/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/tracing/service/TraceService.java
@@ -30,7 +30,6 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.MacroExpression;
 import org.bithon.component.commons.expression.MapAccessExpression;
-import org.bithon.component.commons.expression.validation.ExpressionValidationException;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.storage.datasource.ISchema;
@@ -146,7 +145,6 @@ public class TraceService {
         splitter.split(FilterExpressionToFilters.toExpression(this.summaryTableSchema, filterExpression, filters));
 
         return traceReader.getTraceListSize(splitter.expression,
-                                            splitter.nonIndexedTagFilters,
                                             splitter.indexedTagFilters,
                                             start,
                                             end);
@@ -164,7 +162,6 @@ public class TraceService {
         splitter.split(FilterExpressionToFilters.toExpression(this.summaryTableSchema, filterExpression, filters));
 
         return traceReader.getTraceList(splitter.expression,
-                                        splitter.nonIndexedTagFilters,
                                         splitter.indexedTagFilters,
                                         start,
                                         end,
@@ -183,7 +180,6 @@ public class TraceService {
 
         int interval = TimeBucket.calculate(start.getMilliseconds(), end.getMilliseconds(), bucketCount).getLength();
         List<Map<String, Object>> dataPoints = traceReader.getTraceDistribution(splitter.expression,
-                                                                                splitter.nonIndexedTagFilters,
                                                                                 splitter.indexedTagFilters,
                                                                                 start.toTimestamp(),
                                                                                 end.toTimestamp(),
@@ -201,7 +197,6 @@ public class TraceService {
     static class FilterSplitter {
         private IExpression expression;
         private List<IExpression> indexedTagFilters;
-        private List<IExpression> nonIndexedTagFilters;
         private final ISchema summaryTableSchema;
         private final ISchema indexTableSchema;
 
@@ -227,7 +222,6 @@ public class TraceService {
             TagFilterExtractor extractor = new TagFilterExtractor(this.summaryTableSchema, this.indexTableSchema);
             expression.accept(extractor);
             this.indexedTagFilters = extractor.indexedTagFilter;
-            this.nonIndexedTagFilters = extractor.nonIndexedTagFilter;
             this.expression = expression;
         }
     }
@@ -239,12 +233,10 @@ public class TraceService {
         private boolean isFilterOnIndexedTag = false;
 
         private final List<IExpression> indexedTagFilter;
-        private final List<IExpression> nonIndexedTagFilter;
 
         public TagFilterExtractor(ISchema summaryTableSchema,
                                   ISchema indexTableSchema) {
             this.indexedTagFilter = new ArrayList<>();
-            this.nonIndexedTagFilter = new ArrayList<>();
             this.summaryTableSchema = summaryTableSchema;
             this.indexTableSchema = indexTableSchema;
         }
@@ -300,7 +292,6 @@ public class TraceService {
             if (column != null) {
                 // Given identifier in the expression might be alias, replace it with the actual name
                 mapAccessExpression.setKey(column.getName());
-                isFilterOnIndexedTag = true;
             } else {
                 isFilterOnIndexedTag = false;
             }


### PR DESCRIPTION
Fixes #770
1. use map access expression for 'tags'
2. validate map access expression
3. uses new expression syntax at the FE side

This also introduces incompatibility for old schema that actually has Map datatype used in the underlying storage. These must be updated to use the new IDataType.OBJECT