### PR TITLE
return data type in meta

### DIFF
--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArithmeticExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArithmeticExpression.java
@@ -153,6 +153,11 @@ public abstract class ArithmeticExpression extends BinaryExpression {
         protected long evaluate(long v1, long v2) {
             return v1 / v2;
         }
+
+        @Override
+        public IDataType getDataType() {
+            return IDataType.DOUBLE;
+        }
     }
 }
 

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/IDataType.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/IDataType.java
@@ -220,7 +220,7 @@ public enum IDataType {
     /**
      * The DateTime that stores the time in milliseconds
      */
-    DATETIME_3 {
+    DATETIME_MILLI {
         @Override
         public boolean canCastFrom(IDataType dataType) {
             return false;

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/LiteralExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/LiteralExpression.java
@@ -187,7 +187,7 @@ public abstract class LiteralExpression<T> implements IExpression {
                     case STRING:
                         return this;
 
-                    case DATETIME_3: {
+                    case DATETIME_MILLI: {
                         try {
                             long timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH).parse(value).getTime();
 
@@ -232,7 +232,7 @@ public abstract class LiteralExpression<T> implements IExpression {
                 case BOOLEAN:
                     return new LiteralExpression.BooleanLiteral(value != 0);
 
-                case DATETIME_3:
+                case DATETIME_MILLI:
                     return new TimestampLiteral(value);
 
                 default:
@@ -371,7 +371,7 @@ public abstract class LiteralExpression<T> implements IExpression {
 
         @Override
         public IDataType getDataType() {
-            return IDataType.DATETIME_3;
+            return IDataType.DATETIME_MILLI;
         }
 
         @Override

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/AggregateFunction.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/AggregateFunction.java
@@ -53,7 +53,7 @@ public abstract class AggregateFunction extends AbstractFunction {
         @Override
         public void validateArgs(List<IExpression> args) {
             validateParameterSize(1, args.size());
-            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_3, IDataType.STRING);
+            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_MILLI, IDataType.STRING);
         }
 
         @Override
@@ -72,7 +72,7 @@ public abstract class AggregateFunction extends AbstractFunction {
         @Override
         public void validateArgs(List<IExpression> args) {
             validateParameterSize(1, args.size());
-            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_3, IDataType.STRING);
+            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_MILLI, IDataType.STRING);
         }
 
         @Override
@@ -95,7 +95,7 @@ public abstract class AggregateFunction extends AbstractFunction {
         @Override
         public void validateArgs(List<IExpression> args) {
             validateParameterSize(1, args.size());
-            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_3);
+            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_MILLI);
         }
 
         @Override
@@ -139,7 +139,7 @@ public abstract class AggregateFunction extends AbstractFunction {
         @Override
         public void validateArgs(List<IExpression> args) {
             validateParameterSize(1, args.size());
-            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_3);
+            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_MILLI);
         }
 
         @Override
@@ -158,7 +158,7 @@ public abstract class AggregateFunction extends AbstractFunction {
         @Override
         public void validateArgs(List<IExpression> args) {
             validateParameterSize(1, args.size());
-            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_3);
+            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_MILLI);
         }
 
         @Override
@@ -177,7 +177,7 @@ public abstract class AggregateFunction extends AbstractFunction {
         @Override
         public void validateArgs(List<IExpression> args) {
             validateParameterSize(1, args.size());
-            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_3);
+            validateType(args.get(0).getDataType(), IDataType.DOUBLE, IDataType.LONG, IDataType.DATETIME_MILLI);
         }
 
         @Override

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/TimeFunction.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/TimeFunction.java
@@ -123,8 +123,9 @@ public class TimeFunction {
         public static final FromUnixTimestamp INSTANCE = new FromUnixTimestamp();
 
         public FromUnixTimestamp() {
-            // TODO: Change the DateTime_3 to DateTime
-            super("fromUnixTimestamp", IDataType.LONG, IDataType.DATETIME_3);
+            // TODO: Change the DateTime_3 to DateTime since it returns datatime in second
+            // Currently it works because the return type is not used
+            super("fromUnixTimestamp", IDataType.LONG, IDataType.DATETIME_MILLI);
         }
 
         @Override

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
@@ -19,6 +19,7 @@ package org.bithon.server.storage.jdbc.metric;
 import com.alibaba.druid.pool.DruidDataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.bithon.component.commons.expression.ComparisonExpression;
+import org.bithon.component.commons.expression.IDataType;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.utils.Preconditions;
@@ -151,7 +152,7 @@ public class MetricJdbcReader implements IDataSourceReader {
         QueryExpression queryExpression = new QueryExpression();
         queryExpression.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
         for (Selector selector : query.getSelectors()) {
-            queryExpression.getSelectorList().add(selector.getSelectExpression(), selector.getOutput());
+            queryExpression.getSelectorList().add(selector.getSelectExpression(), selector.getOutput(), selector.getDataType());
         }
         queryExpression.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
         queryExpression.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
@@ -171,7 +172,7 @@ public class MetricJdbcReader implements IDataSourceReader {
 
         QueryExpression queryExpression = new QueryExpression();
         queryExpression.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
-        queryExpression.getSelectorList().add(new TextNode("count(1)"));
+        queryExpression.getSelectorList().add(new TextNode("count(1)"), IDataType.LONG);
         queryExpression.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
         queryExpression.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
         queryExpression.getWhere().and(sqlDialect.transform(query.getFilter()));
@@ -227,7 +228,7 @@ public class MetricJdbcReader implements IDataSourceReader {
 
         QueryExpression queryExpression = new QueryExpression();
         queryExpression.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
-        queryExpression.getSelectorList().add(new TextNode(StringUtils.format("DISTINCT(%s)", sqlDialect.quoteIdentifier(dimension))), dimension);
+        queryExpression.getSelectorList().add(new TextNode(StringUtils.format("DISTINCT(%s)", sqlDialect.quoteIdentifier(dimension))), dimension, IDataType.STRING);
         queryExpression.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
         queryExpression.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
         queryExpression.getWhere().and(sqlDialect.transform(query.getFilter()));

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilder.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilder.java
@@ -499,7 +499,7 @@ public class QueryExpressionBuilder {
         for (Selector selector : this.selectors) {
             IASTNode selectExpression = selector.getSelectExpression();
             if (selectExpression instanceof Expression) {
-                IExpression parsedExpression = ((Expression) selectExpression).getParsedExpression(this.schema);
+                IExpression parsedExpression = ((Expression) selectExpression).getParsedExpression();
 
                 if (parsedExpression instanceof FunctionExpression functionExpression) {
                     if (!functionExpression.getFunction().isAggregator()) {
@@ -517,7 +517,7 @@ public class QueryExpressionBuilder {
         for (Selector selector : this.selectors) {
             IASTNode selectExpression = selector.getSelectExpression();
             if (selectExpression instanceof Expression) {
-                IExpression parsedExpression = ((Expression) selectExpression).getParsedExpression(this.schema);
+                IExpression parsedExpression = ((Expression) selectExpression).getParsedExpression();
 
                 // Replace all aggregator functions, examples:
                 // Case 1: sum(a) ===> a
@@ -609,7 +609,7 @@ public class QueryExpressionBuilder {
             for (Selector selector : this.selectors) {
                 IASTNode selectExpression = selector.getSelectExpression();
                 if (selectExpression instanceof Expression) {
-                    IExpression parsedExpression = ((Expression) selectExpression).getParsedExpression(this.schema);
+                    IExpression parsedExpression = ((Expression) selectExpression).getParsedExpression();
 
                     if (parsedExpression instanceof IdentifierExpression identifierExpression) {
                         // Try to eliminate Alias expression

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilder.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilder.java
@@ -742,18 +742,18 @@ public class QueryExpressionBuilder {
 
             // The timestamp calculation is pushed down to the window aggregation step if needed
             QueryExpression aggregationStep = pipeline.windowAggregation == null ? pipeline.aggregation : pipeline.windowAggregation;
-            aggregationStep.getSelectorList().insert(expr, TimestampSpec.COLUMN_ALIAS, IDataType.DATETIME_3);
+            aggregationStep.getSelectorList().insert(expr, TimestampSpec.COLUMN_ALIAS, IDataType.DATETIME_MILLI);
 
             // Always add the timestamp to the group-by clause of the aggregation step
             pipeline.aggregation.getGroupBy().addField(TimestampSpec.COLUMN_ALIAS);
             if (aggregationStep != pipeline.aggregation) {
                 // Add timestamp to the SELECT list of the aggregation step
-                pipeline.aggregation.getSelectorList().insert(TimestampSpec.COLUMN_ALIAS, IDataType.DATETIME_3);
+                pipeline.aggregation.getSelectorList().insert(TimestampSpec.COLUMN_ALIAS, IDataType.DATETIME_MILLI);
             }
 
             // Add timestamp to the SELECT list of the final step
             if (pipeline.postAggregation != null) {
-                pipeline.postAggregation.getSelectorList().insert(TimestampSpec.COLUMN_ALIAS, IDataType.DATETIME_3);
+                pipeline.postAggregation.getSelectorList().insert(TimestampSpec.COLUMN_ALIAS, IDataType.DATETIME_MILLI);
             }
         }
     }

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilderTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilderTest.java
@@ -314,7 +314,7 @@ public class QueryExpressionBuilderTest {
     public void testExpressionInAggregation_GroupBy() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression(schema,"sum(totalCount*2)"), new Alias("t"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount*2)"), new Alias("t"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName"))
                                                                 .dataSource(schema)
@@ -337,7 +337,7 @@ public class QueryExpressionBuilderTest {
     public void testSimpleAggregation_TimeSeries() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression(schema,"sum(totalCount)"), new Alias("totalCount"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount)"), new Alias("totalCount"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800"),
                                                                                       Duration.ofSeconds(10),
@@ -496,7 +496,7 @@ public class QueryExpressionBuilderTest {
     public void testDuplicateAggregations() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(List.of(new Selector(new Expression(schema,"sum(count4xx) + sum(count5xx)"), new Alias("errorCount")),
+                                                                .fields(List.of(new Selector(new Expression(schema, "sum(count4xx) + sum(count5xx)"), new Alias("errorCount")),
                                                                                 new Selector(new Expression(schema, "round((sum(count4xx) + sum(count5xx))*100.0/sum(totalCount), 2)"), new Alias("errorRate"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilderTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilderTest.java
@@ -291,7 +291,7 @@ public class QueryExpressionBuilderTest {
     public void testSimpleAggregation_GroupBy() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount)"), new Alias("t"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount)"), new Alias("t"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName"))
                                                                 .dataSource(schema)
@@ -314,7 +314,7 @@ public class QueryExpressionBuilderTest {
     public void testExpressionInAggregation_GroupBy() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount*2)"), new Alias("t"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema,"sum(totalCount*2)"), new Alias("t"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName"))
                                                                 .dataSource(schema)
@@ -337,7 +337,7 @@ public class QueryExpressionBuilderTest {
     public void testSimpleAggregation_TimeSeries() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount)"), new Alias("totalCount"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema,"sum(totalCount)"), new Alias("totalCount"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800"),
                                                                                       Duration.ofSeconds(10),
@@ -365,7 +365,7 @@ public class QueryExpressionBuilderTest {
     public void testPostAggregation_GroupBy() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(responseTime*2)/sum(totalCount)"), new Alias("avg"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(responseTime*2)/sum(totalCount)"), new Alias("avg"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .dataSource(schema)
@@ -396,7 +396,7 @@ public class QueryExpressionBuilderTest {
     public void testPostAggregation_GroupBy_NestedFunction() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("round(round(sum(responseTime)/sum(totalCount),2), 2)"), new Alias("avg"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "round(round(sum(responseTime)/sum(totalCount),2), 2)"), new Alias("avg"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .dataSource(schema)
@@ -427,7 +427,7 @@ public class QueryExpressionBuilderTest {
     public void testPostAggregation_TimeSeries() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(responseTime)/sum(totalCount)"), new Alias("avg"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(responseTime)/sum(totalCount)"), new Alias("avg"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800"),
                                                                                       Duration.ofSeconds(10),
@@ -463,7 +463,7 @@ public class QueryExpressionBuilderTest {
     public void testPostFunctionExpression_GroupBy() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("round(sum(responseTime)/sum(totalCount), 2)"),
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "round(sum(responseTime)/sum(totalCount), 2)"),
                                                                                                                new Alias("avg"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
@@ -496,8 +496,8 @@ public class QueryExpressionBuilderTest {
     public void testDuplicateAggregations() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(List.of(new Selector(new Expression("sum(count4xx) + sum(count5xx)"), new Alias("errorCount")),
-                                                                                new Selector(new Expression("round((sum(count4xx) + sum(count5xx))*100.0/sum(totalCount), 2)"), new Alias("errorRate"))))
+                                                                .fields(List.of(new Selector(new Expression(schema,"sum(count4xx) + sum(count5xx)"), new Alias("errorCount")),
+                                                                                new Selector(new Expression(schema, "round((sum(count4xx) + sum(count5xx))*100.0/sum(totalCount), 2)"), new Alias("errorRate"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .dataSource(schema)
@@ -530,7 +530,7 @@ public class QueryExpressionBuilderTest {
     public void testWindowFunction_GroupBy() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("first(activeThreads)"), new Alias("a"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "first(activeThreads)"), new Alias("a"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .filter(new ComparisonExpression.GT(new IdentifierExpression("a"), new LiteralExpression.LongLiteral(5)))
@@ -562,7 +562,7 @@ public class QueryExpressionBuilderTest {
     public void testWindowFunction_GroupBy_NoUseWindowAggregator() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(clickHouseDialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("first(activeThreads)"), new Alias("a"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "first(activeThreads)"), new Alias("a"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .dataSource(schema)
@@ -586,7 +586,7 @@ public class QueryExpressionBuilderTest {
     public void testWindowFunction_TimeSeries() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("first(activeThreads)"), new Alias("activeThreads"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "first(activeThreads)"), new Alias("activeThreads"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800"),
                                                                                       Duration.ofSeconds(10),
@@ -621,7 +621,7 @@ public class QueryExpressionBuilderTest {
     public void testWindowFunction_WithAggregator() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("first(activeThreads)/sum(totalThreads)"), new Alias("ratio"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "first(activeThreads)/sum(totalThreads)"), new Alias("ratio"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .orderBy(OrderBy.builder().name("timestamp").order(Order.asc).build())
@@ -661,7 +661,7 @@ public class QueryExpressionBuilderTest {
     public void testWindowFunction_NoUseWindowAggregator_WithAggregator() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(clickHouseDialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("first(activeThreads)/sum(totalThreads)"), new Alias("ratio"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "first(activeThreads)/sum(totalThreads)"), new Alias("ratio"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .orderBy(OrderBy.builder().name("timestamp").order(Order.asc).build())
@@ -694,7 +694,7 @@ public class QueryExpressionBuilderTest {
     public void testWindowFunctionAfterAggregator() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalThreads) - first(activeThreads)"), new Alias("daemon"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalThreads) - first(activeThreads)"), new Alias("daemon"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
@@ -735,7 +735,7 @@ public class QueryExpressionBuilderTest {
     public void testWindowFunctionAfterAggregator_MySQL() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(mysql)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalThreads) - first(activeThreads)"), new Alias("daemon"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalThreads) - first(activeThreads)"), new Alias("daemon"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
@@ -776,7 +776,7 @@ public class QueryExpressionBuilderTest {
     public void testAggregationWithMacroExpression() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount)/{interval}"), new Alias("qps"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount)/{interval}"), new Alias("qps"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800"),
                                                                                       Duration.ofSeconds(10),
@@ -813,7 +813,7 @@ public class QueryExpressionBuilderTest {
     public void testCardinalityAggregation() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("cardinality(instance)"), new Alias("instanceCount"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "cardinality(instance)"), new Alias("instanceCount"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName"))
@@ -839,7 +839,7 @@ public class QueryExpressionBuilderTest {
     public void testCountAggregation() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("count(1)"), new Alias("cnt"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "count(1)"), new Alias("cnt"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName"))
@@ -865,7 +865,7 @@ public class QueryExpressionBuilderTest {
     public void testHumanReadableLiteral() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("count(1)"), new Alias("cnt"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "count(1)"), new Alias("cnt"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"),
                                                                                       TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .filter(new LogicalExpression.AND(new ComparisonExpression.GT(new IdentifierExpression("totalCount"), new LiteralExpression.ReadableNumberLiteral(HumanReadableNumber.of("1MiB"))),
@@ -898,7 +898,7 @@ public class QueryExpressionBuilderTest {
     public void testPostFilter_UseExpressionVariable() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(responseTime*2)/sum(totalCount)"), new Alias("avg"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(responseTime*2)/sum(totalCount)"), new Alias("avg"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .filter(
                                                                     new LogicalExpression.AND(
@@ -943,7 +943,7 @@ public class QueryExpressionBuilderTest {
     public void testPostFilter_UseAggregationAliasInFilter() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount)"), new Alias("cnt"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount)"), new Alias("cnt"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .filter(new ComparisonExpression.GT(new IdentifierExpression("cnt"), new LiteralExpression.LongLiteral(1000)))
                                                                 .groupBy(List.of("appName", "instanceName"))
@@ -972,7 +972,7 @@ public class QueryExpressionBuilderTest {
     public void testPostFilter_UseAggregationFilter() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount)"), new Alias("totalCount"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount)"), new Alias("totalCount"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .filter(new ComparisonExpression.GT(new IdentifierExpression("totalCount"), new LiteralExpression.LongLiteral(1000)))
                                                                 .groupBy(List.of("appName", "instanceName"))
@@ -998,7 +998,7 @@ public class QueryExpressionBuilderTest {
     public void testPostFilter_FilterNotInTheSelectList_H2() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount)"), new Alias("totalCount"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount)"), new Alias("totalCount"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .filter(ExpressionASTBuilder.builder()
                                                                                             .schema(schema)
@@ -1042,7 +1042,7 @@ public class QueryExpressionBuilderTest {
     public void testPostFilter_FilterNotInTheSelectList_CK() {
         QueryExpression queryExpression = QueryExpressionBuilder.builder()
                                                                 .sqlDialect(clickHouseDialect)
-                                                                .fields(Collections.singletonList(new Selector(new Expression("sum(totalCount)"), new Alias("totalCount"))))
+                                                                .fields(Collections.singletonList(new Selector(new Expression(schema, "sum(totalCount)"), new Alias("totalCount"))))
                                                                 .interval(Interval.of(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"), TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800")))
                                                                 .filter(ExpressionASTBuilder.builder()
                                                                                             .schema(schema)

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/DefaultSchema.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/DefaultSchema.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bithon.server.commons.time.Period;
 import org.bithon.server.storage.datasource.column.DateTimeColumn;
+import org.bithon.server.storage.datasource.column.ExpressionColumn;
 import org.bithon.server.storage.datasource.column.IColumn;
 import org.bithon.server.storage.datasource.store.IDataStoreSpec;
 
@@ -150,6 +151,11 @@ public class DefaultSchema implements ISchema {
 
             if (!metricSpec.getAlias().equals(metricSpec.getName())) {
                 aliasColumns.put(metricSpec.getAlias(), metricSpec);
+            }
+
+            if (metricSpec instanceof ExpressionColumn) {
+                ExpressionColumn expressionColumn = (ExpressionColumn) metricSpec;
+                expressionColumn.setSchema(this);
             }
         });
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/DateTimeColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/DateTimeColumn.java
@@ -44,6 +44,6 @@ public class DateTimeColumn extends AbstractColumn {
 
     @Override
     public Selector toSelector() {
-        return new Selector(getName());
+        return new Selector(getName(), getDataType());
     }
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/DateTimeColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/DateTimeColumn.java
@@ -39,7 +39,7 @@ public class DateTimeColumn extends AbstractColumn {
     @JsonIgnore
     @Override
     public IDataType getDataType() {
-        return IDataType.DATETIME_3;
+        return IDataType.DATETIME_MILLI;
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ExpressionColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ExpressionColumn.java
@@ -17,6 +17,7 @@
 package org.bithon.server.storage.datasource.column;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -77,9 +78,10 @@ public class ExpressionColumn implements IColumn {
 
     @Override
     public Selector toSelector() {
-        return new Selector(new Expression(this.expression), this.name);
+        return new Selector(new Expression(this.expression), this.name, this.valueType);
     }
 
+    @JsonIgnore
     @Override
     public IDataType getDataType() {
         return this.valueType;

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ExpressionColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ExpressionColumn.java
@@ -22,8 +22,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 import org.bithon.component.commons.expression.IDataType;
 import org.bithon.component.commons.utils.Preconditions;
+import org.bithon.server.storage.datasource.DefaultSchema;
 import org.bithon.server.storage.datasource.aggregator.NumberAggregator;
 import org.bithon.server.storage.datasource.query.ast.Expression;
 import org.bithon.server.storage.datasource.query.ast.Selector;
@@ -45,6 +47,9 @@ public class ExpressionColumn implements IColumn {
 
     @Getter
     private final IDataType valueType;
+
+    @Setter
+    private DefaultSchema schema;
 
     @JsonCreator
     public ExpressionColumn(@JsonProperty("name") @NotNull String name,
@@ -78,7 +83,7 @@ public class ExpressionColumn implements IColumn {
 
     @Override
     public Selector toSelector() {
-        return new Selector(new Expression(this.expression), this.name, this.valueType);
+        return new Selector(new Expression(schema, this.expression), this.name, this.valueType);
     }
 
     @JsonIgnore

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/LongColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/LongColumn.java
@@ -44,6 +44,6 @@ public class LongColumn extends AbstractColumn {
 
     @Override
     public Selector toSelector() {
-        return new Selector(getName());
+        return new Selector(getName(), getDataType());
     }
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ObjectColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/ObjectColumn.java
@@ -44,6 +44,6 @@ public class ObjectColumn extends AbstractColumn {
     }
 
     public Selector toSelector() {
-        return new Selector(getName());
+        return new Selector(getName(), getDataType());
     }
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/StringColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/StringColumn.java
@@ -45,6 +45,6 @@ public class StringColumn extends AbstractColumn {
 
     @Override
     public Selector toSelector() {
-        return new Selector(getName());
+        return new Selector(getName(), getDataType());
     }
 }

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/IAggregatableColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/IAggregatableColumn.java
@@ -30,7 +30,7 @@ import org.bithon.server.storage.datasource.query.ast.Selector;
 public interface IAggregatableColumn extends IColumn {
     @JsonIgnore
     default Selector toSelector() {
-        return new Selector(new Expression(getAggregateFunctionExpression()), getName());
+        return new Selector(new Expression(getAggregateFunctionExpression()), getName(), getDataType());
     }
 
     @JsonIgnore

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/Expression.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/Expression.java
@@ -18,6 +18,7 @@ package org.bithon.server.storage.datasource.query.ast;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.bithon.component.commons.expression.IDataType;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.server.storage.common.expression.ExpressionASTBuilder;
@@ -35,6 +36,10 @@ public class Expression implements IASTNode {
     @Getter
     @Setter
     private IExpression parsedExpression;
+
+    public IDataType getDataType() {
+        return parsedExpression.getDataType();
+    }
 
     public Expression(String expression) {
         this.expression = expression;

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/Expression.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/Expression.java
@@ -45,18 +45,20 @@ public class Expression implements IASTNode {
         this.expression = expression;
     }
 
+    public Expression(ISchema schema, String expression) {
+        this.expression = expression;
+        this.parsedExpression = ExpressionASTBuilder.builder()
+                                                    .functions(Functions.getInstance())
+                                                    .schema(schema)
+                                                    .build(expression);
+    }
+
     public Expression(IExpression expression) {
         this.expression = expression.serializeToText();
         this.parsedExpression = expression;
     }
 
-    public IExpression getParsedExpression(ISchema schema) {
-        if (this.parsedExpression == null) {
-            this.parsedExpression = ExpressionASTBuilder.builder()
-                                                        .functions(Functions.getInstance())
-                                                        .schema(schema)
-                                                        .build(expression);
-        }
+    public IExpression getParsedExpression() {
         return parsedExpression;
     }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/Selector.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/Selector.java
@@ -18,6 +18,7 @@ package org.bithon.server.storage.datasource.query.ast;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.bithon.component.commons.expression.IDataType;
 import org.bithon.component.commons.utils.StringUtils;
 
 /**
@@ -45,28 +46,39 @@ public class Selector implements IASTNode {
     @Setter
     private Object tag;
 
-    public Selector(String name) {
-        this(new Column(name), (Alias) null);
+    private final IDataType dataType;
+
+    public Selector(String name, IDataType dataType) {
+        this(new Column(name), (Alias) null, dataType);
     }
 
-    public Selector(String name, String output) {
-        this(new Column(name), output == null ? null : new Alias(output));
+    public Selector(String name, String output, IDataType dataType) {
+        this(new Column(name), output == null ? null : new Alias(output), dataType);
     }
 
-    public Selector(IASTNode selectExpression, String output) {
-        this(selectExpression, output == null ? null : new Alias(output));
+    public Selector(IASTNode selectExpression, String output, IDataType dataType) {
+        this(selectExpression, output == null ? null : new Alias(output), dataType);
     }
 
-    public Selector(IASTNode selectExpression, Alias output) {
+    public Selector(Expression selectExpression, String output) {
+        this(selectExpression, output, selectExpression.getDataType());
+    }
+
+    public Selector(Expression selectExpression, Alias output) {
+        this(selectExpression, output, selectExpression.getDataType());
+    }
+
+    public Selector(IASTNode selectExpression, Alias output, IDataType dataType) {
         this.selectExpression = selectExpression;
         this.output = output;
+        this.dataType = dataType;
     }
 
     public Selector withOutput(String alias) {
         if (this.output != null && this.output.getName().equals(alias)) {
             return this;
         }
-        return new Selector(this.selectExpression, alias);
+        return new Selector(this.selectExpression, alias, this.dataType);
     }
 
     public String getOutputName() {

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/SelectorList.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/SelectorList.java
@@ -17,6 +17,7 @@
 package org.bithon.server.storage.datasource.query.ast;
 
 import lombok.Getter;
+import org.bithon.component.commons.expression.IDataType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,49 +45,42 @@ public class SelectorList implements IASTNode {
     /**
      * insert the column at first place
      */
-    public SelectorList insert(String columnName) {
-        this.selectors.add(0, new Selector(columnName));
+    public SelectorList insert(String columnName, IDataType dataType) {
+        this.selectors.add(0, new Selector(columnName, dataType));
         return this;
     }
 
     /**
      * insert the column at first place
      */
-    public SelectorList insert(IASTNode columnExpression) {
-        return insert(columnExpression, null);
+    public SelectorList insert(IASTNode columnExpression, IDataType dataType) {
+        return insert(columnExpression, null, dataType);
     }
 
-    public SelectorList insert(IASTNode columnExpression, String output) {
+    public SelectorList insert(IASTNode columnExpression, String output, IDataType dataType) {
         if (columnExpression instanceof Selector) {
             throw new RuntimeException("Can't add typeof ResultColumn");
         }
-        selectors.add(0, new Selector(columnExpression, output));
+        selectors.add(0, new Selector(columnExpression, output, dataType));
         return this;
     }
 
-    public Selector add(IASTNode columnExpression) {
-        return add(columnExpression, (Alias) null);
+    public Selector add(IASTNode columnExpression, IDataType dataType) {
+        return add(columnExpression, (Alias) null, dataType);
     }
 
-    public Selector add(IASTNode columnExpression, String output) {
-        return add(columnExpression, new Alias(output));
+    public Selector add(IASTNode columnExpression, String output, IDataType dataType) {
+        return add(columnExpression, new Alias(output), dataType);
     }
 
-    public Selector add(IASTNode columnExpression, Alias output) {
+    public Selector add(IASTNode columnExpression, Alias output, IDataType dataType) {
         if (columnExpression instanceof Selector) {
             throw new RuntimeException("Can't add typeof ResultColumn");
         }
 
-        Selector selector = new Selector(columnExpression, output);
+        Selector selector = new Selector(columnExpression, output, dataType);
         selectors.add(selector);
         return selector;
-    }
-
-    public SelectorList addAll(List<String> columns) {
-        for (String column : columns) {
-            this.selectors.add(new Selector(column));
-        }
-        return this;
     }
 
     @Override

--- a/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/QueryResponse.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/QueryResponse.java
@@ -61,6 +61,8 @@ public class QueryResponse {
     @AllArgsConstructor
     public static class QueryResponseColumn {
         private String name;
+
+        private String dataType;
     }
 
     // The column metadata info in the result set

--- a/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/impl/QueryConverter.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/impl/QueryConverter.java
@@ -73,9 +73,7 @@ public class QueryConverter {
         List<Selector> selectorList = new ArrayList<>(query.getFields().size());
         for (QueryField field : query.getFields()) {
             if (field.getExpression() != null) {
-
-                selectorList.add(new Selector(new Expression(field.getExpression()), field.getName()));
-
+                selectorList.add(new Selector(new Expression(schema, field.getExpression()), field.getName()));
                 continue;
             }
 
@@ -189,7 +187,7 @@ public class QueryConverter {
             if (field.getExpression() != null) {
                 // This is a client side passed post simple expression, NOT aggregation expression
                 // TODO: check if there's any aggregation function in the expression
-                selectorList.add(new Selector(new Expression(field.getExpression()), field.getName()));
+                selectorList.add(new Selector(new Expression(schema, field.getExpression()), field.getName()));
 
                 continue;
             }

--- a/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/impl/QueryConverter.java
+++ b/server/web-service/src/main/java/org/bithon/server/web/service/datasource/api/impl/QueryConverter.java
@@ -208,7 +208,7 @@ public class QueryConverter {
                 selector = columnSpec.toSelector();
                 // TODO: check if there's any aggregation function in the expression
             } else {
-                selector = new Selector(columnSpec.getName());
+                selector = new Selector(columnSpec.getName(), columnSpec.getDataType());
             }
             if (columnSpec.getAlias().equals(field.getName())) {
                 selector = selector.withOutput(field.getName());
@@ -217,11 +217,14 @@ public class QueryConverter {
         }
 
         // Replace the input '*' with all columns in the schema
+        // the insertIndex is the position of the '*' in the selector list
         if (insertedIndex != -1) {
             Set<String> selectedColumns = selectorList.stream().map((Selector::getOutputName)).collect(Collectors.toSet());
             for (IColumn column : schema.getColumns()) {
                 if (!selectedColumns.contains(column.getName())) {
-                    selectorList.add(insertedIndex, new Selector(column.getName()));
+                    // Create a new selector instance instead of call toSelector on column
+                    // because the column may be column like LongLastColumn
+                    selectorList.add(insertedIndex++, new Selector(column.getName(), column.getDataType()));
                 }
             }
         }


### PR DESCRIPTION
so that FE can initialize default formatters by the data type. for example, for date time column, the date time formatter will be applied