### PR TITLE
Fix a problem that target application exit is blocked

### DIFF
--- a/agent/agent-core/src/main/java/org/bithon/agent/starter/AgentStarter.java
+++ b/agent/agent-core/src/main/java/org/bithon/agent/starter/AgentStarter.java
@@ -107,6 +107,7 @@ public class AgentStarter {
             // the last started life cycle object will be stopped in first
             for (int i = services.size() - 1; i >= 0; i--) {
                 try {
+                    LOG.info("Stopping service {}", services.get(i).getClass().getName());
                     services.get(i).stop();
                 } catch (Exception ignored) {
                 }

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/dispatcher/task/DispatchTask.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/dispatcher/task/DispatchTask.java
@@ -50,12 +50,14 @@ public class DispatchTask {
         this.underlyingSender = underlyingSender;
         this.queue = config.getBatchSize() > 0 ? new BatchMessageQueue(queue, config.getBatchSize()) : queue;
         this.queueFullStrategy = config.getQueueFullStrategy();
-        new Thread(() -> {
+        Thread sendThread = new Thread(() -> {
             while (isRunning) {
                 dispatch(true);
             }
             isTaskEnd = true;
-        }, taskName + "-sender").start();
+        }, taskName + "-sender");
+        sendThread.setDaemon(true);
+        sendThread.start();
     }
 
     private void dispatch(boolean waitIfEmpty) {

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -131,6 +131,7 @@
                     <signaturesFiles>
                         <signaturesFile>${project.parent.basedir}/../dev/forbidden-apis-joda-time.txt</signaturesFile>
                         <signaturesFile>${project.parent.basedir}/../dev/forbidden-apis-bithon.txt</signaturesFile>
+                        <signaturesFile>${project.parent.basedir}/../dev/forbidden-apis-agent.txt</signaturesFile>
                     </signaturesFiles>
                     <excludes>
                         <exclude>**/SomeAvroDatum.class</exclude>

--- a/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
+++ b/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
@@ -107,7 +107,7 @@ public class BrpcClient implements IBrpcChannel, Closeable {
         this.appName = appName;
 
         this.invocationManager = new InvocationManager();
-        this.bossGroup = new NioEventLoopGroup(nWorkerThreads, NamedThreadFactory.of("brpc-c-work-" + clientId));
+        this.bossGroup = new NioEventLoopGroup(nWorkerThreads, NamedThreadFactory.daemonThreadFactory("brpc-c-work-" + clientId));
         this.bootstrap = new Bootstrap();
         this.bootstrap.group(this.bossGroup)
                       .channel(NioSocketChannel.class)

--- a/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcServer.java
+++ b/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcServer.java
@@ -76,8 +76,8 @@ public class BrpcServer implements Closeable {
     }
 
     public BrpcServer(String serverId, int nWorkerThreads) {
-        this.bossGroup = new NioEventLoopGroup(1, NamedThreadFactory.of("brpc-server-" + serverId));
-        this.workerGroup = new NioEventLoopGroup(nWorkerThreads, NamedThreadFactory.of("brpc-s-work-" + serverId));
+        this.bossGroup = new NioEventLoopGroup(1, NamedThreadFactory.nonDaemonThreadFactory("brpc-server-" + serverId));
+        this.workerGroup = new NioEventLoopGroup(nWorkerThreads, NamedThreadFactory.nonDaemonThreadFactory("brpc-s-work-" + serverId));
 
         this.invocationManager = new InvocationManager();
         this.sessionManager = new SessionManager(this.invocationManager);

--- a/component/component-commons/src/main/java/org/bithon/component/commons/concurrency/NamedThreadFactory.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/concurrency/NamedThreadFactory.java
@@ -29,11 +29,7 @@ public class NamedThreadFactory implements ThreadFactory {
     private final String namePrefix;
     private final boolean isDaemon;
 
-    public NamedThreadFactory(String namePrefix) {
-        this(namePrefix, false);
-    }
-
-    public NamedThreadFactory(String namePrefix, boolean isDaemon) {
+    private NamedThreadFactory(String namePrefix, boolean isDaemon) {
         final SecurityManager s = System.getSecurityManager();
         this.group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
         this.namePrefix = namePrefix;
@@ -50,7 +46,15 @@ public class NamedThreadFactory implements ThreadFactory {
         return t;
     }
 
-    public static ThreadFactory of(String namePrefix) {
-        return new NamedThreadFactory(namePrefix);
+    /**
+     * Define two thread factories for creating daemon and non-daemon threads
+     * This helps us to use forbidden-apis-maven-plugin to detect improper usage of these factories
+     */
+    public static ThreadFactory nonDaemonThreadFactory(String namePrefix) {
+        return new NamedThreadFactory(namePrefix, false);
+    }
+
+    public static ThreadFactory daemonThreadFactory(String namePrefix) {
+        return new NamedThreadFactory(namePrefix, true);
     }
 }

--- a/dev/forbidden-apis-agent.txt
+++ b/dev/forbidden-apis-agent.txt
@@ -1,0 +1,2 @@
+@defaultMessage in Agent, threads MUST be daemon threads. Use #daemonThreadFactory instead
+org.bithon.component.commons.concurrency.NamedThreadFactory#nonDaemonThreadFactory(java.lang.String)

--- a/server/agent-controller/src/main/java/org/bithon/server/agent/controller/service/AgentSettingLoader.java
+++ b/server/agent-controller/src/main/java/org/bithon/server/agent/controller/service/AgentSettingLoader.java
@@ -56,7 +56,7 @@ public class AgentSettingLoader implements SmartLifecycle {
 
     public AgentSettingLoader(ISettingStorage storage,
                               ObjectMapper objectMapper) {
-        this.scheduledExecutorService = new ScheduledThreadPoolExecutor(1, NamedThreadFactory.of("setting-loader"));
+        this.scheduledExecutorService = new ScheduledThreadPoolExecutor(1, NamedThreadFactory.daemonThreadFactory("setting-loader"));
         this.reader = storage.createReader();
         this.jsonFormatter = objectMapper;
         this.yamlFormatter = new ObjectMapper(new YAMLFactory());

--- a/server/collector/src/main/java/org/bithon/server/collector/http/TraceHttpCollector.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/http/TraceHttpCollector.java
@@ -74,7 +74,7 @@ public class TraceHttpCollector {
                                                1L,
                                                TimeUnit.MINUTES,
                                                new LinkedBlockingQueue<>(8),
-                                               NamedThreadFactory.of("trace-http-processor"),
+                                               NamedThreadFactory.nonDaemonThreadFactory("trace-http-processor"),
                                                new ThreadPoolExecutor.CallerRunsPolicy());
 
         this.spanJavaType = objectMapper.getTypeFactory().constructType(TraceSpan.class);

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/api/MetricQueryApi.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/api/MetricQueryApi.java
@@ -59,7 +59,7 @@ public class MetricQueryApi {
 
     public MetricQueryApi(IDataSourceApi dataSourceApi) {
         this.dataSourceApi = dataSourceApi;
-        this.executor = Executors.newCachedThreadPool(new NamedThreadFactory("metric-query"));
+        this.executor = Executors.newCachedThreadPool(NamedThreadFactory.nonDaemonThreadFactory("metric-query"));
     }
 
     @Data

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/common/handler/AbstractThreadPoolMessageHandler.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/common/handler/AbstractThreadPoolMessageHandler.java
@@ -46,7 +46,7 @@ public abstract class AbstractThreadPoolMessageHandler<MSG> implements IMessageH
                                           keepAliveTime.getSeconds(),
                                           TimeUnit.SECONDS,
                                           new LinkedBlockingQueue<>(queueSize),
-                                          NamedThreadFactory.of(name),
+                                          NamedThreadFactory.nonDaemonThreadFactory(name),
                                           handler);
     }
 

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/MetricMessageHandler.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/MetricMessageHandler.java
@@ -94,7 +94,7 @@ public class MetricMessageHandler implements IMetricMessageHandler {
                                                                                           1,
                                                                                           TimeUnit.MINUTES,
                                                                                           new LinkedBlockingQueue<>(1024),
-                                                                                          NamedThreadFactory.of(dataSourceName + "-handler"),
+                                                                                          NamedThreadFactory.nonDaemonThreadFactory(dataSourceName + "-handler"),
                                                                                           new ThreadPoolExecutor.DiscardOldestPolicy()));
     }
 

--- a/server/service-discovery/client/src/main/java/org/bithon/server/discovery/client/ServiceInvocationExecutor.java
+++ b/server/service-discovery/client/src/main/java/org/bithon/server/discovery/client/ServiceInvocationExecutor.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class ServiceInvocationExecutor implements AutoCloseable, Executor {
 
-    private final ExecutorService executorService = Executors.newCachedThreadPool(new NamedThreadFactory("service-invoker", true));
+    private final ExecutorService executorService = Executors.newCachedThreadPool(NamedThreadFactory.nonDaemonThreadFactory("service-invoker"));
 
     @Override
     public void close() throws Exception {

--- a/server/storage/src/main/java/org/bithon/server/storage/common/expiration/ExpirationScheduler.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/common/expiration/ExpirationScheduler.java
@@ -54,7 +54,7 @@ public class ExpirationScheduler implements SmartLifecycle {
     @Override
     public void start() {
         log.info("Starting storage cleaner...");
-        this.executor = new ScheduledThreadPoolExecutor(1, NamedThreadFactory.of("storage-cleaner"));
+        this.executor = new ScheduledThreadPoolExecutor(1, NamedThreadFactory.nonDaemonThreadFactory("storage-cleaner"));
         this.executor.scheduleAtFixedRate(this::expireAllStorages,
                                           1,
                                           1,

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/SchemaManager.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/SchemaManager.java
@@ -171,7 +171,7 @@ public class SchemaManager implements SmartLifecycle {
         incrementalLoadSchemas();
 
         // start periodic loader
-        loaderScheduler = ScheduledExecutorServiceFactor.newSingleThreadScheduledExecutor(NamedThreadFactory.of("schema-loader"));
+        loaderScheduler = ScheduledExecutorServiceFactor.newSingleThreadScheduledExecutor(NamedThreadFactory.nonDaemonThreadFactory("schema-loader"));
         loaderScheduler.scheduleWithFixedDelay(this::incrementalLoadSchemas,
                                                // no delay to execute the first task
                                                1,

--- a/server/web-app/src/main/java/org/bithon/server/webapp/services/DashboardManager.java
+++ b/server/web-app/src/main/java/org/bithon/server/webapp/services/DashboardManager.java
@@ -79,7 +79,7 @@ public class DashboardManager implements SmartLifecycle {
     public void start() {
         log.info("Starting dashboard incremental loader...");
 
-        loaderScheduler = ScheduledExecutorServiceFactor.newSingleThreadScheduledExecutor(NamedThreadFactory.of("dashboard-loader"));
+        loaderScheduler = ScheduledExecutorServiceFactor.newSingleThreadScheduledExecutor(NamedThreadFactory.nonDaemonThreadFactory("dashboard-loader"));
         loaderScheduler.scheduleWithFixedDelay(this::incrementalLoad,
                                                // no delay to execute the first task
                                                0,

--- a/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/impl/DataSourceApi.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/impl/DataSourceApi.java
@@ -100,7 +100,7 @@ public class DataSourceApi implements IDataSourceApi {
                                                     180L,
                                                     TimeUnit.SECONDS,
                                                     new SynchronousQueue<>(),
-                                                    NamedThreadFactory.of("datasource-async"));
+                                                    NamedThreadFactory.nonDaemonThreadFactory("datasource-async"));
         this.discoveredServiceInvoker = discoveredServiceInvoker;
     }
 


### PR DESCRIPTION
Can be seen as a follow up of #875 
If the target application exits without calling System.exit, the non-daemon threads inside the agent blocks the exit.