### PR TITLE
reduce storage size

### DIFF
--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/TableCreator.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/TableCreator.java
@@ -275,9 +275,9 @@ public class TableCreator {
             }
 
             if (isCodecSupported) {
-                if ("Metric".equals(field.getComment())) {
+                if (Number.class.isAssignableFrom(dataType.getType())) {
                     sb.append(" CODEC(T64, ZSTD)");
-                } else if ("Dimension".equals(field.getComment())) {
+                } else if (String.class.equals(dataType.getType())) {
                     sb.append(" CODEC(ZSTD(1))");
                 }
             }

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/TableCreator.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/TableCreator.java
@@ -246,7 +246,7 @@ public class TableCreator {
         }
     }
 
-    private String getFieldDeclarationExpression(Table<?> table, boolean allowCodec) {
+    private String getFieldDeclarationExpression(Table<?> table, boolean isCodecSupported) {
 
         StringBuilder sb = new StringBuilder(128);
         for (Field<?> field : table.fields()) {
@@ -274,8 +274,12 @@ public class TableCreator {
                 sb.append(StringUtils.format(" DEFAULT %s", defaultValueText));
             }
 
-            if (allowCodec && "Metric".equals(field.getComment())) {
-                sb.append(" CODEC(T64, ZSTD)");
+            if (isCodecSupported) {
+                if ("Metric".equals(field.getComment())) {
+                    sb.append(" CODEC(T64, ZSTD)");
+                } else if ("Dimension".equals(field.getComment())) {
+                    sb.append(" CODEC(ZSTD(1))");
+                }
             }
 
             sb.append(",\n");

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/exception/RetryableExceptions.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/exception/RetryableExceptions.java
@@ -31,8 +31,8 @@ public class RetryableExceptions {
         return message != null
                && (message.startsWith("Connect timed out")
                    || message.contains("connect timed out")
-                   || message.startsWith("Connection reset")
-                   || message.startsWith("Connection refused")
+                   || message.contains("Connection reset")
+                   || message.contains("Connection refused")
                    || message.startsWith("Unexpected end of file from server")
                    // The following is thrown from sun.net.www.protocol.http.HTTPURLConnection
                    || message.startsWith("Error writing request body to server")


### PR DESCRIPTION
#789 

```text
┌─partition─┬─partCount─┬─rowsCount─┬────diskSize─┬─onDiskSize─┬─compressedSize─┬─uncompressedSize─┬─compressRatio(%)─┐
92. │ 20241213  │        14 │ 292964166 │ 17221545315 │ 16.04 GiB  │ 16.02 GiB      │ 57.83 GiB        │               28 │
94. │ 20241215  │        14 │ 292331053 │ 12466005304 │ 11.61 GiB  │ 11.59 GiB      │ 57.69 GiB        │               20 │
```

By enforcing codec for dimensions, storage size of `http-incoming-metrics` reduced by 30% as illustrated above.

