### PR TITLE
Support kafka consumer 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If the target application runs under JDK 11 and above, the following arguments s
 | JDK - HTTP Client      | 1.8         |             | [&check;](doc/metrics/http-outgoing/README.md) | &check; |
 | Alibaba Druid          | 1.0.28      |             | &check;                                        |         |
 | Apache Druid           | 0.16        | 24.0        |                                                | &check; |
-| Apache Kafka           | 0.10        |             | &check;                                        | &check; |
+| Apache Kafka(1)        | 0.10        |             | &check;                                        | &check; |
 | Apache OZone           | 1.3.0       |             |                                                | &check; |
 | Eclipse Glassfish      | 2.34        |             |                                                | &check; |
 | GRPC                   | 1.57.0      |             | &check;                                        |         |
@@ -176,7 +176,7 @@ If the target application runs under JDK 11 and above, the following arguments s
 | MySQL                  | 5.x         | 8.x         | &check;                                        |         |
 | Quartz                 | 2.x         |             | &check;                                        | &check; |
 | Redis - Jedis          | 2.9         | 5.x         | &check;                                        | &check; |
-| Redis - Lettuce(1)     | 5.1.2       | 6.x         | &check;                                        | &check; |
+| Redis - Lettuce(2)     | 5.1.2       | 6.x         | &check;                                        | &check; |
 | Redis - Redisson       | 3.19.0      |             | &check;                                        | &check; |
 | Spring Boot            | 1.5         | 3.0+        |                                                | &check; |
 | Spring Bean            | 4.3.12      |             |                                                | &check; |
@@ -191,8 +191,9 @@ If the target application runs under JDK 11 and above, the following arguments s
 | xxl-job                | 2.3.0       |             |                                                | &check; |
 
 ## Restrictions
-1. For Lettuce, the tracing support is only available when it's used with Spring Data Redis API.
-2. For Redisson, metrics and tracing only work when connections are successfully established between the client and redis servers.
+1. For Apache Kafka clients 3.7, the consumer metrics only works when the `group.protocol` is configured as `classic` which is the default configuration of the consumer client. 
+2. For Lettuce, the tracing support is only available when it's used with Spring Data Redis API.
+
 
 
 

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/KafkaPlugin.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/KafkaPlugin.java
@@ -41,20 +41,35 @@ public class KafkaPlugin implements IPlugin {
                          "org.apache.kafka.common.serialization.Deserializer<K>",
                          "org.apache.kafka.common.serialization.Deserializer<V>")
                 .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.KafkaConsumer$Ctor")
-
-                // tracing
                 .onMethod("poll")
                 .andVisibility(Visibility.PRIVATE)
                 .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.KafkaConsumer$Poll")
                 .build(),
 
-            forClass("org.apache.kafka.clients.consumer.internals.Fetcher")
-                // Since 0.11
-                .onMethod("parseRecord")
-                .andArgs("org.apache.kafka.common.TopicPartition",
-                         "org.apache.kafka.common.record.RecordBatch",
-                         "org.apache.kafka.common.record.Record")
-                .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.Fetcher$ParseRecord")
+            // Metric
+            forClass("org.apache.kafka.clients.consumer.internals.Fetcher$FetchResponseMetricAggregator")
+                .onConstructor()
+                .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.FetchResponseMetricAggregator$Ctor")
+                .onMethod("record")
+                .andArgsSize(3)
+                .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.FetchResponseMetricAggregator$Record")
+                .build(),
+
+            // 3.7
+            forClass("org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer")
+                .onMethod("poll")
+                .andVisibility(Visibility.PRIVATE)
+                .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.KafkaConsumer$Poll")
+                .build(),
+
+            // 3.7
+            // The Fetcher$FetchResponseMetricAggregator in previous release is renamed to FetchMetricsAggregator
+            forClass("org.apache.kafka.clients.consumer.internals.FetchMetricsAggregator")
+                .onConstructor()
+                .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.FetchMetricsAggregator$Ctor")
+                .onMethod("record")
+                .andArgsSize(3)
+                .interceptedBy("org.bithon.agent.plugin.apache.kafka.consumer.interceptor.FetchMetricsAggregator$Record")
                 .build(),
 
             // Spring Kafka, can move to an independent plugin

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/KafkaPluginContext.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/KafkaPluginContext.java
@@ -18,8 +18,6 @@ package org.bithon.agent.plugin.apache.kafka;
 
 import org.bithon.agent.observability.context.InterceptorContext;
 
-import java.util.function.Supplier;
-
 /**
  * @author frank.chen021@outlook.com
  * @date 2022/12/3 15:53
@@ -31,22 +29,33 @@ public class KafkaPluginContext {
      */
     public String groupId = "";
     public String clientId;
-    public Supplier<String> clusterSupplier;
+    public String broker;
 
     public String uri;
     public String topic;
 
     public static String getCurrentDestination() {
-        String dest = (String) InterceptorContext.get("kafka-ctx-destination");
+        String dest = (String) InterceptorContext.get("plugin.kafka.destination");
         return dest == null ? "" : dest;
     }
 
     public static void setCurrentDestination(String destination) {
-        InterceptorContext.set("kafka-ct-destination", destination);
+        InterceptorContext.set("plugin.kafka.destination", destination);
     }
 
     public static void resetCurrentDestination() {
-        InterceptorContext.remove("kafka-ctx-destination");
+        InterceptorContext.remove("plugin.kafka.destination");
     }
 
+    public static KafkaPluginContext getCurrent() {
+        return (KafkaPluginContext) InterceptorContext.get("plugin.kafka.context");
+    }
+
+    public static void setCurrent(KafkaPluginContext context) {
+        InterceptorContext.set("plugin.kafka.context", context);
+    }
+
+    public static void resetCurrent() {
+        InterceptorContext.remove("plugin.kafka.context");
+    }
 }

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/admin/interceptor/AdminClient$Create.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/admin/interceptor/AdminClient$Create.java
@@ -44,14 +44,13 @@ public class AdminClient$Create extends AfterInterceptor {
 
         AdminClientConfig clientProperties = new AdminClientConfig(aopContext.getArgAs(0));
         List<String> bootstrapServers = clientProperties.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
-        String boostrapServer = bootstrapServers.stream()
-                                                .sorted()
-                                                .findFirst()
-                                                .get();
 
         KafkaPluginContext ctx = new KafkaPluginContext();
         ctx.clientId = (String) ReflectionUtils.getFieldValue(aopContext.getReturning(), "clientId");
-        ctx.clusterSupplier = () -> boostrapServer;
+        ctx.broker = bootstrapServers.stream()
+                                     .sorted()
+                                     .findFirst()
+                                     .get();
 
         IBithonObject bithonObject = aopContext.getReturningAs();
         bithonObject.setInjectedObject(ctx);

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/admin/interceptor/KafkaAdminClient$All.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/admin/interceptor/KafkaAdminClient$All.java
@@ -45,7 +45,7 @@ public class KafkaAdminClient$All extends AroundInterceptor {
         aopContext.setSpan(span.method(aopContext.getTargetClass(), aopContext.getMethod())
                                .kind(SpanKind.CLIENT)
                                .tag(Tags.Messaging.SYSTEM, "kafka")
-                               .tag(Tags.Net.PEER, pluginContext.clusterSupplier.get())
+                               .tag(Tags.Net.PEER, pluginContext.broker)
                                .tag(Tags.Messaging.KAFKA_CLIENT_ID, pluginContext.clientId)
                                .start());
 

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Ctor.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Ctor.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.apache.kafka.consumer.interceptor;
+
+import org.bithon.agent.instrumentation.aop.IBithonObject;
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
+import org.bithon.agent.observability.context.InterceptorContext;
+import org.bithon.agent.plugin.apache.kafka.KafkaPluginContext;
+
+/**
+ * 3.7
+ *
+ * @author frank.chen021@outlook.com
+ * @date 6/7/24 11:01 pm
+ */
+public class FetchMetricsAggregator$Ctor extends AfterInterceptor {
+    @Override
+    public void after(AopContext aopContext) throws Exception {
+        KafkaPluginContext kafkaPluginContext = (KafkaPluginContext) InterceptorContext.get("kafka.consumer.context");
+        IBithonObject bithonObject = aopContext.getTargetAs();
+        bithonObject.setInjectedObject(kafkaPluginContext);
+    }
+}

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Ctor.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Ctor.java
@@ -19,7 +19,6 @@ package org.bithon.agent.plugin.apache.kafka.consumer.interceptor;
 import org.bithon.agent.instrumentation.aop.IBithonObject;
 import org.bithon.agent.instrumentation.aop.context.AopContext;
 import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
-import org.bithon.agent.observability.context.InterceptorContext;
 import org.bithon.agent.plugin.apache.kafka.KafkaPluginContext;
 
 /**
@@ -31,8 +30,7 @@ import org.bithon.agent.plugin.apache.kafka.KafkaPluginContext;
 public class FetchMetricsAggregator$Ctor extends AfterInterceptor {
     @Override
     public void after(AopContext aopContext) throws Exception {
-        KafkaPluginContext kafkaPluginContext = (KafkaPluginContext) InterceptorContext.get("kafka.consumer.context");
         IBithonObject bithonObject = aopContext.getTargetAs();
-        bithonObject.setInjectedObject(kafkaPluginContext);
+        bithonObject.setInjectedObject(KafkaPluginContext.getCurrent());
     }
 }

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Record.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Record.java
@@ -1,0 +1,58 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.apache.kafka.consumer.interceptor;
+
+import org.apache.kafka.common.TopicPartition;
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
+import org.bithon.agent.observability.metric.collector.MetricRegistryFactory;
+import org.bithon.agent.plugin.apache.kafka.KafkaPluginContext;
+import org.bithon.agent.plugin.apache.kafka.consumer.metrics.ConsumerMetricRegistry;
+import org.bithon.agent.plugin.apache.kafka.consumer.metrics.ConsumerMetrics;
+
+/**
+ * {@link FetchMetricsAggregator#Record(TopicPartition partition, int bytes, int records)}
+ * @author frank.chen021@outlook.com
+ * @date 6/7/24 11:01 pm
+ */
+public class FetchMetricsAggregator$Record extends AfterInterceptor {
+
+    private final ConsumerMetricRegistry metricRegistry = MetricRegistryFactory.getOrCreateRegistry("kafka-consumer-metrics", ConsumerMetricRegistry::new);
+
+    @Override
+    public void after(AopContext aopContext) throws Exception {
+        if (aopContext.hasException()) {
+            return;
+        }
+        KafkaPluginContext kafkaPluginContext = aopContext.getInjectedOnTargetAs();
+        if (kafkaPluginContext == null) {
+            return;
+        }
+
+        TopicPartition topicPartition = aopContext.getArgAs(0);
+        int bytes = aopContext.getArgAs(1);
+        int records = aopContext.getArgAs(2);
+
+        ConsumerMetrics metrics = metricRegistry.getOrCreateMetrics(kafkaPluginContext.clusterSupplier.get(),
+                                                                    kafkaPluginContext.groupId,
+                                                                    kafkaPluginContext.clientId,
+                                                                    topicPartition.topic(),
+                                                                    String.valueOf(topicPartition.partition()));
+        metrics.consumedBytes.update(bytes);
+        metrics.consumedRecords.update(records);
+    }
+}

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Record.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchMetricsAggregator$Record.java
@@ -47,7 +47,7 @@ public class FetchMetricsAggregator$Record extends AfterInterceptor {
         int bytes = aopContext.getArgAs(1);
         int records = aopContext.getArgAs(2);
 
-        ConsumerMetrics metrics = metricRegistry.getOrCreateMetrics(kafkaPluginContext.clusterSupplier.get(),
+        ConsumerMetrics metrics = metricRegistry.getOrCreateMetrics(kafkaPluginContext.broker,
                                                                     kafkaPluginContext.groupId,
                                                                     kafkaPluginContext.clientId,
                                                                     topicPartition.topic(),

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchResponseMetricAggregator$Ctor.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchResponseMetricAggregator$Ctor.java
@@ -19,11 +19,10 @@ package org.bithon.agent.plugin.apache.kafka.consumer.interceptor;
 import org.bithon.agent.instrumentation.aop.IBithonObject;
 import org.bithon.agent.instrumentation.aop.context.AopContext;
 import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
-import org.bithon.agent.observability.context.InterceptorContext;
 import org.bithon.agent.plugin.apache.kafka.KafkaPluginContext;
 
 /**
- *  * {@link org.apache.kafka.clients.consumer.internals.Fetcher.FetchResponseMetricAggregator}
+ * * {@link org.apache.kafka.clients.consumer.internals.Fetcher.FetchResponseMetricAggregator}
  *
  * @author frank.chen021@outlook.com
  * @date 6/7/24 11:14 pm
@@ -31,8 +30,7 @@ import org.bithon.agent.plugin.apache.kafka.KafkaPluginContext;
 public class FetchResponseMetricAggregator$Ctor extends AfterInterceptor {
     @Override
     public void after(AopContext aopContext) throws Exception {
-        KafkaPluginContext kafkaPluginContext = (KafkaPluginContext) InterceptorContext.get("kafka.consumer.context");
         IBithonObject bithonObject = aopContext.getTargetAs();
-        bithonObject.setInjectedObject(kafkaPluginContext);
+        bithonObject.setInjectedObject(KafkaPluginContext.getCurrent());
     }
 }

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchResponseMetricAggregator$Ctor.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchResponseMetricAggregator$Ctor.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.apache.kafka.consumer.interceptor;
+
+import org.bithon.agent.instrumentation.aop.IBithonObject;
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
+import org.bithon.agent.observability.context.InterceptorContext;
+import org.bithon.agent.plugin.apache.kafka.KafkaPluginContext;
+
+/**
+ *  * {@link org.apache.kafka.clients.consumer.internals.Fetcher.FetchResponseMetricAggregator}
+ *
+ * @author frank.chen021@outlook.com
+ * @date 6/7/24 11:14 pm
+ */
+public class FetchResponseMetricAggregator$Ctor extends AfterInterceptor {
+    @Override
+    public void after(AopContext aopContext) throws Exception {
+        KafkaPluginContext kafkaPluginContext = (KafkaPluginContext) InterceptorContext.get("kafka.consumer.context");
+        IBithonObject bithonObject = aopContext.getTargetAs();
+        bithonObject.setInjectedObject(kafkaPluginContext);
+    }
+}

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchResponseMetricAggregator$Record.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/FetchResponseMetricAggregator$Record.java
@@ -48,7 +48,7 @@ public class FetchResponseMetricAggregator$Record extends AfterInterceptor {
         int bytes = aopContext.getArgAs(1);
         int records = aopContext.getArgAs(2);
 
-        ConsumerMetrics metrics = metricRegistry.getOrCreateMetrics(kafkaPluginContext.clusterSupplier.get(),
+        ConsumerMetrics metrics = metricRegistry.getOrCreateMetrics(kafkaPluginContext.broker,
                                                                     kafkaPluginContext.groupId,
                                                                     kafkaPluginContext.clientId,
                                                                     topicPartition.topic(),

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/ListenerConsumer$Ctor.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/ListenerConsumer$Ctor.java
@@ -74,8 +74,7 @@ public class ListenerConsumer$Ctor extends AfterInterceptor {
                                         .collect(Collectors.joining(","));
                 }
             }
-            String cluster = pluginContext.clusterSupplier.get();
-            pluginContext.uri = "kafka://" + cluster + (topicString == null ? "" : "?topic=" + topicString);
+            pluginContext.uri = "kafka://" + pluginContext.broker + (topicString == null ? "" : "?topic=" + topicString);
             pluginContext.topic = topicString;
         }
 

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/ListenerConsumer$PollAndInvoke.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/consumer/interceptor/ListenerConsumer$PollAndInvoke.java
@@ -84,7 +84,7 @@ public class ListenerConsumer$PollAndInvoke extends AroundInterceptor {
         span.tag(aopContext.getException())
             .tag("status", aopContext.hasException() ? "500" : "200")
             .tag("uri", pluginContext.uri)
-            .tag(Tags.Net.PEER, pluginContext.clusterSupplier.get())
+            .tag(Tags.Net.PEER, pluginContext.broker)
             .tag(Tags.Messaging.KAFKA_TOPIC, pluginContext.topic)
             .tag(Tags.Messaging.KAFKA_CONSUMER_GROUP, pluginContext.groupId)
             .tag(Tags.Messaging.KAFKA_CLIENT_ID, pluginContext.clientId)

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/network/interceptor/NetworkClient$CompleteResponses.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/network/interceptor/NetworkClient$CompleteResponses.java
@@ -54,6 +54,9 @@ public class NetworkClient$CompleteResponses extends AfterInterceptor {
     @Override
     public void after(AopContext aopContext) {
         KafkaPluginContext pluginContext = aopContext.getInjectedOnTargetAs();
+        if (pluginContext == null) {
+            return;
+        }
 
         List<ClientResponse> responses = aopContext.getArgAs(0);
         for (ClientResponse response : responses) {
@@ -80,7 +83,7 @@ public class NetworkClient$CompleteResponses extends AfterInterceptor {
 
             String exceptionName = response.wasDisconnected() ? "Disconnected" : "";
 
-            // authenticationException is only support in some higher version(at least 1.0 version has no such exception)
+            // authenticationException is only support in some higher version (at least 1.0 version has no such exception)
             // So, we need to use reflection to get the value so that this code is compatible with these old Kafka clients
             Exception exception = null;
             if (authenticationExceptionField != null) {

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/network/interceptor/NetworkClient$CompleteResponses.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/network/interceptor/NetworkClient$CompleteResponses.java
@@ -100,7 +100,7 @@ public class NetworkClient$CompleteResponses extends AfterInterceptor {
             }
 
             NetworkMetrics metrics = metricRegistry.getOrCreateMetrics(messageType,
-                                                                       pluginContext.clusterSupplier.get(),
+                                                                       pluginContext.broker,
                                                                        nodeId,
                                                                        pluginContext.groupId,
                                                                        pluginContext.clientId,

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/KafkaProducer$DoSend.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/KafkaProducer$DoSend.java
@@ -77,7 +77,7 @@ public class KafkaProducer$DoSend extends AroundInterceptor {
 
         aopContext.setSpan(span.method(aopContext.getTargetClass(), aopContext.getMethod())
                                .kind(SpanKind.PRODUCER)
-                               .tag(Tags.Net.PEER, pluginContext.clusterSupplier.get())
+                               .tag(Tags.Net.PEER, pluginContext.broker)
                                .tag(Tags.Messaging.SYSTEM, "kafka")
                                .tag(Tags.Messaging.KAFKA_CLIENT_ID, pluginContext.clientId)
                                .tag(Tags.Messaging.KAFKA_TOPIC, record.topic())

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/SenderMetrics$RecordErrors.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/SenderMetrics$RecordErrors.java
@@ -38,7 +38,7 @@ public class SenderMetrics$RecordErrors extends AfterInterceptor {
         int count = aopContext.getArgAs(1);
 
         KafkaPluginContext producerCtx = aopContext.getInjectedOnTargetAs();
-        metricRegistry.getOrCreateMetrics(producerCtx.clusterSupplier.get(),
+        metricRegistry.getOrCreateMetrics(producerCtx.broker,
                                           KafkaPluginContext.getCurrentDestination(),
                                           topic,
                                           producerCtx.clientId).errorRecordCount.update(count);

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/SenderMetrics$RecordRetries.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/SenderMetrics$RecordRetries.java
@@ -37,7 +37,7 @@ public class SenderMetrics$RecordRetries extends AfterInterceptor {
         int count = aopContext.getArgAs(1);
 
         KafkaPluginContext producerCtx = aopContext.getInjectedOnTargetAs();
-        metricRegistry.getOrCreateMetrics(producerCtx.clusterSupplier.get(),
+        metricRegistry.getOrCreateMetrics(producerCtx.broker,
                                           KafkaPluginContext.getCurrentDestination(),
                                           topic,
                                           producerCtx.clientId).retryRecordCount.update(count);

--- a/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/SenderMetrics$UpdateProduceRequestMetrics.java
+++ b/agent/agent-plugins/apache-kafka/src/main/java/org/bithon/agent/plugin/apache/kafka/producer/interceptor/SenderMetrics$UpdateProduceRequestMetrics.java
@@ -85,7 +85,7 @@ public class SenderMetrics$UpdateProduceRequestMetrics extends AfterInterceptor 
                     int recordCount = (int) recordCountField.get(batch);
                     int maxRecordSize = (int) maxRecordSizeField.get(batch);
 
-                    ProducerMetrics metrics = metricRegistry.getOrCreateMetrics(producerCtx.clusterSupplier.get(),
+                    ProducerMetrics metrics = metricRegistry.getOrCreateMetrics(producerCtx.broker,
                                                                                 nodeId,
                                                                                 topicPartition.topic(),
                                                                                 producerCtx.clientId);


### PR DESCRIPTION
3.x refactors the KafkaConsumer into LegacyKafkaConsumer and async mode consumer. In this pr, only the legacy mode is supported.

And the metrics of fetch is also improved by using the batch interface to improve the performance