### PR TITLE
Change default JDK in docker image to JDK 21

### DIFF
--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-ARG JDK_VERSION=17
+ARG JDK_VERSION=21
 
 FROM maven:3.9.6-eclipse-temurin-${JDK_VERSION} as builder
 


### PR DESCRIPTION
![image](https://github.com/FrankChen021/bithon/assets/6525742/0a768bd6-a667-48cc-9135-8cb8e9c6c602)
![image](https://github.com/FrankChen021/bithon/assets/6525742/cbedd44e-cfe2-49b3-af7e-2cd9d39af219)

heap can utilize up to 90% of max heap 
jdk21
![image](https://github.com/FrankChen021/bithon/assets/6525742/9a2f1c69-a675-40cb-b690-dc9dc13bd23f)

while jdk8 utilizes up to 75% by default of max heap configured
![image](https://github.com/FrankChen021/bithon/assets/6525742/66976b41-87c8-43fb-9329-5f2ea30f1516)

