### PR TITLE
Update notification props to control rendered expressions

### DIFF
--- a/server/alerting/README.md
+++ b/server/alerting/README.md
@@ -27,7 +27,8 @@ name: "the name of the alert"
 expr: "PromQL style expression, for example: avg(jvm-metrics.processCpuLoad)[1m] > 0.1[-1h]"
 for: "The duration before the alert should be fired. In the format of duration. Like 1m, 1h"
 every: "Optional, the interval of evaluation in minutes"
-notifications: [name list of notification channels]
+notificationProps:
+  channels: [name list of notification channels]
 ```
 
 ### Expression Syntax

--- a/server/alerting/common/src/main/java/org/bithon/server/alerting/common/model/AlertRule.java
+++ b/server/alerting/common/src/main/java/org/bithon/server/alerting/common/model/AlertRule.java
@@ -36,9 +36,9 @@ import org.bithon.component.commons.utils.Preconditions;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.alerting.common.parser.AlertExpressionASTParser;
 import org.bithon.server.storage.alerting.pojo.AlertStorageObject;
+import org.bithon.server.storage.alerting.pojo.NotificationProps;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -79,14 +79,8 @@ public class AlertRule {
     @JsonProperty("for")
     private int forTimes = 3;
 
-    /**
-     * silence period in minute
-     */
     @JsonProperty
-    private HumanReadableDuration silence = HumanReadableDuration.DURATION_30_MINUTE;
-
-    @JsonProperty
-    private List<String> notifications;
+    private NotificationProps notificationProps;
 
     @JsonIgnore
     private boolean enabled = true;
@@ -133,9 +127,13 @@ public class AlertRule {
         rule.setName(alertObject.getName());
         rule.setEvery(alertObject.getPayload().getEvery());
         rule.setExpr(alertObject.getPayload().getExpr());
-        rule.setSilence(alertObject.getPayload().getSilence());
         rule.setForTimes(alertObject.getPayload().getForTimes());
-        rule.setNotifications(alertObject.getPayload().getNotifications());
+        if (alertObject.getPayload().getNotifications() != null) {
+            rule.setNotificationProps(NotificationProps.builder()
+                                                       .silence(alertObject.getPayload().getSilence())
+                                                       .channels(alertObject.getPayload().getNotifications())
+                                                       .build());
+        }
         return rule;
     }
 

--- a/server/alerting/common/src/main/java/org/bithon/server/alerting/common/model/AlertRule.java
+++ b/server/alerting/common/src/main/java/org/bithon/server/alerting/common/model/AlertRule.java
@@ -128,11 +128,14 @@ public class AlertRule {
         rule.setEvery(alertObject.getPayload().getEvery());
         rule.setExpr(alertObject.getPayload().getExpr());
         rule.setForTimes(alertObject.getPayload().getForTimes());
-        if (alertObject.getPayload().getNotifications() != null) {
+        if (alertObject.getPayload().getNotifications() != null && alertObject.getPayload().getNotificationProps() == null) {
+            // backward compatibility
             rule.setNotificationProps(NotificationProps.builder()
                                                        .silence(alertObject.getPayload().getSilence())
                                                        .channels(alertObject.getPayload().getNotifications())
                                                        .build());
+        } else {
+            rule.setNotificationProps(alertObject.getPayload().getNotificationProps());
         }
         return rule;
     }

--- a/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/evaluator/AlertEvaluator.java
+++ b/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/evaluator/AlertEvaluator.java
@@ -269,7 +269,7 @@ public class AlertEvaluator implements DisposableBean {
                             successiveCount,
                             expectedMatchCount);
 
-                HumanReadableDuration silenceDuration = context.getAlertRule().getSilence();
+                HumanReadableDuration silenceDuration = context.getAlertRule().getNotificationProps().getSilence();
 
                 String lastAlertingAt = prevState == null ? "N/A" : TimeSpan.of(Timestamp.valueOf(prevState.getLastAlertAt()).getTime()).format("HH:mm:ss");
 
@@ -347,7 +347,7 @@ public class AlertEvaluator implements DisposableBean {
             // notification
             notification.setLastAlertAt(alertAt.getTime());
             notification.setAlertRecordId(id);
-            for (String channelName : alertRule.getNotifications()) {
+            for (String channelName : alertRule.getNotificationProps().getChannels()) {
                 context.log(AlertEvaluator.class, "Sending alerting notification to channel [%s]", channelName);
 
                 try {
@@ -390,7 +390,7 @@ public class AlertEvaluator implements DisposableBean {
             // notification
             notification.setLastAlertAt(alertAt.getTime());
             notification.setAlertRecordId(context.getPrevState().getLastRecordId());
-            for (String channelName : alertRule.getNotifications()) {
+            for (String channelName : alertRule.getNotificationProps().getChannels()) {
                 context.log(AlertEvaluator.class, "Sending RESOLVED notification to channel [%s]", channelName);
 
                 try {

--- a/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/storage/redis/AlertStateRedisStorage.java
+++ b/server/alerting/evaluator/src/main/java/org/bithon/server/alerting/evaluator/storage/redis/AlertStateRedisStorage.java
@@ -52,7 +52,8 @@ public class AlertStateRedisStorage implements IAlertStateStorage {
 
                 @Override
                 public void onUpdated(AlertRule original, AlertRule updated) {
-                    if (original.getSilence().equals(updated.getSilence())) {
+                    if (original.getNotificationProps().getSilence().equals(updated.getNotificationProps().getSilence())) {
+                        // The silence period has been changed
                         try {
                             redisClient.delete(getAlertKey(original.getId(), "silence"));
                         } catch (Exception ignored) {

--- a/server/alerting/manager/alert-command-api.http
+++ b/server/alerting/manager/alert-command-api.http
@@ -10,8 +10,10 @@ name: "Alert1"
 expr: "avg(jvm-metrics.processCpuLoad)[1m] > 0.1[-1h]"
 for: 1
 every: 1m
-notifications:
-  - console-1
+notificationProps:
+  silence: 1m
+  channels:
+    - console-1
 
 
 ### Update an alert
@@ -26,9 +28,11 @@ Content-Type: application/json
   "every": "1m",
   "for": "1m",
   "expression": "avg(jvm-metrics.processCpuLoad)[1m] > 0.1 AND max(jvm-metrics.heapUsed) > 100",
-  "notifications": [
-    "console"
-  ]
+  "notificationProps": {
+    "silence": "1m",
+    "channels": [
+        "console"
+  ]}
 }
 
 ### Get an alert
@@ -75,5 +79,6 @@ name: "Alert1"
 expr: "avg(jvm-metrics.processCpuLoad)[1m] > 0.1[-1h]"
 for: 1
 every: 1m
-notifications:
-  - console-1
+notificationProps:
+  channels:
+    - console-1

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/AlertChannelApi.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/AlertChannelApi.java
@@ -49,6 +49,7 @@ import org.bithon.server.storage.alerting.IAlertNotificationChannelStorage;
 import org.bithon.server.storage.alerting.IAlertObjectStorage;
 import org.bithon.server.storage.alerting.pojo.AlertStatus;
 import org.bithon.server.storage.alerting.pojo.AlertStorageObject;
+import org.bithon.server.storage.alerting.pojo.AlertStorageObjectPayload;
 import org.bithon.server.storage.alerting.pojo.NotificationChannelObject;
 import org.bithon.server.storage.datasource.query.Limit;
 import org.bithon.server.storage.datasource.query.OrderBy;
@@ -182,7 +183,11 @@ public class AlertChannelApi {
         // Check if it's used
         List<AlertStorageObject> alerts = alertStorage.getAlertListByTime(new Timestamp(0), new Timestamp(System.currentTimeMillis()));
         for (AlertStorageObject alert : alerts) {
-            if (alert.getPayload().getNotifications().contains(request.getName())) {
+            AlertStorageObjectPayload payload = alert.getPayload();
+            if (payload.getNotifications() != null && alert.getPayload().getNotifications().contains(request.getName())) {
+                return ApiResponse.fail(StringUtils.format("The notification channel can't be deleted because it's used by alert [%s].", alert.getName()));
+            }
+            if (payload.getNotificationProps() != null && payload.getNotificationProps().getChannels().contains(request.getName())) {
                 return ApiResponse.fail(StringUtils.format("The notification channel can't be deleted because it's used by alert [%s].", alert.getName()));
             }
         }

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/parameter/CreateAlertRuleRequest.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/parameter/CreateAlertRuleRequest.java
@@ -72,7 +72,9 @@ public class CreateAlertRuleRequest {
     @NotEmpty
     private String expr;
 
-    public class NotificationCreateProps {
+    @Getter
+    @Setter
+    public static class NotificationCreateProps {
 
         /**
          * silence period in minute
@@ -96,7 +98,7 @@ public class CreateAlertRuleRequest {
          * Can be empty.
          * Defined as 'not' semantics for backward compatibility.
          */
-        private Set<String> notRenderExpressions;
+        private Set<String> renderExpressions;
     }
 
     @Valid
@@ -111,7 +113,7 @@ public class CreateAlertRuleRequest {
         alertRule.setEvery(this.every);
         alertRule.setNotificationProps(NotificationProps.builder()
                                                         .channels(this.notificationProps.channels)
-                                                        .renderExpressions(this.notificationProps.notRenderExpressions)
+                                                        .renderExpressions(this.notificationProps.renderExpressions)
                                                         .silence(this.notificationProps.silence)
                                                         .message(this.notificationProps.message)
                                                         .build());

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/parameter/CreateAlertRuleRequest.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/api/parameter/CreateAlertRuleRequest.java
@@ -111,7 +111,7 @@ public class CreateAlertRuleRequest {
         alertRule.setEvery(this.every);
         alertRule.setNotificationProps(NotificationProps.builder()
                                                         .channels(this.notificationProps.channels)
-                                                        .notRenderExpressions(this.notificationProps.notRenderExpressions)
+                                                        .renderExpressions(this.notificationProps.notRenderExpressions)
                                                         .silence(this.notificationProps.silence)
                                                         .message(this.notificationProps.message)
                                                         .build());

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
@@ -137,7 +137,7 @@ public class AlertCommandService {
             alertExpression.getMetricExpression().validate(schemas);
         }
 
-        for (String channel : alertRule.getNotifications()) {
+        for (String channel : alertRule.getNotificationProps().getChannels()) {
             if (!this.notificationChannelStorage.exists(channel)) {
                 throw new BizException("Notification channel [%s] does not exist", channel);
             }
@@ -153,8 +153,7 @@ public class AlertCommandService {
                                                                .every(alertRule.getEvery())
                                                                .expr(alertRule.getExpr())
                                                                .forTimes(alertRule.getForTimes())
-                                                               .notifications(alertRule.getNotifications())
-                                                               .silence(alertRule.getSilence())
+                                                               .notificationProps(alertRule.getNotificationProps())
                                                                .build());
         return alertStorageObject;
     }

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/http/HttpNotificationChannel.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/http/HttpNotificationChannel.java
@@ -133,11 +133,15 @@ public class HttpNotificationChannel implements INotificationChannel {
     }
 
     private void send(NotificationMessage message, Duration timeout) throws IOException {
-        String messageBody = this.props.body.replace("{alert.appName}", StringUtils.getOrEmpty(message.getAlertRule().getAppName()))
-                                            .replace("{alert.name}", message.getAlertRule().getName())
-                                            .replace("{alert.expr}", message.getAlertRule().getExpr())
-                                            .replace("{alert.url}", getURL(message))
-                                            .replace("{alert.status}", message.getStatus().name());
+        String messageBody = StringUtils.hasText(message.getAlertRule().getNotificationProps().getMessage()) ?
+            message.getAlertRule().getNotificationProps().getMessage()
+            : this.props.body;
+
+        messageBody = messageBody.replace("{alert.appName}", StringUtils.getOrEmpty(message.getAlertRule().getAppName()))
+                                 .replace("{alert.name}", message.getAlertRule().getName())
+                                 .replace("{alert.expr}", message.getAlertRule().getExpr())
+                                 .replace("{alert.url}", getURL(message))
+                                 .replace("{alert.status}", message.getStatus().name());
 
         String evaluationMessage = "";
         if (message.getStatus() == AlertStatus.ALERTING) {

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
@@ -101,7 +101,7 @@ public class AlertImageRenderService implements ApplicationContextAware {
         Map<String, String> images = new ConcurrentHashMap<>();
 
         List<CompletableFuture<Void>> renderTasks = expressions.stream()
-                                                               .filter((expression) -> shouldRenderExpression(rule.getNotificationProps().getNotRenderExpressions(), expression.getId()))
+                                                               .filter((expression) -> shouldRenderExpression(rule.getNotificationProps().getRenderExpressions(), expression.getId()))
                                                                .map((expression) ->
                                                                         CompletableFuture.runAsync(() -> {
                                                                             try {
@@ -129,8 +129,8 @@ public class AlertImageRenderService implements ApplicationContextAware {
         return new TreeMap<>(images);
     }
 
-    private boolean shouldRenderExpression(Set<String> notRenderedExpression, String expressionId) {
-        return notRenderedExpression == null || !notRenderedExpression.contains(expressionId);
+    private boolean shouldRenderExpression(Set<String> renderExpressions, String expressionId) {
+        return renderExpressions != null && renderExpressions.contains(expressionId);
     }
 
     private String render(AlertExpression expression,

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
@@ -49,10 +49,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -96,9 +98,10 @@ public class AlertImageRenderService implements ApplicationContextAware {
             return Collections.emptyMap();
         }
 
-        Map<String, String> images = new LinkedHashMap<>();
+        Map<String, String> images = new ConcurrentHashMap<>();
 
         List<CompletableFuture<Void>> renderTasks = expressions.stream()
+                                                               .filter((expression) -> shouldRenderExpression(rule.getNotificationProps().getNotRenderExpressions(), expression.getId()))
                                                                .map((expression) ->
                                                                         CompletableFuture.runAsync(() -> {
                                                                             try {
@@ -123,7 +126,11 @@ public class AlertImageRenderService implements ApplicationContextAware {
         // Wait for all tasks to complete
         CompletableFuture.allOf(renderTasks.toArray(new CompletableFuture[0])).join();
 
-        return images;
+        return new TreeMap<>(images);
+    }
+
+    private boolean shouldRenderExpression(Set<String> notRenderedExpression, String expressionId) {
+        return notRenderedExpression == null || !notRenderedExpression.contains(expressionId);
     }
 
     private String render(AlertExpression expression,

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
@@ -101,7 +101,7 @@ public class AlertImageRenderService implements ApplicationContextAware {
         Map<String, String> images = new ConcurrentHashMap<>();
 
         List<CompletableFuture<Void>> renderTasks = expressions.stream()
-                                                               .filter((expression) -> shouldRenderExpression(rule.getNotificationProps().getRenderExpressions(), expression.getId()))
+                                                               .filter((expression) -> shouldRenderExpression(rule, expression.getId()))
                                                                .map((expression) ->
                                                                         CompletableFuture.runAsync(() -> {
                                                                             try {
@@ -129,8 +129,13 @@ public class AlertImageRenderService implements ApplicationContextAware {
         return new TreeMap<>(images);
     }
 
-    private boolean shouldRenderExpression(Set<String> renderExpressions, String expressionId) {
-        return renderExpressions != null && renderExpressions.contains(expressionId);
+    private boolean shouldRenderExpression(AlertRule rule, String expressionId) {
+        Set<String> renderExpressions = rule.getNotificationProps().getRenderExpressions();
+        boolean shouldRender = renderExpressions != null && renderExpressions.contains(expressionId);
+
+        log.debug("Rendering expression [{}] for alert [{}]: {}", expressionId, rule.getName(), shouldRender);
+
+        return shouldRender;
     }
 
     private String render(AlertExpression expression,

--- a/server/server-commons/src/main/java/org/bithon/server/commons/utils/HumanReadableDurationValidator.java
+++ b/server/server-commons/src/main/java/org/bithon/server/commons/utils/HumanReadableDurationValidator.java
@@ -41,6 +41,9 @@ public class HumanReadableDurationValidator implements ConstraintValidator<Human
 
     @Override
     public boolean isValid(HumanReadableDuration value, ConstraintValidatorContext context) {
+        if (value == null || value.getDuration() == null) {
+            return false;
+        }
         long seconds = value.getDuration().getSeconds();
         if (seconds < this.min) {
             return false;

--- a/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/NotificationProps.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/NotificationProps.java
@@ -53,7 +53,6 @@ public class NotificationProps {
      * there's no need to render them as images.
      * <p>
      * Can be empty.
-     * Defined as 'not' semantics for backward compatibility.
      */
-    private Set<String> notRenderExpressions;
+    private Set<String> renderExpressions;
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/NotificationProps.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/NotificationProps.java
@@ -16,47 +16,44 @@
 
 package org.bithon.server.storage.alerting.pojo;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 import org.bithon.component.commons.utils.HumanReadableDuration;
 
 import java.util.List;
+import java.util.Set;
 
 /**
- * NOTE: The serialization order is manually controlled so that people understand an alert in a natural way
- *
  * @author frank.chen021@outlook.com
- * @date 2024/2/11 19:51
+ * @date 9/12/24 5:27 pm
  */
-@Data
+@Getter
+@Setter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@JsonPropertyOrder({"expr", "for", "every", "silence", "notifications", "notificationProps"})
-public class AlertStorageObjectPayload {
-    @JsonProperty
-    private String expr;
-
-    @JsonProperty("for")
-    private int forTimes;
-
-    @JsonProperty
-    private HumanReadableDuration every = HumanReadableDuration.DURATION_1_MINUTE;
+public class NotificationProps {
 
     /**
      * silence period in minute
      */
-    @JsonProperty
     private HumanReadableDuration silence;
 
-    @Deprecated
-    @JsonProperty
-    private List<String> notifications;
+    @NotEmpty
+    private List<String> channels;
 
-    @JsonProperty
-    private NotificationProps notificationProps;
+    /**
+     * Can be empty. If empty, the template defined on the channel will be used
+     */
+    private String message;
+
+    /**
+     * Which expression will be rendered as image.
+     * Some ALERT rule might use composite alert expressions, some of which might be seen as 'pre-conditions',
+     * there's no need to render them as images.
+     * <p>
+     * Can be empty.
+     * Defined as 'not' semantics for backward compatibility.
+     */
+    private Set<String> notRenderExpressions;
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/NotificationProps.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/alerting/pojo/NotificationProps.java
@@ -16,7 +16,9 @@
 
 package org.bithon.server.storage.alerting.pojo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -32,7 +34,12 @@ import java.util.Set;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class NotificationProps {
+
+    @JsonCreator
+    public NotificationProps() {
+    }
 
     /**
      * silence period in minute

--- a/server/web-app/src/main/resources/static/js/alert/alert-edit-component.js
+++ b/server/web-app/src/main/resources/static/js/alert/alert-edit-component.js
@@ -136,7 +136,10 @@ class AlertEditComponent {
             expr: expression,
             every: every + $('#everyUnit').val(),
             for: forValue,
-            notifications: notification.map((n) => n.text)
+            notificationProps: {
+                silence: "1m",
+                channels: notification.map((n) => n.text)
+            }
         };
     }
 
@@ -147,7 +150,7 @@ class AlertEditComponent {
         $('#every').val(alert.payload.every.substring(0, alert.payload.every.length - 1));
         $('#everyUnit').val(alert.payload.every.substring(alert.payload.every.length - 1));
 
-        $('#notifications').val(alert.payload.notifications).trigger('change');
+        $('#notifications').val(alert.payload.notificationProps.channels).trigger('change');
 
         this.expressionDashboard.renderExpression(alert.payload.expr);
     }


### PR DESCRIPTION
so that it's able to control which expressions can be rendered.

**Background:**
Some alert rule has composite expressions, some of which are just pre-conditions. There's no need to render these expressions in IMAGE.

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/f608774d-232d-4a62-9a30-07b344025a54" />
