### PR TITLE
improvement over alerting

### DIFF
--- a/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/evaluator/AlertEvaluator.java
+++ b/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/evaluator/AlertEvaluator.java
@@ -150,7 +150,7 @@ public class AlertEvaluator implements DisposableBean {
                 return;
             }
 
-            AlertStatus prevStatus = context.getPrevState() == null ? AlertStatus.NORMAL : context.getPrevState().getStatus();
+            AlertStatus prevStatus = context.getPrevState() == null ? AlertStatus.READY : context.getPrevState().getStatus();
 
             // Evaluate the alert rule
             AlertStatus newStatus = evaluate(context, context.getPrevState());

--- a/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/evaluator/AlertEvaluator.java
+++ b/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/evaluator/AlertEvaluator.java
@@ -151,6 +151,8 @@ public class AlertEvaluator implements DisposableBean {
             }
 
             AlertStatus prevStatus = context.getPrevState() == null ? AlertStatus.NORMAL : context.getPrevState().getStatus();
+
+            // Evaluate the alert rule
             AlertStatus newStatus = evaluate(context, context.getPrevState());
 
             if (prevStatus.canTransitTo(newStatus)) {
@@ -159,6 +161,11 @@ public class AlertEvaluator implements DisposableBean {
                 if (newStatus == AlertStatus.ALERTING) {
                     // Fire and save alert record
                     fireAlert(alertRule, context);
+                } else if (newStatus == AlertStatus.RESOLVED) {
+                    // Update alert status and resolve alert
+                    this.alertRecordStorage.updateAlertStatus(alertRule.getId(), context.getPrevState(), newStatus);
+
+                    this.resolveAlert(alertRule, context);
                 } else {
                     // Update alert status only
                     this.alertRecordStorage.updateAlertStatus(alertRule.getId(), context.getPrevState(), newStatus);
@@ -221,13 +228,27 @@ public class AlertEvaluator implements DisposableBean {
                             expectedMatchCount);
 
                 HumanReadableDuration silenceDuration = context.getAlertRule().getSilence();
-                if (stateStorage.tryEnterSilence(alertRule.getId(), silenceDuration.getDuration())) {
+
+                String lastAlertingAt = prevState == null ? "N/A" : TimeSpan.of(Timestamp.valueOf(prevState.getLastAlertAt()).getTime()).format("HH:mm:ss");
+
+                // Calc the silence period by adding some margin
+                // Let's say current timestamp is 10:01:02.123, and the silence period is 1 minute,
+                // The silence period is [now(), 10:02:00.000(assuming the evaluation execution finishes within 1 minute) + 1 minute]
+                TimeSpan now = TimeSpan.now();
+                TimeSpan endOfThisMinute = now.ceil(Duration.ofMinutes(1));
+                Duration silencePeriod = silenceDuration.getDuration().plus(Duration.ofMillis(endOfThisMinute.diff(now)));
+                if (stateStorage.tryEnterSilence(alertRule.getId(), silencePeriod)) {
                     Duration silenceRemainTime = stateStorage.getSilenceRemainTime(alertRule.getId());
-                    context.log(AlertEvaluator.class, "Alerting，but is under notification silence period(%s) to %s. Last alert at: %s",
+                    context.log(AlertEvaluator.class, "Alerting，but is under notification silence duration (%s) from last alerting timestamp %s to %s.",
                                 silenceDuration,
-                                TimeSpan.of(System.currentTimeMillis() + silenceRemainTime.toMillis()).format("HH:mm:ss"),
-                                prevState == null ? "N/A" : TimeSpan.of(Timestamp.valueOf(prevState.getLastAlertAt()).getTime()).format("HH:mm:ss"));
+                                lastAlertingAt,
+                                TimeSpan.of(System.currentTimeMillis() + silenceRemainTime.toMillis()).format("HH:mm:ss"));
                     return AlertStatus.SUPPRESSING;
+                } else {
+                    context.log(AlertEvaluator.class,
+                                "Alerting，silence period(%s) is over. Last alert at: %s",
+                                silenceDuration,
+                                lastAlertingAt);
                 }
 
                 return AlertStatus.ALERTING;
@@ -257,6 +278,7 @@ public class AlertEvaluator implements DisposableBean {
         // Prepare notification
         NotificationMessage notification = new NotificationMessage();
         notification.setAlertRule(alertRule);
+        notification.setStatus(AlertStatus.ALERTING);
         notification.setExpressions(alertRule.getFlattenExpressions().values());
         notification.setConditionEvaluation(new HashMap<>());
         context.getEvaluationResults().forEach((expressionId, result) -> {
@@ -283,7 +305,7 @@ public class AlertEvaluator implements DisposableBean {
             notification.setLastAlertAt(alertAt.getTime());
             notification.setAlertRecordId(id);
             for (String channelName : alertRule.getNotifications()) {
-                context.log(AlertEvaluator.class, "Sending notification to channel [%s]", channelName);
+                context.log(AlertEvaluator.class, "Sending alerting notification to channel [%s]", channelName);
 
                 try {
                     notificationApi.notify(channelName, notification);
@@ -293,6 +315,49 @@ public class AlertEvaluator implements DisposableBean {
             }
         } catch (Exception e) {
             context.logException(AlertEvaluator.class, e, "Exception when sending notification");
+        }
+    }
+
+    /**
+     * Fire alert and update its status
+     */
+    private void resolveAlert(AlertRule alertRule, EvaluationContext context) {
+        // Prepare notification
+        NotificationMessage notification = new NotificationMessage();
+        notification.setStatus(AlertStatus.RESOLVED);
+        notification.setAlertRule(alertRule);
+        notification.setExpressions(alertRule.getFlattenExpressions().values());
+        notification.setConditionEvaluation(new HashMap<>());
+        context.getEvaluationResults().forEach((expressionId, result) -> {
+            AlertExpression expression = context.getAlertExpressions().get(expressionId);
+
+            IEvaluationOutput outputs = context.getRuleEvaluationOutput(expressionId);
+            notification.getConditionEvaluation()
+                        .put(expression.getId(),
+                             new ExpressionEvaluationResult(result,
+                                                            outputs == null ? null : OutputMessage.builder()
+                                                                                                  .current(outputs.getCurrentText())
+                                                                                                  .delta(outputs.getDeltaText())
+                                                                                                  .threshold(outputs.getThresholdText())
+                                                                                                  .build()));
+        });
+
+        Timestamp alertAt = new Timestamp(System.currentTimeMillis());
+        try {
+            // notification
+            notification.setLastAlertAt(alertAt.getTime());
+            notification.setAlertRecordId(context.getPrevState().getLastRecordId());
+            for (String channelName : alertRule.getNotifications()) {
+                context.log(AlertEvaluator.class, "Sending RESOLVED notification to channel [%s]", channelName);
+
+                try {
+                    notificationApi.notify(channelName, notification);
+                } catch (Exception e) {
+                    context.logException(AlertEvaluator.class, e, "Exception when sending notification to channel [%s]", channelName);
+                }
+            }
+        } catch (Exception e) {
+            context.logException(AlertEvaluator.class, e, "Exception when sending RESOLVED notification");
         }
     }
 

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/AlertChannelApi.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/AlertChannelApi.java
@@ -47,6 +47,7 @@ import org.bithon.server.alerting.notification.message.NotificationMessage;
 import org.bithon.server.alerting.notification.message.OutputMessage;
 import org.bithon.server.storage.alerting.IAlertNotificationChannelStorage;
 import org.bithon.server.storage.alerting.IAlertObjectStorage;
+import org.bithon.server.storage.alerting.pojo.AlertStatus;
 import org.bithon.server.storage.alerting.pojo.AlertStorageObject;
 import org.bithon.server.storage.alerting.pojo.NotificationChannelObject;
 import org.bithon.server.storage.datasource.query.Limit;
@@ -151,6 +152,7 @@ public class AlertChannelApi {
                                                 EvaluationResult.MATCHED,
                                                 new OutputMessage("1", "2", "1")
                                             )))
+                                            .status(AlertStatus.ALERTING)
                                             .alertRule(AlertRule.builder()
                                                                 .id("fake")
                                                                 .name("Notification Channel Test")

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
@@ -318,7 +318,7 @@ public class AlertCommandService {
         TimeSpan now = TimeSpan.now().floor(Duration.ofMinutes(1));
 
         AlertStateObject stateObject = new AlertStateObject();
-        stateObject.setStatus(AlertStatus.NORMAL);
+        stateObject.setStatus(AlertStatus.READY);
         evaluator.evaluate(now, rule, stateObject);
 
         return logStorage.getLogs();

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/console/ConsoleNotificationChannel.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/console/ConsoleNotificationChannel.java
@@ -34,11 +34,9 @@ public class ConsoleNotificationChannel implements INotificationChannel {
 
     @Override
     public void send(NotificationMessage message) {
-        StringBuilder sb = new StringBuilder(">>>>>>>>>>>ALERT<<<<<<<<<<<<<<<\n");
+        StringBuilder sb = new StringBuilder(StringUtils.format(">>>>>>>>>>>%s<<<<<<<<<<<<<<<\n", message.getStatus()));
         sb.append(StringUtils.format("Name: %s\n", message.getAlertRule().getName()));
-        message.getConditionEvaluation().forEach((sn, cnd) -> {
-            sb.append(StringUtils.format("Expression %s: %s", sn, cnd.getOutputs()));
-        });
+        message.getConditionEvaluation().forEach((sn, cnd) -> sb.append(StringUtils.format("Expression %s: %s", sn, cnd.getOutputs())));
         log.info(sb.toString());
     }
 

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/message/NotificationMessage.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/message/NotificationMessage.java
@@ -22,6 +22,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.bithon.server.alerting.common.model.AlertExpression;
 import org.bithon.server.alerting.common.model.AlertRule;
+import org.bithon.server.storage.alerting.pojo.AlertStatus;
 
 import java.util.Collection;
 import java.util.Map;
@@ -40,4 +41,5 @@ public class NotificationMessage {
     private Map<String, ExpressionEvaluationResult> conditionEvaluation;
     private AlertRule alertRule;
     private Long lastAlertAt;
+    private AlertStatus status;
 }

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/api/MetricQueryApi.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/api/MetricQueryApi.java
@@ -27,11 +27,13 @@ import org.bithon.component.commons.utils.HumanReadablePercentage;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.metric.expression.MetricExpression;
 import org.bithon.server.metric.expression.MetricExpressionASTBuilder;
+import org.bithon.server.web.service.WebServiceModuleEnabler;
 import org.bithon.server.web.service.datasource.api.IDataSourceApi;
 import org.bithon.server.web.service.datasource.api.IntervalRequest;
 import org.bithon.server.web.service.datasource.api.QueryRequest;
 import org.bithon.server.web.service.datasource.api.QueryResponse;
 import org.bithon.server.web.service.datasource.api.TimeSeriesMetric;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,6 +55,7 @@ import java.util.concurrent.TimeUnit;
  */
 @CrossOrigin
 @RestController
+@Conditional(WebServiceModuleEnabler.class)
 public class MetricQueryApi {
     private final IDataSourceApi dataSourceApi;
     private final ExecutorService executor;

--- a/server/server-commons/src/main/java/org/bithon/server/commons/serializer/HumanReadablePercentageDeserializer.java
+++ b/server/server-commons/src/main/java/org/bithon/server/commons/serializer/HumanReadablePercentageDeserializer.java
@@ -36,7 +36,7 @@ public class HumanReadablePercentageDeserializer extends JsonDeserializer<HumanR
         if (node.isObject()) {
             String type = node.get("type").asText();
             Preconditions.checkIfTrue("percentage".equals(type), "Expecting type to be 'percentage' but got '%s'", type);
-            return HumanReadablePercentage.of(node.get("value").asText());
+            return HumanReadablePercentage.of(node.get("text").asText());
         } else {
             // Simple string
             if (node.isValueNode()) {

--- a/server/server-commons/src/main/java/org/bithon/server/commons/serializer/HumanReadablePercentageSerializer.java
+++ b/server/server-commons/src/main/java/org/bithon/server/commons/serializer/HumanReadablePercentageSerializer.java
@@ -33,7 +33,8 @@ public class HumanReadablePercentageSerializer extends JsonSerializer<HumanReada
                           JsonGenerator gen,
                           SerializerProvider serializers) throws IOException {
         gen.writeStartObject();
-        gen.writeStringField("value", value.toString());
+        gen.writeStringField("text", value.toString());
+        gen.writeNumberField("value", value.getFraction());
         gen.writeStringField("type", "percentage");
         gen.writeEndObject();
     }

--- a/server/server-commons/src/main/java/org/bithon/server/commons/serializer/HumanReadableSizeSerializer.java
+++ b/server/server-commons/src/main/java/org/bithon/server/commons/serializer/HumanReadableSizeSerializer.java
@@ -28,11 +28,18 @@ import java.io.IOException;
  * @date 2024/3/3 20:12
  */
 public class HumanReadableSizeSerializer extends JsonSerializer<HumanReadableNumber> {
+
+    public static final String TYPE_NAME = "readable_number";
+
     @Override
     public void serialize(HumanReadableNumber value,
                           JsonGenerator gen,
                           SerializerProvider serializers) throws IOException {
-        gen.writeString(value.toString());
+        gen.writeStartObject();
+        gen.writeStringField("text", value.toString());
+        gen.writeNumberField("value", value.doubleValue());
+        gen.writeStringField("type", TYPE_NAME);
+        gen.writeEndObject();
     }
 
     @Override

--- a/server/server-commons/src/test/java/org/bithon/server/commons/serializer/HumanReadableNumberSerializerTest.java
+++ b/server/server-commons/src/test/java/org/bithon/server/commons/serializer/HumanReadableNumberSerializerTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.bithon.component.commons.utils.HumanReadableNumber;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -29,14 +30,19 @@ import org.junit.Test;
  */
 public class HumanReadableNumberSerializerTest {
 
-    @Test
-    public void test_Deserialization() throws JsonProcessingException {
-        ObjectMapper om = new ObjectMapper();
+    private ObjectMapper om;
+
+    @Before
+    public void setUp() {
+        om = new ObjectMapper();
         SimpleModule m = new SimpleModule();
         m.addDeserializer(HumanReadableNumber.class, new HumanReadableSizeDeserializer());
         m.addSerializer(HumanReadableNumber.class, new HumanReadableSizeSerializer());
         om.registerModule(m);
+    }
 
+    @Test
+    public void test_SerializationAndDeserialization() throws JsonProcessingException {
         Assert.assertEquals("5G", om.readValue(om.writeValueAsString(HumanReadableNumber.of("5G")), HumanReadableNumber.class)
                                     .toString());
 
@@ -45,5 +51,12 @@ public class HumanReadableNumberSerializerTest {
 
         Assert.assertEquals("5GiB", om.readValue(om.writeValueAsString(HumanReadableNumber.of("5GiB")), HumanReadableNumber.class)
                                       .toString());
+    }
+
+    @Test
+    public void test_DeserializeFromSimpleString() throws JsonProcessingException {
+        // Deserialization from simple string
+        Assert.assertEquals("5GiB", om.readValue("\"5GiB\"", HumanReadableNumber.class).toString());
+
     }
 }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/alerting/AlertObjectJdbcStorage.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/alerting/AlertObjectJdbcStorage.java
@@ -336,7 +336,7 @@ public class AlertObjectJdbcStorage implements IAlertObjectStorage {
                              obj.setLastRecordId(record.get(Tables.BITHON_ALERT_STATE.LAST_RECORD_ID));
 
                              Integer status = record.get(Tables.BITHON_ALERT_STATE.ALERT_STATUS);
-                             obj.setAlertStatus(status == null ? AlertStatus.PENDING : AlertStatus.fromCode(status));
+                             obj.setAlertStatus(status == null ? AlertStatus.READY : AlertStatus.fromCode(status));
                              return obj;
                          });
     }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/alerting/NotificationChannelJdbcStorage.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/alerting/NotificationChannelJdbcStorage.java
@@ -186,14 +186,14 @@ public class NotificationChannelJdbcStorage implements IAlertNotificationChannel
         if (createdAt instanceof Timestamp) {
             channel.setCreatedAt((Timestamp) createdAt);
         } else {
-            channel.setCreatedAt(Timestamp.valueOf(createdAt.toString()));
+            channel.setCreatedAt(Timestamp.valueOf((LocalDateTime) createdAt));
         }
 
         Object updatedAt = record.get(Tables.BITHON_ALERT_NOTIFICATION_CHANNEL.UPDATED_AT);
         if (updatedAt instanceof Timestamp) {
             channel.setUpdatedAt((Timestamp) updatedAt);
         } else {
-            channel.setUpdatedAt(Timestamp.valueOf(updatedAt.toString()));
+            channel.setUpdatedAt(Timestamp.valueOf((LocalDateTime) updatedAt));
         }
         return channel;
     }

--- a/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/AlertStatus.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/AlertStatus.java
@@ -22,9 +22,9 @@ package org.bithon.server.storage.alerting.pojo;
  */
 public enum AlertStatus {
     /**
-     * The initial status of an alert
+     * The initial status of an alert, ready for evaluation
      */
-    NORMAL(0) {
+    READY(0) {
         @Override
         public boolean canTransitTo(AlertStatus newStatus) {
             return (newStatus == PENDING || newStatus == ALERTING);

--- a/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/AlertStatus.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/AlertStatus.java
@@ -77,6 +77,10 @@ public enum AlertStatus {
         this.statusCode = statusCode;
     }
 
+    /**
+     * check if the status can transit to the new status.
+     * the old status and the new status SHOULD NOT be the same.
+     */
     public abstract boolean canTransitTo(AlertStatus newStatus);
 
     public static AlertStatus fromCode(int statusCode) {


### PR DESCRIPTION
1. fix a problem that standalone collector can't start. introduced by #902
2. fix a problem that channels can't be listed  under ck. introduced by #904
3. improve serialization of HumanReadablePercentage and HumanReadableNumber for simpler handling at FE side
4. send RESOLVED notification
5. fix the payload end timestamp, previously it was EXCLUSIVE which might cause ambiguity. now it's INCLUSIVE.
