### PR TITLE
add back token-based match and remove LIKE operator support

### DIFF
--- a/component/component-commons/src/main/java/org/bithon/component/commons/exception/HttpMappableException.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/exception/HttpMappableException.java
@@ -52,9 +52,14 @@ public class HttpMappableException extends RuntimeException {
         this.causeExceptionClass = causeExceptionClass;
     }
 
-
     public HttpMappableException(Throwable cause, int statusCode, String messageFormat, Object... args) {
         super(StringUtils.format(messageFormat, args), cause);
+        this.statusCode = statusCode;
+        this.causeExceptionClass = cause.getClass().getName();
+    }
+
+    public HttpMappableException(Throwable cause, int statusCode, String message) {
+        super(message, cause);
         this.statusCode = statusCode;
         this.causeExceptionClass = cause.getClass().getName();
     }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ConditionalExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ConditionalExpression.java
@@ -16,6 +16,8 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
+
 import java.util.Set;
 
 /**
@@ -113,6 +115,26 @@ public abstract class ConditionalExpression extends BinaryExpression {
         @Override
         public Object evaluate(IEvaluationContext context) {
             return !((boolean) super.evaluate(context));
+        }
+    }
+
+    /**
+     * match token in given input
+     */
+    public static class HasToken extends ConditionalExpression {
+        public HasToken(IExpression left, IExpression right) {
+            super("hasToken", left, right);
+        }
+
+        @Override
+        public Object evaluate(IEvaluationContext context) {
+            String input = (String) lhs.evaluate(context);
+            if (input == null) {
+                return false;
+            }
+
+            String pattern = (String) rhs.evaluate(context);
+            return StringFunction.HasToken.INSTANCE.evaluate(input, pattern);
         }
     }
 

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ConditionalExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ConditionalExpression.java
@@ -104,50 +104,6 @@ public abstract class ConditionalExpression extends BinaryExpression {
         }
     }
 
-    public static class Like extends ConditionalExpression {
-
-        public Like(IExpression left, IExpression right) {
-            this("like", left, right);
-        }
-
-        public Like(String operator, IExpression left, IExpression right) {
-            super(operator, left, right);
-        }
-
-        @Override
-        public Object evaluate(IEvaluationContext context) {
-            String input = (String) lhs.evaluate(context);
-            if (input == null) {
-                return false;
-            }
-
-            String pattern = (String) rhs.evaluate(context);
-
-            if (pattern.contains("%")) {
-                // Replace % with .* to convert SQL LIKE pattern to a regex pattern
-                String regexPattern = pattern.replace("%", ".*");
-
-                // Use regex matching to check if the inputString matches the pattern
-                return input.matches(regexPattern);
-            } else {
-                // If the given pattern does not contain '%', check for exact match
-                return input.equals(pattern);
-            }
-        }
-    }
-
-    public static class NotLike extends Like {
-
-        public NotLike(IExpression left, IExpression right) {
-            super("not like", left, right);
-        }
-
-        @Override
-        public Object evaluate(IEvaluationContext context) {
-            return !((boolean) super.evaluate(context));
-        }
-    }
-
     public static class NotIn extends In {
 
         public NotIn(IExpression left, ExpressionList right) {

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/FunctionExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/FunctionExpression.java
@@ -17,6 +17,7 @@
 package org.bithon.component.commons.expression;
 
 import org.bithon.component.commons.expression.function.IFunction;
+import org.bithon.component.commons.utils.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +40,9 @@ public class FunctionExpression implements IExpression {
      * @param args MUST be a WRITABLE list
      */
     public FunctionExpression(IFunction function, List<IExpression> args) {
+        Preconditions.checkNotNull(function, "function object cannot be null");
+        function.validateArgs(args);
+
         this.function = function;
         this.args = args;
     }
@@ -91,10 +95,7 @@ public class FunctionExpression implements IExpression {
         return visitor.visit(this);
     }
 
-    public static FunctionExpression create(IFunction function, String... args) {
-        return new FunctionExpression(function,
-                                      Arrays.stream(args)
-                                            .map(IdentifierExpression::new)
-                                            .collect(Collectors.toList()));
+    public static FunctionExpression create(IFunction function, IExpression... args) {
+        return new FunctionExpression(function, args);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/IdentifierExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/IdentifierExpression.java
@@ -26,6 +26,12 @@ public class IdentifierExpression implements IExpression {
         return new IdentifierExpression(identifier);
     }
 
+    public static IdentifierExpression of(String identifier, IDataType argType) {
+        IdentifierExpression expr = new IdentifierExpression(identifier);
+        expr.setDataType(argType);
+        return expr;
+    }
+
     /**
      * NOT final to allow AST optimization
      */

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/Functions.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/Functions.java
@@ -50,8 +50,8 @@ public class Functions implements IFunctionProvider {
     public Functions() {
         register(new NumberFunction.Round());
 
-        register(new StringFunction.StartsWith());
-        register(new StringFunction.EndsWith());
+        register(StringFunction.StartsWith.INSTANCE);
+        register(StringFunction.EndsWith.INSTANCE);
         register(StringFunction.HasToken.INSTANCE);
         register(new StringFunction.Lower());
         register(new StringFunction.Upper());

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/Functions.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/Functions.java
@@ -52,7 +52,7 @@ public class Functions implements IFunctionProvider {
 
         register(new StringFunction.StartsWith());
         register(new StringFunction.EndsWith());
-        register(new StringFunction.HasToken());
+        register(StringFunction.HasToken.INSTANCE);
         register(new StringFunction.Lower());
         register(new StringFunction.Upper());
         register(new StringFunction.Substring());

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/StringFunction.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/StringFunction.java
@@ -53,6 +53,8 @@ public class StringFunction {
 
     public static class HasToken extends AbstractFunction {
 
+        public static final HasToken INSTANCE = new HasToken();
+
         public HasToken() {
             super("hasToken",
                   Arrays.asList(IDataType.STRING, IDataType.STRING),

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/StringFunction.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/function/builtin/StringFunction.java
@@ -73,9 +73,11 @@ public class StringFunction {
 
         @Override
         public Object evaluate(List<Object> args) {
-            String haystack = (String) args.get(0);
-            String needle = (String) args.get(1);
-            return haystack != null && needle != null && haystack.contains(needle);
+            return evaluate((String) args.get(0), (String) args.get(1));
+        }
+
+        public boolean evaluate(String target, String token) {
+            return target != null && token != null && target.contains(token);
         }
 
         @Override
@@ -137,7 +139,9 @@ public class StringFunction {
 
 
     public static class StartsWith extends AbstractFunction {
-        public StartsWith() {
+        public static final StartsWith INSTANCE = new StartsWith();
+
+        private StartsWith() {
             super("startsWith", Arrays.asList(IDataType.STRING, IDataType.STRING), IDataType.BOOLEAN);
         }
 
@@ -155,7 +159,9 @@ public class StringFunction {
     }
 
     public static class EndsWith extends AbstractFunction {
-        public EndsWith() {
+        public static final EndsWith INSTANCE = new EndsWith();
+
+        private EndsWith() {
             super("endsWith",
                   Arrays.asList(IDataType.STRING, IDataType.STRING),
                   IDataType.BOOLEAN);

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/optimzer/ExpressionOptimizer.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/optimzer/ExpressionOptimizer.java
@@ -311,18 +311,10 @@ public class ExpressionOptimizer {
                 // Turn the expression: 'NOT var not in ('xxx')' into 'var in (xxx)'
                 return new ConditionalExpression.In(((ConditionalExpression.NotIn) subExpression).getLhs(),
                                                     (ExpressionList) ((ConditionalExpression.NotIn) subExpression).getRhs());
-            } else if (subExpression instanceof ConditionalExpression.NotLike) {
-                // Turn the expression: 'NOT var not like 'xxx'' into 'var like (xxx)'
-                return new ConditionalExpression.Like(((ConditionalExpression.NotLike) subExpression).getLhs(),
-                                                      ((ConditionalExpression.NotLike) subExpression).getRhs());
             } else if (subExpression instanceof ConditionalExpression.In) {
                 // Turn into In into NotIn
                 return new ConditionalExpression.NotIn(((ConditionalExpression.In) subExpression).getLhs(),
                                                        (ExpressionList) ((ConditionalExpression.In) subExpression).getRhs());
-            } else if (subExpression instanceof ConditionalExpression.Like) {
-                // Turn into Like into NotLike
-                return new ConditionalExpression.NotLike(((ConditionalExpression.Like) subExpression).getLhs(),
-                                                         ((ConditionalExpression.Like) subExpression).getRhs());
             } else if (subExpression instanceof ComparisonExpression.EQ) {
                 // Turn '=' into '<>'
                 return new ComparisonExpression.NE(((ComparisonExpression.EQ) subExpression).getLhs(),
@@ -347,6 +339,9 @@ public class ExpressionOptimizer {
                 // Turn '>= into '<'
                 return new ComparisonExpression.LT(((ComparisonExpression.GTE) subExpression).getLhs(),
                                                    ((ComparisonExpression.GTE) subExpression).getRhs());
+            } else if (subExpression instanceof LogicalExpression.NOT) {
+                // NOT (NOT (xxx))  => xxx
+                return ((LogicalExpression.NOT) subExpression).getOperands().get(0);
             }
 
             return expression;

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
@@ -78,22 +78,40 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
 
     @Override
     public boolean visit(LogicalExpression expression) {
+        boolean needClose = false;
+
         String concatOperator = expression.getOperator();
         if (expression instanceof LogicalExpression.NOT) {
             sb.append("NOT ");
             concatOperator = "AND";
+            needClose = expression.getOperands().size() > 1;
+            if (needClose) {
+                sb.append('(');
+            }
         }
 
-        sb.append('(');
         for (int i = 0, size = expression.getOperands().size(); i < size; i++) {
             if (i > 0) {
                 sb.append(' ');
                 sb.append(concatOperator);
                 sb.append(' ');
             }
-            expression.getOperands().get(i).accept(this);
+
+            IExpression operand = expression.getOperands().get(i);
+            if (operand instanceof ConditionalExpression || operand instanceof LogicalExpression) {
+                sb.append('(');
+                operand.accept(this);
+                sb.append(')');
+            } else {
+                // Might be FunctionExpression
+                operand.accept(this);
+            }
         }
-        sb.append(')');
+
+        if (needClose) {
+            sb.append(')');
+        }
+
         return false;
     }
 

--- a/component/component-commons/src/test/java/org/bithon/component/commons/expression/ExpressionEvaluationTest.java
+++ b/component/component-commons/src/test/java/org/bithon/component/commons/expression/ExpressionEvaluationTest.java
@@ -26,41 +26,6 @@ import org.junit.Test;
 public class ExpressionEvaluationTest {
 
     @Test
-    public void test_LikeExpression1() {
-        // a LIKE '%bison%'
-        ConditionalExpression.Like expr = new ConditionalExpression.Like(new IdentifierExpression("a"),
-                                                                         new LiteralExpression.StringLiteral("%an%"));
-        Assert.assertTrue((boolean) expr.evaluate(name -> "bison is an animal"));
-    }
-
-    @Test
-    public void test_LikeExpression2() {
-        // a LIKE 'bison%'
-        ConditionalExpression.Like expr = new ConditionalExpression.Like(new IdentifierExpression("a"),
-                                                                         new LiteralExpression.StringLiteral("bison%"));
-        Assert.assertTrue((boolean) expr.evaluate(name -> "bison is an animal"));
-        Assert.assertTrue((boolean) expr.evaluate(name -> "bison"));
-    }
-
-    @Test
-    public void test_LikeExpression3() {
-        // a LIKE 'bison'
-        ConditionalExpression.Like expr = new ConditionalExpression.Like(new IdentifierExpression("a"),
-                                                                         new LiteralExpression.StringLiteral("bison"));
-        Assert.assertTrue((boolean) expr.evaluate(name -> "bison"));
-        Assert.assertFalse((boolean) expr.evaluate(name -> "bisonn"));
-    }
-
-    @Test
-    public void test_LikeExpression4() {
-        // a LIKE 'bison'
-        ConditionalExpression.Like expr = new ConditionalExpression.Like(new IdentifierExpression("a"),
-                                                                         new LiteralExpression.StringLiteral("%bison"));
-        Assert.assertTrue((boolean) expr.evaluate(name -> "american bison"));
-        Assert.assertTrue((boolean) expr.evaluate(name -> "bison"));
-    }
-
-    @Test
     public void test_ContainsExpression() {
         // a contains 'bison'
         IExpression expr = new ConditionalExpression.Contains(new IdentifierExpression("a"),

--- a/component/component-commons/src/test/java/org/bithon/component/commons/expression/optimizer/ExpressionOptimizerTest.java
+++ b/component/component-commons/src/test/java/org/bithon/component/commons/expression/optimizer/ExpressionOptimizerTest.java
@@ -53,7 +53,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assert.assertEquals(5, expr.getOperands().size());
-        Assert.assertEquals("(a = 1 AND b = 2 AND c = 3 AND d = 4 AND e = 5)", expr.serializeToText(null));
+        Assert.assertEquals("(a = 1) AND (b = 2) AND (c = 3) AND (d = 4) AND (e = 5)", expr.serializeToText(null));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assert.assertEquals(3, expr.getOperands().size());
-        Assert.assertEquals("(a = 1 OR b = 2 OR c = 3)", expr.serializeToText(null));
+        Assert.assertEquals("(a = 1) OR (b = 2) OR (c = 3)", expr.serializeToText(null));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assert.assertEquals(2, expr.getOperands().size());
-        Assert.assertEquals("(a = 1 AND (b = 2 OR c = 3))", expr.serializeToText(null));
+        Assert.assertEquals("(a = 1) AND ((b = 2) OR (c = 3))", expr.serializeToText(null));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assert.assertEquals(4, expr.getOperands().size());
-        Assert.assertEquals("(a = 1 AND b = 2 AND c = 3 AND d = 4)", expr.serializeToText(null));
+        Assert.assertEquals("(a = 1) AND (b = 2) AND (c = 3) AND (d = 4)", expr.serializeToText(null));
     }
 
     @Test
@@ -133,7 +133,7 @@ public class ExpressionOptimizerTest {
         );
 
         expr = ExpressionOptimizer.optimize(expr);
-        Assert.assertEquals("NOT (a = 1 AND b = 2 AND c = 3 AND d = 4)", expr.serializeToText(null));
+        Assert.assertEquals("NOT ((a = 1) AND (b = 2) AND (c = 3) AND (d = 4))", expr.serializeToText(null));
     }
 
     @Test

--- a/server/alerting/common/src/test/java/org/bithon/server/alerting/common/serializer/AlertExpressionSerializerTest.java
+++ b/server/alerting/common/src/test/java/org/bithon/server/alerting/common/serializer/AlertExpressionSerializerTest.java
@@ -48,7 +48,7 @@ public class AlertExpressionSerializerTest {
 
         Assert.assertEquals("1", tree.get("id").asText());
         Assert.assertEquals("avg(jvm-metrics.cpu{appName = \"a\", instance = \"b\"})[5m] > 1%[-7m]", tree.get("expressionText").asText());
-        Assert.assertEquals("(appName = 'a' AND instance = 'b')", tree.get("where").asText());
+        Assert.assertEquals("(appName = 'a') AND (instance = 'b')", tree.get("where").asText());
     }
 
     @Test
@@ -67,7 +67,7 @@ public class AlertExpressionSerializerTest {
 
         // appName should be escaped as ab\"cd
         Assert.assertEquals("avg(jvm-metrics.cpu{appName = \"ab\\\"cd\", instance = \"ab'cd\"})[5m] > 1%[-7m]", tree.get("expressionText").asText());
-        Assert.assertEquals("(appName = 'ab\"cd' AND instance = 'ab\\'cd')", tree.get("where").asText());
+        Assert.assertEquals("(appName = 'ab\"cd') AND (instance = 'ab\\'cd')", tree.get("where").asText());
     }
 
     @Test
@@ -84,7 +84,7 @@ public class AlertExpressionSerializerTest {
 
         Assert.assertEquals("1", tree.get("id").asText());
         Assert.assertEquals("avg(jvm-metrics.cpu{appName = \"a\", instance = \"b\"})[5m] > 1", tree.get("expressionText").asText());
-        Assert.assertEquals("(appName = 'a' AND instance = 'b')", tree.get("where").asText());
+        Assert.assertEquals("(appName = 'a') AND (instance = 'b')", tree.get("where").asText());
     }
 
     @Test

--- a/server/alerting/evaluator/src/test/java/org/bithon/server/alerting/evaluator/evaluation/AlertRuleEvaluatorTest.java
+++ b/server/alerting/evaluator/src/test/java/org/bithon/server/alerting/evaluator/evaluation/AlertRuleEvaluatorTest.java
@@ -540,7 +540,7 @@ public class AlertRuleEvaluatorTest {
     }
 
     @Test
-    public void testLike() throws IOException {
+    public void test_Contains() throws IOException {
         // Current
         EasyMock.expect(dataSourceProvider.groupBy(EasyMock.anyObject()))
                 .andReturn(QueryResponse.builder()
@@ -554,7 +554,7 @@ public class AlertRuleEvaluatorTest {
                                         .build());
         EasyMock.replay(dataSourceProvider);
 
-        String expr = StringUtils.format("sum(test-metrics.%s{type like 'a'})[1m] <= 50%%[-1m]", metric);
+        String expr = StringUtils.format("sum(test-metrics.%s{type contains 'a'})[1m] <= 50%%[-1m]", metric);
         AlertExpression expression = (AlertExpression) AlertExpressionASTParser.parse(expr);
 
         AlertRule alertRule = AlertRule.builder()
@@ -572,7 +572,7 @@ public class AlertRuleEvaluatorTest {
     }
 
     @Test
-    public void testNotLike() throws IOException {
+    public void test_NotContains() throws IOException {
         // Current
         EasyMock.expect(dataSourceProvider.groupBy(EasyMock.anyObject()))
                 .andReturn(QueryResponse.builder()
@@ -586,7 +586,7 @@ public class AlertRuleEvaluatorTest {
                                         .build());
         EasyMock.replay(dataSourceProvider);
 
-        String expr = StringUtils.format("sum(test-metrics.%s{type not like 'a'})[1m] <= 50%%[-1m]", metric);
+        String expr = StringUtils.format("sum(test-metrics.%s{type not contains 'a'})[1m] <= 50%%[-1m]", metric);
         AlertExpression expression = (AlertExpression) AlertExpressionASTParser.parse(expr);
 
         AlertRule alertRule = AlertRule.builder()

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
@@ -129,8 +129,6 @@ public class AlertCommandService {
             throw new BizException(e.getMessage());
         }
 
-        alertRule.setExpr(new AlertExpressionSerializer().serialize(alertRule.getAlertExpression()));
-
         Map<String, ISchema> schemas = dataSourceApi.getSchemas();
 
         for (AlertExpression alertExpression : alertRule.getFlattenExpressions().values()) {

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertExpressionSuggester.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertExpressionSuggester.java
@@ -64,7 +64,7 @@ public class AlertExpressionSuggester {
         MetricExpressionParser.EQ,
         MetricExpressionParser.IS,
         MetricExpressionParser.NOT,
-        MetricExpressionParser.LIKE,
+        MetricExpressionParser.HASTOKEN,
         MetricExpressionParser.CONTAINS,
         MetricExpressionParser.STARTSWITH,
         MetricExpressionParser.ENDSWITH);

--- a/server/alerting/manager/src/test/java/org/bithon/server/alerting/manager/biz/AlertExpressionSuggesterTest.java
+++ b/server/alerting/manager/src/test/java/org/bithon/server/alerting/manager/biz/AlertExpressionSuggesterTest.java
@@ -176,7 +176,7 @@ public class AlertExpressionSuggesterTest {
         Collection<String> suggestions = suggest(suggester, "sum(event.count{app");
 
         // TODO: BUG, should suggest startsWith, contains
-        Assert.assertEquals(Arrays.asList("!=", "<", "<=", "<>", "=", ">", ">=", "endswith", "in", "like", "not"), suggestions);
+        Assert.assertEquals(Arrays.asList("!=", "<", "<=", "<>", "=", ">", ">=", "endswith", "hastoken", "in", "not"), suggestions);
     }
 
     @Test
@@ -189,7 +189,7 @@ public class AlertExpressionSuggesterTest {
         Collection<String> suggestions = suggest(suggester, "sum(event.count{app not");
 
         // BUG: should also suggest startsWith, contains
-        Assert.assertEquals(Arrays.asList("endswith", "in", "like"), suggestions);
+        Assert.assertEquals(Arrays.asList("endswith", "hastoken", "in"), suggestions);
     }
 
     @Test

--- a/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
+++ b/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
@@ -49,7 +49,7 @@ labelSelectorExpression
 
 labelPredicateExpression
   : LT|LTE|GT|GTE|NE|EQ
-  | NOT? (CONTAINS|STARTSWITH|ENDSWITH|LIKE)
+  | NOT? (CONTAINS|STARTSWITH|ENDSWITH|HASTOKEN)
   ;
 
 metricPredicateExpression
@@ -96,7 +96,7 @@ EQ: '=';
 IS: I S;
 IN: I N;
 NOT: N O T;
-LIKE: L I K E;
+HASTOKEN: H A S T O K E N;
 CONTAINS: C O N T A I N S;
 STARTSWITH: S T A R T S W I T H;
 ENDSWITH: E N D S W I T H;

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpressionASTBuilder.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpressionASTBuilder.java
@@ -23,12 +23,14 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.ExpressionList;
+import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IDataType;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.utils.HumanReadableDuration;
 import org.bithon.component.commons.utils.HumanReadableNumber;
 import org.bithon.component.commons.utils.HumanReadablePercentage;
@@ -186,7 +188,7 @@ public class MetricExpressionASTBuilder {
         }
 
         private static PredicateEnum getPredicate(int predicateToken,
-                                                  LiteralExpression expected,
+                                                  LiteralExpression<?> expected,
                                                   HumanReadableDuration expectedWindow) {
             switch (predicateToken) {
                 case MetricExpressionParser.LT:
@@ -293,10 +295,9 @@ public class MetricExpressionASTBuilder {
                     checkIfTrue(expected instanceof LiteralExpression.StringLiteral, "The expected value of 'endsWith' predicate must be type of string literal.");
                     yield new ConditionalExpression.EndsWith(identifier, expected);
                 }
-                // For compatibility
-                case MetricExpressionParser.LIKE -> {
-                    checkIfTrue(expected instanceof LiteralExpression.StringLiteral, "The expected value of 'LIKE' predicate must be type of string literal.");
-                    yield new ConditionalExpression.Like(identifier, expected);
+                case MetricExpressionParser.HASTOKEN -> {
+                    checkIfTrue(expected instanceof LiteralExpression.StringLiteral, "The expected value of 'hasToken' predicate must be type of string literal.");
+                    yield new FunctionExpression(StringFunction.HasToken.INSTANCE, identifier, expected);
                 }
                 default -> throw new RuntimeException("Unsupported predicate type: " + predicateType);
             };

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpressionASTBuilder.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpressionASTBuilder.java
@@ -23,14 +23,12 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.ExpressionList;
-import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IDataType;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
-import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.utils.HumanReadableDuration;
 import org.bithon.component.commons.utils.HumanReadableNumber;
 import org.bithon.component.commons.utils.HumanReadablePercentage;
@@ -297,7 +295,7 @@ public class MetricExpressionASTBuilder {
                 }
                 case MetricExpressionParser.HASTOKEN -> {
                     checkIfTrue(expected instanceof LiteralExpression.StringLiteral, "The expected value of 'hasToken' predicate must be type of string literal.");
-                    yield new FunctionExpression(StringFunction.HasToken.INSTANCE, identifier, expected);
+                    yield new ConditionalExpression.HasToken(identifier, expected);
                 }
                 default -> throw new RuntimeException("Unsupported predicate type: " + predicateType);
             };

--- a/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
+++ b/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
@@ -175,12 +175,12 @@ public class MetricExpressionASTBuilderTest {
     }
 
     @Test
-    public void test_LikePredicateExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m] > 1");
-        Assert.assertEquals("(appName like 'a%' AND instanceName like '192.%')", expression.getLabelSelectorExpression().serializeToText(null));
+    public void test_hasTokenPredicateExpression() {
+        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 'a', instanceName hasToken '192.'})[5m] > 1");
+        Assert.assertEquals("(hasToken(appName, 'a') AND hasToken(instanceName, '192.'))", expression.getLabelSelectorExpression().serializeToText(null));
 
-        // like require string literal
-        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 5})[5m] > 1"));
+        // hasToken require string literal
+        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 5})[5m] > 1"));
     }
 
     @Test
@@ -197,9 +197,9 @@ public class MetricExpressionASTBuilderTest {
         expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not endsWith 'a'})[5m] is null");
         Assert.assertEquals("NOT (appName endsWith 'a')", expression.getLabelSelectorExpression().serializeToText(null));
 
-        // not like
-        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not like 'a'})[5m] is null");
-        Assert.assertEquals("NOT (appName like 'a')", expression.getLabelSelectorExpression().serializeToText(null));
+        // not hasToken
+        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not hasToken 'a'})[5m] is null");
+        Assert.assertEquals("NOT (hasToken(appName, 'a'))", expression.getLabelSelectorExpression().serializeToText(null));
     }
 
     @Test
@@ -254,17 +254,17 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_OffsetExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m] > 1%[-7m]");
+        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 1%[-7m]");
         Assert.assertNotNull(expression.getOffset());
         Assert.assertEquals(-7, expression.getOffset().getDuration().toMinutes());
 
         // Only percentage is supported now
-        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m] > 1[0m]"));
+        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 1[0m]"));
 
-        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m] > 1%[0m]"));
-        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m] > 1%[1m]"));
+        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 1%[0m]"));
+        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 1%[1m]"));
 
-        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m] is null[-5m]"));
+        Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] is null[-5m]"));
     }
 
     @Test
@@ -285,16 +285,16 @@ public class MetricExpressionASTBuilderTest {
 
         // Two filters
         {
-            MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m] > 10%[-5m]");
-            Assert.assertEquals("avg(jvm-metrics.cpu{appName like \"a%\", instanceName like \"192.%\"})[5m] > 10%[-5m]",
+            MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 10%[-5m]");
+            Assert.assertEquals("avg(jvm-metrics.cpu{appName contains \"a\", instanceName contains \"192.\"})[5m] > 10%[-5m]",
                                 expression.serializeToText(null));
         }
 
 
         // count aggregator
         {
-            MetricExpression expression = MetricExpressionASTBuilder.parse("count(   jvm-metrics.cpu{appName like 'a%', instanceName like '192.%'})[5m]  >  1");
-            Assert.assertEquals("count(jvm-metrics.cpu{appName like \"a%\", instanceName like \"192.%\"})[5m] > 1",
+            MetricExpression expression = MetricExpressionASTBuilder.parse("count(   jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m]  >  1");
+            Assert.assertEquals("count(jvm-metrics.cpu{appName contains \"a\", instanceName contains \"192.\"})[5m] > 1",
                                 expression.serializeToText());
         }
     }

--- a/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
+++ b/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
@@ -177,7 +177,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_hasTokenPredicateExpression() {
         MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 'a', instanceName hasToken '192.'})[5m] > 1");
-        Assert.assertEquals("(hasToken(appName, 'a') AND hasToken(instanceName, '192.'))", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("(appName hasToken 'a') AND (instanceName hasToken '192.')", expression.getLabelSelectorExpression().serializeToText(null));
 
         // hasToken require string literal
         Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 5})[5m] > 1"));
@@ -199,7 +199,7 @@ public class MetricExpressionASTBuilderTest {
 
         // not hasToken
         expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not hasToken 'a'})[5m] is null");
-        Assert.assertEquals("NOT (hasToken(appName, 'a'))", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("NOT (appName hasToken 'a')", expression.getLabelSelectorExpression().serializeToText(null));
     }
 
     @Test
@@ -309,7 +309,7 @@ public class MetricExpressionASTBuilderTest {
     public void test_MultipleSelector() {
         MetricExpression alertExpression = MetricExpressionASTBuilder.parse("avg(http-metrics.responseTime{appName='a', instance='localhost', url='http://localhost/test'})[5m] > 1%[-7m]");
         IExpression whereExpression = alertExpression.getLabelSelectorExpression();
-        Assert.assertEquals("(appName = 'a' AND instance = 'localhost' AND url = 'http://localhost/test')", whereExpression.serializeToText(null));
+        Assert.assertEquals("(appName = 'a') AND (instance = 'localhost') AND (url = 'http://localhost/test')", whereExpression.serializeToText(null));
     }
 
     @Test

--- a/server/pipeline/src/test/java/org/bithon/server/pipeline/common/transformer/ExpressionTransformerTest.java
+++ b/server/pipeline/src/test/java/org/bithon/server/pipeline/common/transformer/ExpressionTransformerTest.java
@@ -47,8 +47,8 @@ public class ExpressionTransformerTest {
 
 
     @Test
-    public void testLikeExpression() throws JsonProcessingException {
-        ITransformer transformer = new ExpressionTransformer("a LIKE '%bison%'", "bison", null);
+    public void test_ContainsExpression() throws JsonProcessingException {
+        ITransformer transformer = new ExpressionTransformer("a contains 'bison'", "bison", null);
 
         // deserialize from json to test deserialization
         ObjectMapper om = new ObjectMapper();

--- a/server/server-commons/src/main/java/org/bithon/server/commons/serializer/ExpressionDeserializer.java
+++ b/server/server-commons/src/main/java/org/bithon/server/commons/serializer/ExpressionDeserializer.java
@@ -71,8 +71,6 @@ public class ExpressionDeserializer extends JsonDeserializer<IExpression> {
                     BinaryExpressionDeserializer.deserialize(type, jsonNode, ComparisonExpression.NE::new);
                 case "in" ->
                     new ConditionalExpression.In(Expression.deserialize(jsonNode.get("lhs")), ExpressionListExpressionDeserializer.deserialize(jsonNode.get("rhs")));
-                case "like" ->
-                    BinaryExpressionDeserializer.deserialize(type, jsonNode, ConditionalExpression.Like::new);
                 case "literal" -> LiteralExpressionDeserializer.deserialize(jsonNode);
                 case "logical" -> LogicalExpressionDeserializer.deserialize(jsonNode);
                 case "identifier" -> IdentifierExpressionDeserializer.deserialize(jsonNode);

--- a/server/server-commons/src/test/java/org/bithon/server/commons/serializer/ExpressionDeserializerTest.java
+++ b/server/server-commons/src/test/java/org/bithon/server/commons/serializer/ExpressionDeserializerTest.java
@@ -48,8 +48,7 @@ public class ExpressionDeserializerTest {
                                                            new IdentifierExpression("a"),
                                                            new ConditionalExpression.In(new IdentifierExpression("a"),
                                                                                         new ExpressionList(LiteralExpression.ofLong(1),
-                                                                                                           LiteralExpression.ofLong(2))),
-                                                           new ConditionalExpression.Like(new IdentifierExpression("a"), LiteralExpression.ofString("c"))
+                                                                                                           LiteralExpression.ofLong(2)))
         );
 
         String jsonText = om.writeValueAsString(expression);

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
@@ -24,6 +24,7 @@ import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.server.commons.utils.SqlLikeExpression;
+import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,8 +86,8 @@ public class ClickHouseExpressionOptimizer extends ExpressionOptimizer.AbstractO
             if (leadingTokenIndex > 0 && trailingTokenIndex < pattenLength - 1) {
                 // This is the case that the pattern is surrounded by token separators,
                 // CK can use index for such LIKE expression.
-                return new ConditionalExpression.Like(input,
-                                                      LiteralExpression.ofString(SqlLikeExpression.toLikePattern(pattern)));
+                return new LikeOperator(input,
+                                        LiteralExpression.ofString(SqlLikeExpression.toLikePattern(pattern)));
             }
 
             // Otherwise, we try to extract tokens from the pattern to turn this function as
@@ -115,8 +116,8 @@ public class ClickHouseExpressionOptimizer extends ExpressionOptimizer.AbstractO
                 return expression;
             }
 
-            subExpressions.add(new ConditionalExpression.Like(input,
-                                                              LiteralExpression.ofString(SqlLikeExpression.toLikePattern(pattern))));
+            subExpressions.add(new LikeOperator(input,
+                                                LiteralExpression.ofString(SqlLikeExpression.toLikePattern(pattern))));
 
             return new LogicalExpression.AND(subExpressions);
         }

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
@@ -24,7 +24,7 @@ import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.server.commons.utils.SqlLikeExpression;
-import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
+import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
@@ -21,7 +21,7 @@ import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
-import org.bithon.component.commons.expression.function.Functions;
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.server.commons.utils.SqlLikeExpression;
 import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
@@ -39,7 +39,7 @@ public class ClickHouseExpressionOptimizer extends ExpressionOptimizer.AbstractO
     public IExpression visit(ConditionalExpression expression) {
         if (expression instanceof ConditionalExpression.StartsWith) {
             return new FunctionExpression(
-                Functions.getInstance().getFunction("startsWith"),
+                StringFunction.StartsWith.INSTANCE,
                 expression.getLhs(),
                 expression.getRhs()
             );
@@ -47,18 +47,20 @@ public class ClickHouseExpressionOptimizer extends ExpressionOptimizer.AbstractO
 
         if (expression instanceof ConditionalExpression.EndsWith) {
             return new FunctionExpression(
-                Functions.getInstance().getFunction("endsWith"),
+                StringFunction.EndsWith.INSTANCE,
                 expression.getLhs(),
                 expression.getRhs()
             );
         }
-
+        if (expression instanceof ConditionalExpression.HasToken) {
+            return this.visit(new FunctionExpression(StringFunction.HasToken.INSTANCE, expression.getLhs(), expression.getRhs()));
+        }
         return super.visit(expression);
     }
 
     @Override
     public IExpression visit(FunctionExpression expression) {
-        if (!"hasToken".equals(expression.getName())) {
+        if (!(expression.getFunction() instanceof StringFunction.HasToken)) {
             return super.visit(expression);
         }
         return HasTokenFunctionOptimizer.optimize(expression);

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/schema/AggregateFunctionColumn.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/schema/AggregateFunctionColumn.java
@@ -67,7 +67,8 @@ public class AggregateFunctionColumn implements IColumn {
         this.alias = StringUtils.isEmpty(alias) ? name : alias;
         this.dataType = dataType;
         this.aggregator = aggregator;
-        this.functionExpression = FunctionExpression.create("sum".equals(aggregator) ? SumMergeFunction.INSTANCE : CountMergeFunction.INSTANCE, name);
+        this.functionExpression = FunctionExpression.create("sum".equals(aggregator) ? SumMergeFunction.INSTANCE : CountMergeFunction.INSTANCE,
+                                                            IdentifierExpression.of(name, dataType));
     }
 
     @Override

--- a/server/storage-jdbc-clickhouse/src/test/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizerTest.java
+++ b/server/storage-jdbc-clickhouse/src/test/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizerTest.java
@@ -54,7 +54,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, 'SERVER-ERROR')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assert.assertEquals("(hasToken(a, 'SERVER') AND hasToken(a, 'ERROR') AND a like '%SERVER-ERROR%')",
+        Assert.assertEquals("hasToken(a, 'SERVER') AND hasToken(a, 'ERROR') AND (a like '%SERVER-ERROR%')",
                             expr.serializeToText(null));
     }
 
@@ -65,7 +65,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, '_SERVER')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assert.assertEquals("(hasToken(a, 'SERVER') AND a like '%\\_SERVER%')", expr.serializeToText(null));
+        Assert.assertEquals("hasToken(a, 'SERVER') AND (a like '%\\_SERVER%')", expr.serializeToText(null));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, 'ERROR_')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assert.assertEquals("(hasToken(a, 'ERROR') AND a like '%ERROR\\_%')", expr.serializeToText(null));
+        Assert.assertEquals("hasToken(a, 'ERROR') AND (a like '%ERROR\\_%')", expr.serializeToText(null));
     }
 
     @Test
@@ -85,6 +85,6 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, 'SERVER_ERROR') AND hasToken(a, 'EXCEPTION_CODE')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assert.assertEquals("(hasToken(a, 'SERVER') AND hasToken(a, 'ERROR') AND a like '%SERVER\\_ERROR%' AND hasToken(a, 'EXCEPTION') AND hasToken(a, 'CODE') AND a like '%EXCEPTION\\_CODE%')", expr.serializeToText(null));
+        Assert.assertEquals("hasToken(a, 'SERVER') AND hasToken(a, 'ERROR') AND (a like '%SERVER\\_ERROR%') AND hasToken(a, 'EXCEPTION') AND hasToken(a, 'CODE') AND (a like '%EXCEPTION\\_CODE%')", expr.serializeToText(null));
     }
 }

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
@@ -32,6 +32,7 @@ import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
+import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 import java.util.Arrays;
 
@@ -109,12 +110,12 @@ public class H2SqlDialect implements ISqlDialect {
                 }
 
                 if (expression instanceof ConditionalExpression.StartsWith) {
-                    return new ConditionalExpression.Like(expression.getLhs(),
-                                                          LiteralExpression.ofString(((LiteralExpression<?>) expression.getRhs()).asString() + "%"));
+                    return new LikeOperator(expression.getLhs(),
+                                            LiteralExpression.ofString(((LiteralExpression<?>) expression.getRhs()).asString() + "%"));
                 }
                 if (expression instanceof ConditionalExpression.EndsWith) {
-                    return new ConditionalExpression.Like(expression.getLhs(),
-                                                          LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
+                    return new LikeOperator(expression.getLhs(),
+                                            LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
                 }
                 return super.visit(expression);
             }
@@ -130,8 +131,8 @@ public class H2SqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(patternExpression, LiteralExpression.ofString("%")));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0),
+                                            patternExpression);
                 } else if ("endsWith".equals(expression.getName())) {
                     // H2 does not provide endsWith function, turns it into LIKE expression as: LIKE '%prefix'
                     IExpression patternExpression = expression.getArgs().get(1);
@@ -141,8 +142,8 @@ public class H2SqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(LiteralExpression.ofString("%"), patternExpression));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0),
+                                            patternExpression);
 
                 } else if ("hasToken".equals(expression.getName())) {
                     // H2 does not provide hasToken function, turns it into LIKE expression as: LIKE '%prefix'
@@ -153,8 +154,8 @@ public class H2SqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(LiteralExpression.ofString("%"), patternExpression));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0),
+                                            patternExpression);
                 }
 
                 return super.visit(expression);

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
@@ -26,6 +26,7 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MapAccessExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
@@ -116,6 +117,9 @@ public class H2SqlDialect implements ISqlDialect {
                 if (expression instanceof ConditionalExpression.EndsWith) {
                     return new LikeOperator(expression.getLhs(),
                                             LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
+                }
+                if (expression instanceof ConditionalExpression.HasToken) {
+                    return this.visit(new FunctionExpression(StringFunction.HasToken.INSTANCE, expression.getLhs(), expression.getRhs()));
                 }
                 return super.visit(expression);
             }

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
@@ -31,8 +31,8 @@ import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
-import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 import java.util.Arrays;
 

--- a/server/storage-jdbc-h2/src/test/java/org/bithon/server/storage/jdbc/h2/H2SqlDialectTest.java
+++ b/server/storage-jdbc-h2/src/test/java/org/bithon/server/storage/jdbc/h2/H2SqlDialectTest.java
@@ -20,7 +20,7 @@ import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
-import org.bithon.component.commons.expression.function.Functions;
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ public class H2SqlDialectTest {
 
     @Test
     public void testTransformStartsWith() {
-        IExpression expr = new H2SqlDialect().transform(new FunctionExpression(Functions.getInstance().getFunction("startsWith"),
+        IExpression expr = new H2SqlDialect().transform(new FunctionExpression(StringFunction.StartsWith.INSTANCE,
                                                                                new IdentifierExpression("a"),
                                                                                LiteralExpression.ofString("1231")));
         Assert.assertEquals("a like '1231%'", expr.serializeToText(null));
@@ -40,7 +40,7 @@ public class H2SqlDialectTest {
 
     @Test
     public void testTransformEndsWith() {
-        IExpression expr = new H2SqlDialect().transform(new FunctionExpression(Functions.getInstance().getFunction("endsWith"),
+        IExpression expr = new H2SqlDialect().transform(new FunctionExpression(StringFunction.EndsWith.INSTANCE,
                                                                                new IdentifierExpression("a"),
                                                                                LiteralExpression.ofString("1231")));
         Assert.assertEquals("a like '%1231'", expr.serializeToText(null));
@@ -48,7 +48,7 @@ public class H2SqlDialectTest {
 
     @Test
     public void testHasToken() {
-        IExpression expr = new H2SqlDialect().transform(new FunctionExpression(Functions.getInstance().getFunction("hasToken"),
+        IExpression expr = new H2SqlDialect().transform(new FunctionExpression(StringFunction.HasToken.INSTANCE,
                                                                                new IdentifierExpression("a"),
                                                                                LiteralExpression.ofString("1231")));
         Assert.assertEquals("a like '%1231%'", expr.serializeToText(null));

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
@@ -31,8 +31,8 @@ import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
-import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 import java.util.Arrays;
 

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
@@ -32,6 +32,7 @@ import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
+import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 import java.util.Arrays;
 
@@ -109,12 +110,12 @@ public class MySQLSqlDialect implements ISqlDialect {
                 }
 
                 if (expression instanceof ConditionalExpression.StartsWith) {
-                    return new ConditionalExpression.Like(expression.getLhs(),
-                                                          LiteralExpression.ofString(((LiteralExpression<?>) expression.getRhs()).asString() + "%"));
+                    return new LikeOperator(expression.getLhs(),
+                                            LiteralExpression.ofString(((LiteralExpression<?>) expression.getRhs()).asString() + "%"));
                 }
                 if (expression instanceof ConditionalExpression.EndsWith) {
-                    return new ConditionalExpression.Like(expression.getLhs(),
-                                                          LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
+                    return new LikeOperator(expression.getLhs(),
+                                            LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
                 }
 
                 return super.visit(expression);
@@ -131,8 +132,8 @@ public class MySQLSqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(patternExpression, LiteralExpression.ofString("%")));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0),
+                                            patternExpression);
                 } else if ("endsWith".equals(expression.getName())) {
                     // MySQL does not provide endsWith function, turns it into LIKE expression as: LIKE '%prefix'
                     IExpression patternExpression = expression.getArgs().get(1);
@@ -142,8 +143,8 @@ public class MySQLSqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(LiteralExpression.ofString("%"), patternExpression));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0),
+                                            patternExpression);
                 }
 
                 return super.visit(expression);

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
@@ -26,6 +26,7 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MapAccessExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
@@ -117,7 +118,9 @@ public class MySQLSqlDialect implements ISqlDialect {
                     return new LikeOperator(expression.getLhs(),
                                             LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
                 }
-
+                if (expression instanceof ConditionalExpression.HasToken) {
+                    return this.visit(new FunctionExpression(StringFunction.HasToken.INSTANCE, expression.getLhs(), expression.getRhs()));
+                }
                 return super.visit(expression);
             }
 

--- a/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialect.java
+++ b/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialect.java
@@ -31,6 +31,7 @@ import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
 
 import java.util.Arrays;
@@ -110,12 +111,12 @@ public class PostgresqlDialect implements ISqlDialect {
                 }
 
                 if (expression instanceof ConditionalExpression.StartsWith) {
-                    return new ConditionalExpression.Like(expression.getLhs(),
-                                                          LiteralExpression.ofString(((LiteralExpression<?>) expression.getRhs()).asString() + "%"));
+                    return new LikeOperator(expression.getLhs(),
+                                            LiteralExpression.ofString(((LiteralExpression<?>) expression.getRhs()).asString() + "%"));
                 }
                 if (expression instanceof ConditionalExpression.EndsWith) {
-                    return new ConditionalExpression.Like(expression.getLhs(),
-                                                          LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
+                    return new LikeOperator(expression.getLhs(),
+                                            LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
                 }
                 return super.visit(expression);
             }
@@ -131,8 +132,7 @@ public class PostgresqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(patternExpression, LiteralExpression.ofString("%")));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0), patternExpression);
                 } else if ("endsWith".equals(expression.getName())) {
                     // H2 does not provide endsWith function, turns it into LIKE expression as: LIKE '%prefix'
                     IExpression patternExpression = expression.getArgs().get(1);
@@ -142,8 +142,7 @@ public class PostgresqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(LiteralExpression.ofString("%"), patternExpression));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0), patternExpression);
 
                 } else if ("hasToken".equals(expression.getName())) {
                     // H2 does not provide hasToken function, turns it into LIKE expression as: LIKE '%prefix'
@@ -154,8 +153,7 @@ public class PostgresqlDialect implements ISqlDialect {
                         patternExpression = new FunctionExpression(Functions.getInstance().getFunction("concat"),
                                                                    Arrays.asList(LiteralExpression.ofString("%"), patternExpression));
                     }
-                    return new ConditionalExpression.Like(expression.getArgs().get(0),
-                                                          patternExpression);
+                    return new LikeOperator(expression.getArgs().get(0), patternExpression);
                 }
 
                 return super.visit(expression);

--- a/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialect.java
+++ b/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialect.java
@@ -26,6 +26,7 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MapAccessExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
@@ -117,6 +118,9 @@ public class PostgresqlDialect implements ISqlDialect {
                 if (expression instanceof ConditionalExpression.EndsWith) {
                     return new LikeOperator(expression.getLhs(),
                                             LiteralExpression.ofString("%" + ((LiteralExpression<?>) expression.getRhs()).asString()));
+                }
+                if (expression instanceof ConditionalExpression.HasToken) {
+                    return this.visit(new FunctionExpression(StringFunction.HasToken.INSTANCE, expression.getLhs(), expression.getRhs()));
                 }
                 return super.visit(expression);
             }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/Expression2Sql.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/Expression2Sql.java
@@ -25,6 +25,7 @@ import org.bithon.component.commons.expression.serialization.ExpressionSerialize
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.utils.SqlLikeExpression;
 import org.bithon.server.storage.datasource.ISchema;
+import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 /**
  * @author frank.chen021@outlook.com
@@ -109,8 +110,8 @@ public class Expression2Sql extends ExpressionSerializer {
 
         String pattern = ((LiteralExpression<?>) expression.getRhs()).asString();
 
-        serializeBinary(new ConditionalExpression.Like(expression.getLhs(),
-                                                       LiteralExpression.ofString(SqlLikeExpression.toLikePattern(pattern))));
+        serializeBinary(new LikeOperator(expression.getLhs(),
+                                         LiteralExpression.ofString(SqlLikeExpression.toLikePattern(pattern))));
 
         return false;
     }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/Expression2Sql.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/Expression2Sql.java
@@ -25,7 +25,6 @@ import org.bithon.component.commons.expression.serialization.ExpressionSerialize
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.utils.SqlLikeExpression;
 import org.bithon.server.storage.datasource.ISchema;
-import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 /**
  * @author frank.chen021@outlook.com

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/LikeOperator.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/LikeOperator.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package org.bithon.server.storage.jdbc.common.expression;
+package org.bithon.server.storage.jdbc.common.dialect;
 
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.IEvaluationContext;

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/MapAccessExpressionTransformer.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/MapAccessExpressionTransformer.java
@@ -23,7 +23,6 @@ import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MapAccessExpression;
 import org.bithon.component.commons.utils.StringUtils;
-import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 /**
  * @author frank.chen021@outlook.com

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/MapAccessExpressionTransformer.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/MapAccessExpressionTransformer.java
@@ -23,6 +23,7 @@ import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MapAccessExpression;
 import org.bithon.component.commons.utils.StringUtils;
+import org.bithon.server.storage.jdbc.common.expression.LikeOperator;
 
 /**
  * @author frank.chen021@outlook.com
@@ -42,7 +43,7 @@ public class MapAccessExpressionTransformer {
 
         String mapName = ((IdentifierExpression) mapAccessExpression.getMap()).getIdentifier();
         String key = mapAccessExpression.getKey();
-        String value = ((LiteralExpression) expression.getRhs()).getValue().toString();
+        String value = ((LiteralExpression<?>) expression.getRhs()).getValue().toString();
 
         if (!(expression instanceof ComparisonExpression.EQ)) {
             // Since we store JSON formatted string in H2, it's hard to implement other operators except EQ
@@ -50,7 +51,7 @@ public class MapAccessExpressionTransformer {
             throw new UnsupportedOperationException(StringUtils.format("H2 does not support operators other than EQ on column [%s]", mapName));
         }
 
-        return new ConditionalExpression.Like(new IdentifierExpression(mapName),
-                                              LiteralExpression.ofString("%\"" + key + "\":\"" + value + "\"%"));
+        return new LikeOperator(new IdentifierExpression(mapName),
+                                LiteralExpression.ofString("%\"" + key + "\":\"" + value + "\"%"));
     }
 }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/expression/LikeOperator.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/expression/LikeOperator.java
@@ -1,0 +1,40 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.storage.jdbc.common.expression;
+
+import org.bithon.component.commons.expression.ConditionalExpression;
+import org.bithon.component.commons.expression.IEvaluationContext;
+import org.bithon.component.commons.expression.IExpression;
+
+/**
+ * The Like operator in SQL
+ */
+public class LikeOperator extends ConditionalExpression {
+
+    public LikeOperator(IExpression left, IExpression right) {
+        this("like", left, right);
+    }
+
+    public LikeOperator(String operator, IExpression left, IExpression right) {
+        super(operator, left, right);
+    }
+
+    @Override
+    public Object evaluate(IEvaluationContext context) {
+        throw new UnsupportedOperationException("Like is not designed for evaluation. Use 'contains' instead.");
+    }
+}

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilderTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/metric/QueryExpressionBuilderTest.java
@@ -884,7 +884,7 @@ public class QueryExpressionBuilderTest {
                             SELECT "appName",
                                    count(1) AS "cnt"
                             FROM "bithon_jvm_metrics"
-                            WHERE "timestamp" >= '2024-07-26T21:22:00.000+08:00' AND "timestamp" < '2024-07-26T21:32:00.000+08:00' AND ("bithon_jvm_metrics"."totalCount" > 1048576 AND "bithon_jvm_metrics"."totalCount" < 3600 AND "bithon_jvm_metrics"."totalCount" < 0.5)
+                            WHERE "timestamp" >= '2024-07-26T21:22:00.000+08:00' AND "timestamp" < '2024-07-26T21:32:00.000+08:00' AND ("bithon_jvm_metrics"."totalCount" > 1048576) AND ("bithon_jvm_metrics"."totalCount" < 3600) AND ("bithon_jvm_metrics"."totalCount" < 0.5)
                             GROUP BY "appName"
                             ORDER BY "appName" asc
                             """.trim(),

--- a/server/storage/src/main/antlr4/org/bithon/server/storage/common/expression/Expression.g4
+++ b/server/storage/src/main/antlr4/org/bithon/server/storage/common/expression/Expression.g4
@@ -26,7 +26,7 @@ expression
 // The 'endsWith' and 'startsWith' functions are supported in previous version,
 // but now they're defined as predicate, to make sure the backward compatibility, we put them in the expression below
 functionExpressionDecl
-   : (IDENTIFIER | ENDSWITH | STARTSWITH) expressionListDecl
+   : (IDENTIFIER | ENDSWITH | STARTSWITH | HASTOKEN) expressionListDecl
    ;
 
 notExpressionDecl
@@ -66,7 +66,7 @@ simplePredicate
   ;
 
 extraPredicate
-  : LIKE | STARTSWITH | ENDSWITH | CONTAINS
+  : STARTSWITH | ENDSWITH | CONTAINS | HASTOKEN
   ;
 
 notPredicate
@@ -107,7 +107,7 @@ EQ: '=';
 AND: A N D;
 OR: O R;
 IN: I N;
-LIKE: L I K E;
+HASTOKEN: H A S T O K E N;
 ENDSWITH: E N D S W I T H;
 STARTSWITH: S T A R T S W I T H;
 CONTAINS: C O N T A I N S;

--- a/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
@@ -37,6 +37,7 @@ import org.bithon.component.commons.expression.TernaryExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
 import org.bithon.component.commons.expression.function.IFunction;
 import org.bithon.component.commons.expression.function.IFunctionProvider;
+import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.expression.function.builtin.TimeFunction;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.component.commons.expression.validation.ExpressionValidator;
@@ -45,6 +46,7 @@ import org.bithon.component.commons.expression.validation.IIdentifierProvider;
 import org.bithon.component.commons.utils.HumanReadableDuration;
 import org.bithon.component.commons.utils.HumanReadableNumber;
 import org.bithon.component.commons.utils.HumanReadablePercentage;
+import org.bithon.component.commons.utils.Preconditions;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.antlr4.SyntaxErrorListener;
 import org.bithon.server.commons.antlr4.TokenUtils;
@@ -234,7 +236,10 @@ public class ExpressionASTBuilder {
             public IExpression visitExtraPredicate(ExpressionParser.ExtraPredicateContext ctx) {
                 TerminalNode op = (TerminalNode) ctx.getChild(0);
                 return switch (op.getSymbol().getType()) {
-                    case ExpressionLexer.LIKE -> new ConditionalExpression.Like(left, right);
+                    case ExpressionLexer.HASTOKEN -> {
+                        Preconditions.checkIfTrue(right instanceof LiteralExpression, "The 2nd parameter of hasToken must be a string constant");
+                        yield new FunctionExpression(StringFunction.HasToken.INSTANCE, left, right);
+                    }
                     case ExpressionLexer.STARTSWITH -> new ConditionalExpression.StartsWith(left, right);
                     case ExpressionLexer.ENDSWITH -> new ConditionalExpression.EndsWith(left, right);
                     case ExpressionLexer.CONTAINS -> new ConditionalExpression.Contains(left, right);
@@ -245,10 +250,6 @@ public class ExpressionASTBuilder {
             @Override
             public IExpression visitNotPredicate(ExpressionParser.NotPredicateContext ctx) {
                 IExpression expr = ctx.extraPredicate().accept(this);
-                if (expr instanceof ConditionalExpression.Like) {
-                    return new ConditionalExpression.NotLike(((ConditionalExpression.Like) expr).getLhs(),
-                                                             ((ConditionalExpression.Like) expr).getRhs());
-                }
                 return new LogicalExpression.NOT(expr);
             }
 

--- a/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/common/expression/ExpressionASTBuilder.java
@@ -37,7 +37,6 @@ import org.bithon.component.commons.expression.TernaryExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
 import org.bithon.component.commons.expression.function.IFunction;
 import org.bithon.component.commons.expression.function.IFunctionProvider;
-import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.expression.function.builtin.TimeFunction;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
 import org.bithon.component.commons.expression.validation.ExpressionValidator;
@@ -238,7 +237,7 @@ public class ExpressionASTBuilder {
                 return switch (op.getSymbol().getType()) {
                     case ExpressionLexer.HASTOKEN -> {
                         Preconditions.checkIfTrue(right instanceof LiteralExpression, "The 2nd parameter of hasToken must be a string constant");
-                        yield new FunctionExpression(StringFunction.HasToken.INSTANCE, left, right);
+                        yield new ConditionalExpression.HasToken(left, right);
                     }
                     case ExpressionLexer.STARTSWITH -> new ConditionalExpression.StartsWith(left, right);
                     case ExpressionLexer.ENDSWITH -> new ConditionalExpression.EndsWith(left, right);

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/IColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/IColumn.java
@@ -87,7 +87,7 @@ public interface IColumn extends IIdentifier {
      * so this interface provides an opportunity for subclasses to override the default aggregator name
      */
     default IExpression createAggregateFunctionExpression(IFunction function) {
-        return new FunctionExpression(function, new IdentifierExpression(getName()));
+        return new FunctionExpression(function, IdentifierExpression.of(getName(), getDataType()));
     }
 
     IDataType getDataType();

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateLastColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/last/AggregateLastColumn.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import org.bithon.component.commons.expression.FunctionExpression;
+import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
 import org.bithon.server.storage.datasource.aggregator.LongLastAggregator;
 import org.bithon.server.storage.datasource.aggregator.NumberAggregator;
@@ -44,7 +45,7 @@ public abstract class AggregateLastColumn implements IAggregatableColumn {
                                String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Last.INSTANCE, name);
+        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Last.INSTANCE, IdentifierExpression.of(name, getDataType()));
     }
 
     @Override

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/max/AggregateMaxColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/max/AggregateMaxColumn.java
@@ -19,6 +19,7 @@ package org.bithon.server.storage.datasource.column.aggregatable.max;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import org.bithon.component.commons.expression.FunctionExpression;
+import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
 import org.bithon.server.storage.datasource.column.aggregatable.IAggregatableColumn;
 
@@ -40,7 +41,7 @@ public abstract class AggregateMaxColumn implements IAggregatableColumn {
                               String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Max.INSTANCE, name);
+        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Max.INSTANCE, IdentifierExpression.of(name, getDataType()));
     }
 
     @JsonIgnore

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/min/AggregateMinColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/min/AggregateMinColumn.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import org.bithon.component.commons.expression.FunctionExpression;
+import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
 import org.bithon.server.storage.datasource.column.aggregatable.IAggregatableColumn;
 
@@ -45,7 +46,7 @@ public abstract class AggregateMinColumn implements IAggregatableColumn {
 
         // For IMetricSpec, the `name` property is the right text mapped a column in the underlying database,
         // So the two parameters of the following ctor are all `name` properties
-        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Min.INSTANCE, name);
+        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Min.INSTANCE, IdentifierExpression.of(name, getDataType()));
     }
 
     @JsonIgnore

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateSumColumn.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/column/aggregatable/sum/AggregateSumColumn.java
@@ -19,6 +19,7 @@ package org.bithon.server.storage.datasource.column.aggregatable.sum;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import org.bithon.component.commons.expression.FunctionExpression;
+import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
 import org.bithon.server.storage.datasource.column.aggregatable.IAggregatableColumn;
 
@@ -40,7 +41,7 @@ public abstract class AggregateSumColumn implements IAggregatableColumn {
                               String alias) {
         this.name = name;
         this.alias = alias == null ? name : alias;
-        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Sum.INSTANCE, name);
+        this.aggregateFunctionExpression = FunctionExpression.create(AggregateFunction.Sum.INSTANCE, IdentifierExpression.of(name, getDataType()));
     }
 
     @JsonIgnore

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionASTBuilderTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionASTBuilderTest.java
@@ -194,9 +194,9 @@ public class ExpressionASTBuilderTest {
     public void test_StringLiteralUnEscaped() {
         // At the AST layer, the string literal does not hold escape characters.
         // The business layer (the layer that uses the AST) needs to handle the escaping
-        Assert.assertEquals("message like 'a''", ExpressionASTBuilder.builder()
-                                                                       .build("message LIKE 'a\\''")
-                                                                       .serializeToText(null));
+        Assert.assertEquals("message contains 'a''", ExpressionASTBuilder.builder()
+                                                                         .build("message contains 'a\\''")
+                                                                         .serializeToText(null));
     }
 
     @Test

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionASTBuilderTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionASTBuilderTest.java
@@ -131,6 +131,16 @@ public class ExpressionASTBuilderTest {
     }
 
     @Test
+    public void test_LogicalExpression_ConsecutiveAND_WithBrace() {
+        IExpression expr = ExpressionASTBuilder.builder().build("(a = 1) AND (b = 1 AND c = 1 AND d = 1)");
+        Assert.assertTrue(expr instanceof LogicalExpression.AND);
+
+        // Logical AND is flattened
+        Assert.assertEquals(4, ((LogicalExpression.AND) expr).getOperands().size());
+        Assert.assertEquals("(a = 1) AND (b = 1) AND (c = 1) AND (d = 1)", expr.serializeToText(null));
+    }
+
+    @Test
     public void test_LogicalExpression_OR() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 1 OR b = 1");
         Assert.assertTrue(expr instanceof LogicalExpression.OR);

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/optimizer/ExpressionOptimizerTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/optimizer/ExpressionOptimizerTest.java
@@ -343,8 +343,8 @@ public class ExpressionOptimizerTest {
 
     @Test
     public void test_Not_NotLike() {
-        IExpression expr = ExpressionASTBuilder.builder().build("not a not like 'a'");
-        Assert.assertEquals("a like 'a'", expr.serializeToText(null));
+        IExpression expr = ExpressionASTBuilder.builder().build("not a not contains 'a'");
+        Assert.assertEquals("a contains 'a'", expr.serializeToText(null));
     }
 
     @Test

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/optimizer/ExpressionOptimizerTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/optimizer/ExpressionOptimizerTest.java
@@ -260,7 +260,7 @@ public class ExpressionOptimizerTest {
     public void test_OptimizeOR_4() {
         IExpression expr = ExpressionASTBuilder.builder().build("2 > 1 OR 1 = 1");
 
-        Assert.assertTrue(expr instanceof LiteralExpression);
+        Assert.assertTrue(expr instanceof LiteralExpression.BooleanLiteral);
         Assert.assertEquals("true", expr.serializeToText(null));
     }
 
@@ -275,14 +275,14 @@ public class ExpressionOptimizerTest {
     public void test_OptimizeOR_6() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 'God' OR 1 > 2 OR b = 'c'");
 
-        Assert.assertEquals("(a = 'God' OR b = 'c')", expr.serializeToText(null));
+        Assert.assertEquals("(a = 'God') OR (b = 'c')", expr.serializeToText(null));
     }
 
     @Test
     public void test_OptimizeLogical() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 'God' OR 1 > 2 OR b = 'c' AND 1 = 1");
 
-        Assert.assertEquals("(a = 'God' OR b = 'c')", expr.serializeToText(null));
+        Assert.assertEquals("(a = 'God') OR (b = 'c')", expr.serializeToText(null));
     }
 
     @Test


### PR DESCRIPTION
1. previously this is supported by a function, now it's supported as operator. both query and alerting module are updated.
   ```sql
   message hasToken 'WARN'
   --- alerting expression
   count(datasource.field{message hasToken 'WARN'}) > 0
   ```
3. LIKE operator is removed from grammar. `contains` is provided previously as a replacement. but it's kept in the jdbc layer for expression optimization and transformation.