### PR TITLE
Prechanges to support complex expression on metric expression

### DIFF
--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArithmeticExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArithmeticExpression.java
@@ -141,7 +141,17 @@ public abstract class ArithmeticExpression extends BinaryExpression {
 
     public static class DIV extends ArithmeticExpression {
         public DIV(IExpression lhs, IExpression rhs) {
-            super("/", lhs, rhs);
+            super("/", lhs, validNotZero(rhs));
+        }
+
+        private static IExpression validNotZero(IExpression rhs) {
+            if (rhs instanceof LiteralExpression) {
+                Object value = ((LiteralExpression<?>) rhs).getValue();
+                if (value instanceof Number && ((Number) value).doubleValue() == 0) {
+                    throw new ArithmeticException("Divisor CAN'T be ZERO");
+                }
+            }
+            return rhs;
         }
 
         @Override

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArrayAccessExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArrayAccessExpression.java
@@ -16,6 +16,7 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 import org.bithon.component.commons.utils.StringUtils;
 
 import java.util.Collection;
@@ -140,5 +141,10 @@ public class ArrayAccessExpression implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArrayAccessExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ArrayAccessExpression.java
@@ -145,6 +145,9 @@ public class ArrayAccessExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        this.array.serializeToText(serializer);
+        serializer.append('[');
+        serializer.append(index);
+        serializer.append(']');
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/BinaryExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/BinaryExpression.java
@@ -60,6 +60,6 @@ public abstract class BinaryExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.serializeBinary(this);
+        serializer.serialize(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/BinaryExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/BinaryExpression.java
@@ -16,6 +16,8 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
+
 /**
  * @author frank.chen021@outlook.com
  * @date 2023/4/7 20:17
@@ -54,5 +56,10 @@ public abstract class BinaryExpression implements IExpression {
     @Override
     public String getType() {
         return type;
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.serializeBinary(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ExpressionList.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ExpressionList.java
@@ -77,6 +77,15 @@ public class ExpressionList implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        serializer.append('(');
+        {
+            for (int i = 0, size = expressions.size(); i < size; i++) {
+                if (i > 0) {
+                    serializer.append(", ");
+                }
+                expressions.get(i).serializeToText(serializer);
+            }
+        }
+        serializer.append(')');
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ExpressionList.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ExpressionList.java
@@ -16,6 +16,8 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -71,5 +73,10 @@ public class ExpressionList implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/FunctionExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/FunctionExpression.java
@@ -17,6 +17,7 @@
 package org.bithon.component.commons.expression;
 
 import org.bithon.component.commons.expression.function.IFunction;
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 import org.bithon.component.commons.utils.Preconditions;
 
 import java.util.ArrayList;
@@ -93,6 +94,11 @@ public class FunctionExpression implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 
     public static FunctionExpression create(IFunction function, IExpression... args) {

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/FunctionExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/FunctionExpression.java
@@ -98,7 +98,7 @@ public class FunctionExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        serializer.serialize(this);
     }
 
     public static FunctionExpression create(IFunction function, IExpression... args) {

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/IExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/IExpression.java
@@ -17,8 +17,7 @@
 package org.bithon.component.commons.expression;
 
 import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
-
-import java.util.function.Function;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 
 /**
  * @author frank.chen021@outlook.com
@@ -37,11 +36,14 @@ public interface IExpression {
     <T> T accept(IExpressionVisitor<T> visitor);
 
     default String serializeToText() {
-        return serializeToText((s) -> "\"" + s + "\"");
+        return serializeToText(IdentifierQuotaStrategy.DOUBLE_QUOTE);
     }
 
-    default String serializeToText(Function<String, String> quoteIdentifier) {
-        ExpressionSerializer serializer = new ExpressionSerializer(quoteIdentifier);
-        return serializer.serialize(this);
+    default String serializeToText(IdentifierQuotaStrategy strategy) {
+        ExpressionSerializer serializer = new ExpressionSerializer(strategy);
+        serializeToText(serializer);
+        return serializer.getSerializedText();
     }
+
+    void serializeToText(ExpressionSerializer serializer);
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/IdentifierExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/IdentifierExpression.java
@@ -97,7 +97,7 @@ public class IdentifierExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        serializer.serialize(this);
     }
 
     @Override

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/IdentifierExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/IdentifierExpression.java
@@ -16,6 +16,8 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
+
 /**
  * @author frank.chen021@outlook.com
  * @date 2023/4/7 20:16
@@ -91,6 +93,11 @@ public class IdentifierExpression implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 
     @Override

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/LiteralExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/LiteralExpression.java
@@ -16,6 +16,7 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 import org.bithon.component.commons.expression.validation.ExpressionValidationException;
 import org.bithon.component.commons.utils.HumanReadableDuration;
 import org.bithon.component.commons.utils.HumanReadableNumber;
@@ -154,6 +155,11 @@ public abstract class LiteralExpression<T> implements IExpression {
     @Override
     public String toString() {
         return value.toString();
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 
     public static class StringLiteral extends LiteralExpression<String> {

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/LiteralExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/LiteralExpression.java
@@ -159,7 +159,7 @@ public abstract class LiteralExpression<T> implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        serializer.serialize(this);
     }
 
     public static class StringLiteral extends LiteralExpression<String> {

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/LogicalExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/LogicalExpression.java
@@ -16,6 +16,7 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 import org.bithon.component.commons.utils.StringUtils;
 
 import java.util.ArrayList;
@@ -92,6 +93,11 @@ public abstract class LogicalExpression implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 
     public abstract LogicalExpression copy(List<IExpression> expressionList);

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/LogicalExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/LogicalExpression.java
@@ -97,7 +97,7 @@ public abstract class LogicalExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        serializer.serialize(this);
     }
 
     public abstract LogicalExpression copy(List<IExpression> expressionList);

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/MacroExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/MacroExpression.java
@@ -65,6 +65,6 @@ public class MacroExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        serializer.serialize(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/MacroExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/MacroExpression.java
@@ -16,6 +16,8 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
+
 /**
  * @author Frank Chen
  * @date 26/8/23 9:37 pm
@@ -59,5 +61,10 @@ public class MacroExpression implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/MapAccessExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/MapAccessExpression.java
@@ -86,6 +86,11 @@ public class MapAccessExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        this.map.serializeToText(serializer);
+        serializer.append('[');
+        serializer.append('\'');
+        serializer.append(this.key);
+        serializer.append('\'');
+        serializer.append(']');
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/MapAccessExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/MapAccessExpression.java
@@ -16,6 +16,7 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 import org.bithon.component.commons.utils.ReflectionUtils;
 
 import java.util.Map;
@@ -81,5 +82,10 @@ public class MapAccessExpression implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/TernaryExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/TernaryExpression.java
@@ -16,6 +16,8 @@
 
 package org.bithon.component.commons.expression;
 
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
+
 /**
  * @author frank.chen021@outlook.com
  * @date 16/7/24 3:36 pm
@@ -88,5 +90,10 @@ public class TernaryExpression implements IExpression {
     @Override
     public <T> T accept(IExpressionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.visit(this);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/TernaryExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/TernaryExpression.java
@@ -94,6 +94,14 @@ public class TernaryExpression implements IExpression {
 
     @Override
     public void serializeToText(ExpressionSerializer serializer) {
-        serializer.visit(this);
+        this.conditionExpression.serializeToText(serializer);
+        serializer.append(' ');
+        serializer.append('?');
+        serializer.append(' ');
+        this.trueExpression.serializeToText(serializer);
+        serializer.append(' ');
+        serializer.append(':');
+        serializer.append(' ');
+        this.falseExpression.serializeToText(serializer);
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
@@ -33,7 +33,6 @@ import org.bithon.component.commons.expression.TernaryExpression;
 import org.bithon.component.commons.utils.StringUtils;
 
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * @author frank.chen021@outlook.com
@@ -42,10 +41,10 @@ import java.util.function.Function;
 public class ExpressionSerializer implements IExpressionInDepthVisitor {
     protected final StringBuilder sb = new StringBuilder(512);
 
-    protected final Function<String, String> quoteIdentifier;
+    protected final IdentifierQuotaStrategy quoteIdentifier;
     private final String qualifier;
 
-    public ExpressionSerializer(Function<String, String> quoteIdentifier) {
+    public ExpressionSerializer(IdentifierQuotaStrategy quoteIdentifier) {
         this(null, quoteIdentifier);
     }
 
@@ -53,13 +52,17 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
      * @param qualifier       the qualifier of the identifier if the identifier is not a qualified name
      * @param quoteIdentifier if the identifier should be quoted
      */
-    public ExpressionSerializer(String qualifier, Function<String, String> quoteIdentifier) {
+    public ExpressionSerializer(String qualifier, IdentifierQuotaStrategy quoteIdentifier) {
         this.qualifier = qualifier == null ? null : qualifier.trim();
         this.quoteIdentifier = quoteIdentifier;
     }
 
     public String serialize(IExpression expression) {
         expression.accept(this);
+        return sb.toString();
+    }
+
+    public String getSerializedText() {
         return sb.toString();
     }
 
@@ -134,7 +137,7 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
 
     protected void quoteIdentifierIfNeeded(String name) {
         if (quoteIdentifier != null) {
-            sb.append(quoteIdentifier.apply(name));
+            sb.append(quoteIdentifier.quoteIdentifier(name));
         } else {
             sb.append(name);
         }
@@ -231,7 +234,7 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
         sb.append(str);
     }
 
-    protected boolean serializeBinary(BinaryExpression expression) {
+    public boolean serializeBinary(BinaryExpression expression) {
         IExpression left = expression.getLhs();
         if (left instanceof BinaryExpression) {
             sb.append('(');

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/ExpressionSerializer.java
@@ -16,31 +16,22 @@
 
 package org.bithon.component.commons.expression.serialization;
 
-import org.bithon.component.commons.expression.ArithmeticExpression;
-import org.bithon.component.commons.expression.ArrayAccessExpression;
 import org.bithon.component.commons.expression.BinaryExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
-import org.bithon.component.commons.expression.ExpressionList;
 import org.bithon.component.commons.expression.FunctionExpression;
 import org.bithon.component.commons.expression.IExpression;
-import org.bithon.component.commons.expression.IExpressionInDepthVisitor;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.MacroExpression;
-import org.bithon.component.commons.expression.MapAccessExpression;
-import org.bithon.component.commons.expression.TernaryExpression;
 import org.bithon.component.commons.utils.StringUtils;
-
-import java.util.List;
 
 /**
  * @author frank.chen021@outlook.com
  * @date 2023/8/18 21:08
  */
-public class ExpressionSerializer implements IExpressionInDepthVisitor {
+public class ExpressionSerializer {
     protected final StringBuilder sb = new StringBuilder(512);
-
     protected final IdentifierQuotaStrategy quoteIdentifier;
     private final String qualifier;
 
@@ -58,16 +49,27 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
     }
 
     public String serialize(IExpression expression) {
-        expression.accept(this);
+        expression.serializeToText(this);
         return sb.toString();
     }
 
-    public String getSerializedText() {
+    public final void append(int index) {
+        sb.append(index);
+    }
+
+    public final void append(char c) {
+        sb.append(c);
+    }
+
+    public final void append(String str) {
+        sb.append(str);
+    }
+
+    public final String getSerializedText() {
         return sb.toString();
     }
 
-    @Override
-    public boolean visit(LiteralExpression<?> expression) {
+    public void serialize(LiteralExpression<?> expression) {
         Object value = expression.getValue();
         if (expression instanceof LiteralExpression.StringLiteral) {
             sb.append('\'');
@@ -76,13 +78,10 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
         } else {
             sb.append(value);
         }
-        return false;
     }
 
-    @Override
-    public boolean visit(LogicalExpression expression) {
+    public void serialize(LogicalExpression expression) {
         boolean needClose = false;
-
         String concatOperator = expression.getOperator();
         if (expression instanceof LogicalExpression.NOT) {
             sb.append("NOT ");
@@ -92,34 +91,28 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
                 sb.append('(');
             }
         }
-
         for (int i = 0, size = expression.getOperands().size(); i < size; i++) {
             if (i > 0) {
                 sb.append(' ');
                 sb.append(concatOperator);
                 sb.append(' ');
             }
-
             IExpression operand = expression.getOperands().get(i);
             if (operand instanceof ConditionalExpression || operand instanceof LogicalExpression) {
                 sb.append('(');
-                operand.accept(this);
+                operand.serializeToText(this);
                 sb.append(')');
             } else {
                 // Might be FunctionExpression
-                operand.accept(this);
+                operand.serializeToText(this);
             }
         }
-
         if (needClose) {
             sb.append(')');
         }
-
-        return false;
     }
 
-    @Override
-    public boolean visit(IdentifierExpression expression) {
+    public void serialize(IdentifierExpression expression) {
         if (StringUtils.hasText(qualifier)
             && !expression.isQualified()) {
             quoteIdentifierIfNeeded(qualifier);
@@ -132,7 +125,6 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
             }
             quoteIdentifierIfNeeded(expression.getIdentifier());
         }
-        return false;
     }
 
     protected void quoteIdentifierIfNeeded(String name) {
@@ -143,36 +135,7 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
         }
     }
 
-    @Override
-    public boolean visit(ConditionalExpression expression) {
-        serializeBinary(expression);
-        return false;
-    }
-
-    @Override
-    public boolean visit(ArithmeticExpression expression) {
-        serializeBinary(expression);
-        return false;
-    }
-
-    @Override
-    public boolean visit(ExpressionList expression) {
-        sb.append('(');
-        {
-            List<IExpression> expressionList = expression.getExpressions();
-            for (int i = 0, size = expressionList.size(); i < size; i++) {
-                if (i > 0) {
-                    sb.append(", ");
-                }
-                expressionList.get(i).accept(this);
-            }
-        }
-        sb.append(')');
-        return false;
-    }
-
-    @Override
-    public boolean visit(FunctionExpression expression) {
+    public void serialize(FunctionExpression expression) {
         boolean first = true;
         sb.append(expression.getName());
         sb.append('(');
@@ -182,80 +145,36 @@ public class ExpressionSerializer implements IExpressionInDepthVisitor {
             } else {
                 sb.append(", ");
             }
-            p.accept(this);
+            p.serializeToText(this);
         }
         sb.append(')');
-        return false;
     }
 
-    @Override
-    public boolean visit(ArrayAccessExpression expression) {
-        expression.getArray().accept(this);
-        sb.append('[');
-        sb.append(expression.getIndex());
-        sb.append(']');
-        return false;
-    }
-
-    @Override
-    public boolean visit(MapAccessExpression expression) {
-        expression.getMap().accept(this);
-        sb.append('[');
-        sb.append('\'');
-        sb.append(expression.getKey());
-        sb.append('\'');
-        sb.append(']');
-        return false;
-    }
-
-    @Override
-    public boolean visit(MacroExpression expression) {
+    public void serialize(MacroExpression expression) {
         sb.append('{');
         sb.append(expression.getMacro());
         sb.append('}');
-        return false;
     }
 
-    @Override
-    public boolean visit(TernaryExpression expression) {
-        expression.getConditionExpression().accept(this);
-        sb.append(' ');
-        sb.append('?');
-        sb.append(' ');
-        expression.getTrueExpression().accept(this);
-        sb.append(' ');
-        sb.append(':');
-        sb.append(' ');
-        expression.getFalseExpression().accept(this);
-        return false;
-    }
-
-    public void append(String str) {
-        sb.append(str);
-    }
-
-    public boolean serializeBinary(BinaryExpression expression) {
+    public void serialize(BinaryExpression expression) {
         IExpression left = expression.getLhs();
         if (left instanceof BinaryExpression) {
             sb.append('(');
         }
-        left.accept(this);
+        left.serializeToText(this);
         if (left instanceof BinaryExpression) {
             sb.append(')');
         }
         sb.append(' ');
         sb.append(expression.getType());
         sb.append(' ');
-
         IExpression right = expression.getRhs();
         if (right instanceof BinaryExpression) {
             sb.append('(');
         }
-        right.accept(this);
+        right.serializeToText(this);
         if (right instanceof BinaryExpression) {
             sb.append(')');
         }
-
-        return false;
     }
 }

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/IdentifierQuotaStrategy.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/serialization/IdentifierQuotaStrategy.java
@@ -1,0 +1,31 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.component.commons.expression.serialization;
+
+
+/**
+ * @author frank.chen021@outlook.com
+ * @date 4/4/25 1:46 pm
+ */
+@FunctionalInterface
+public interface IdentifierQuotaStrategy {
+    IdentifierQuotaStrategy NONE = identifier -> identifier;
+    IdentifierQuotaStrategy SINGLE_QUOTE = identifier -> "'" + identifier + "'";
+    IdentifierQuotaStrategy DOUBLE_QUOTE = identifier -> "\"" + identifier + "\"";
+
+    String quoteIdentifier(String identifier);
+}

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/validation/ExpressionTypeValidator.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/validation/ExpressionTypeValidator.java
@@ -26,6 +26,7 @@ import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.function.IFunction;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 
 /**
  * @author frank.chen021@outlook.com
@@ -51,7 +52,7 @@ class ExpressionTypeValidator implements IExpressionInDepthVisitor {
                 && !dataType.equals(IDataType.DOUBLE)
                 && !dataType.equals(IDataType.LONG)) {
                 throw new ExpressionValidationException("The expression [%s] in the logical expression should be a conditional expression.",
-                                                        operand.serializeToText(null));
+                                                        operand.serializeToText(IdentifierQuotaStrategy.NONE));
             }
         }
         return true;
@@ -87,16 +88,16 @@ class ExpressionTypeValidator implements IExpressionInDepthVisitor {
                 expression.setRhs(rhs.castTo(lhsType));
             } catch (ExpressionValidationException e) {
                 throw new ExpressionValidationException("Can't convert [%s] into type of [%s] in the expression: %s",
-                                                        rhs.serializeToText(null),
+                                                        rhs.serializeToText(IdentifierQuotaStrategy.NONE),
                                                         lhsType,
-                                                        expression.serializeToText(null));
+                                                        expression.serializeToText(IdentifierQuotaStrategy.NONE));
             }
             return true;
         }
 
         if (!lhsType.canCastFrom(rhsType)) {
             throw new ExpressionValidationException("The data types of the two operators in the expression [%s] are not compatible (%s vs %s).",
-                                                    expression.serializeToText(null),
+                                                    expression.serializeToText(IdentifierQuotaStrategy.NONE),
                                                     lhsType.name(),
                                                     rhsType == null ? "null" : rhsType.name());
         }
@@ -112,7 +113,7 @@ class ExpressionTypeValidator implements IExpressionInDepthVisitor {
         for (int i = 1, size = expression.getExpressions().size(); i < size; i++) {
             if (!dataType.canCastFrom(expression.getExpressions().get(i).getDataType())) {
                 throw new ExpressionValidationException("The data types of elements in the expression list %s are not the same.",
-                                                        expression.serializeToText(null));
+                                                        expression.serializeToText(IdentifierQuotaStrategy.NONE));
             }
         }
         return true;

--- a/component/component-commons/src/test/java/org/bithon/component/commons/expression/optimizer/ExpressionOptimizerTest.java
+++ b/component/component-commons/src/test/java/org/bithon/component/commons/expression/optimizer/ExpressionOptimizerTest.java
@@ -22,6 +22,7 @@ import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +54,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assertions.assertEquals(5, expr.getOperands().size());
-        Assertions.assertEquals("(a = 1) AND (b = 2) AND (c = 3) AND (d = 4) AND (e = 5)", expr.serializeToText(null));
+        Assertions.assertEquals("(a = 1) AND (b = 2) AND (c = 3) AND (d = 4) AND (e = 5)", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -70,7 +71,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assertions.assertEquals(3, expr.getOperands().size());
-        Assertions.assertEquals("(a = 1) OR (b = 2) OR (c = 3)", expr.serializeToText(null));
+        Assertions.assertEquals("(a = 1) OR (b = 2) OR (c = 3)", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -87,7 +88,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assertions.assertEquals(2, expr.getOperands().size());
-        Assertions.assertEquals("(a = 1) AND ((b = 2) OR (c = 3))", expr.serializeToText(null));
+        Assertions.assertEquals("(a = 1) AND ((b = 2) OR (c = 3))", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -111,7 +112,7 @@ public class ExpressionOptimizerTest {
         expr.accept(new ExpressionOptimizer.AbstractOptimizer());
 
         Assertions.assertEquals(4, expr.getOperands().size());
-        Assertions.assertEquals("(a = 1) AND (b = 2) AND (c = 3) AND (d = 4)", expr.serializeToText(null));
+        Assertions.assertEquals("(a = 1) AND (b = 2) AND (c = 3) AND (d = 4)", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -133,7 +134,7 @@ public class ExpressionOptimizerTest {
         );
 
         expr = ExpressionOptimizer.optimize(expr);
-        Assertions.assertEquals("NOT ((a = 1) AND (b = 2) AND (c = 3) AND (d = 4))", expr.serializeToText(null));
+        Assertions.assertEquals("NOT ((a = 1) AND (b = 2) AND (c = 3) AND (d = 4))", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -143,6 +144,6 @@ public class ExpressionOptimizerTest {
         );
 
         expr = ExpressionOptimizer.optimize(expr);
-        Assertions.assertEquals("false", expr.serializeToText(null));
+        Assertions.assertEquals("false", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 }

--- a/server/alerting/common/src/main/java/org/bithon/server/alerting/common/model/AlertExpression.java
+++ b/server/alerting/common/src/main/java/org/bithon/server/alerting/common/model/AlertExpression.java
@@ -22,10 +22,9 @@ import org.bithon.component.commons.expression.IEvaluationContext;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IExpressionInDepthVisitor;
 import org.bithon.component.commons.expression.IExpressionVisitor;
+import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 import org.bithon.server.alerting.common.evaluator.metric.IMetricEvaluator;
 import org.bithon.server.metric.expression.MetricExpression;
-
-import java.util.function.Function;
 
 /**
  * NOTE: When changes are made to this class,
@@ -93,8 +92,8 @@ public class AlertExpression implements IExpression {
     }
 
     @Override
-    public String serializeToText(Function<String, String> quoteIdentifier) {
-        return serializeToText(true);
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.append(serializeToText(true));
     }
 
     public String serializeToText(boolean includePredication) {

--- a/server/alerting/common/src/main/java/org/bithon/server/alerting/common/parser/AlertExpressionASTParser.java
+++ b/server/alerting/common/src/main/java/org/bithon/server/alerting/common/parser/AlertExpressionASTParser.java
@@ -87,7 +87,11 @@ public class AlertExpressionASTParser {
 
         @Override
         public IExpression visitSimpleAlertExpression(MetricExpressionParser.SimpleAlertExpressionContext ctx) {
-            MetricExpression metricExpression = MetricExpressionASTBuilder.build(ctx.metricExpression());
+            IExpression expression = MetricExpressionASTBuilder.build(ctx.atomicMetricExpressionImpl());
+            if (!(expression instanceof MetricExpression metricExpression)) {
+                throw new InvalidExpressionException("Complex expression is not supported now.");
+            }
+
             if (metricExpression.getPredicate() == null) {
                 // the general metric expression allows null predicate, but for alerting, it's a compulsory field
                 throw new InvalidExpressionException("Missing predicate expression");

--- a/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
+++ b/server/alerting/manager/src/main/java/org/bithon/server/alerting/manager/biz/AlertCommandService.java
@@ -21,11 +21,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
-import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.alerting.common.model.AlertExpression;
 import org.bithon.server.alerting.common.model.AlertRule;
-import org.bithon.server.alerting.common.model.IAlertInDepthExpressionVisitor;
 import org.bithon.server.alerting.evaluator.evaluator.AlertEvaluator;
 import org.bithon.server.alerting.evaluator.evaluator.INotificationApiInvoker;
 import org.bithon.server.alerting.evaluator.repository.AlertRepository;
@@ -114,17 +112,6 @@ public class AlertCommandService {
         this.userProvider = userProvider;
         this.notificationChannelStorage = notificationChannelStorage;
         this.applicationContext = applicationContext;
-    }
-
-    static class AlertExpressionSerializer extends ExpressionSerializer implements IAlertInDepthExpressionVisitor {
-        public AlertExpressionSerializer() {
-            super(null);
-        }
-
-        @Override
-        public void visit(AlertExpression expression) {
-            sb.append(expression.serializeToText(true));
-        }
     }
 
     private AlertStorageObject toAlertStorageObject(AlertRule alertRule) throws BizException {

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/image/AlertImageRenderService.java
@@ -32,6 +32,7 @@ import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.component.commons.utils.CollectionUtils;
 import org.bithon.component.commons.utils.Preconditions;
 import org.bithon.component.commons.utils.StringUtils;
@@ -181,7 +182,7 @@ public class AlertImageRenderService implements ApplicationContextAware {
                 multipleGroups.add(new LogicalExpression.AND(oneGroup));
             }
 
-            seriesSelector = '(' + new LogicalExpression.OR(multipleGroups).serializeToText(null) + ')';
+            seriesSelector = '(' + new LogicalExpression.OR(multipleGroups).serializeToText(IdentifierQuotaStrategy.NONE) + ')';
         }
 
         QueryResponse response = metricQueryApi.timeSeries(MetricQueryApi.MetricQueryRequest.builder()

--- a/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
+++ b/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
@@ -1,7 +1,7 @@
 grammar MetricExpression;
 
 alertExpression
-  : metricExpression                                    #simpleAlertExpression
+  : atomicMetricExpressionImpl                          #simpleAlertExpression
   | alertExpression AND alertExpression                 #logicalAlertExpression
   | alertExpression OR alertExpression                  #logicalAlertExpression
   | LEFT_PARENTHESIS alertExpression RIGHT_PARENTHESIS  #parenthesisAlertExpression
@@ -9,12 +9,17 @@ alertExpression
 
 // sum by (a,b,c) (metric {})
 metricExpression
-  : aggregatorExpression LEFT_PARENTHESIS metricQNameExpression labelExpression? RIGHT_PARENTHESIS durationExpression? groupByExpression? (metricPredicateExpression metricExpectedExpression)?  #atomicMetricExpression
+  : atomicMetricExpressionImpl                        #atomicMetricExpression
   | metricExpression (MUL|DIV) metricExpression       #arithmeticExpression
   | metricExpression (ADD|SUB) metricExpression       #arithmeticExpression
   | '(' metricExpression ')'                          #parenthesisMetricExpression
   | (INTEGER_LITERAL | DECIMAL_LITERAL | PERCENTAGE_LITERAL | SIZE_LITERAL | DURATION_LITERAL) #metricLiteralExpression // This allows to use literal expression in arithmetic expression
   ;
+
+atomicMetricExpressionImpl
+  : aggregatorExpression LEFT_PARENTHESIS metricQNameExpression labelExpression? RIGHT_PARENTHESIS durationExpression? groupByExpression? (metricPredicateExpression metricExpectedExpression)?
+  ;
+
 
 aggregatorExpression
   : IDENTIFIER

--- a/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
+++ b/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
@@ -9,9 +9,11 @@ alertExpression
 
 // sum by (a,b,c) (metric {})
 metricExpression
-  : aggregatorExpression LEFT_PARENTHESIS metricQNameExpression labelExpression? RIGHT_PARENTHESIS durationExpression? groupByExpression? (metricPredicateExpression metricExpectedExpression)?                               #atomicMetricExpression
+  : aggregatorExpression LEFT_PARENTHESIS metricQNameExpression labelExpression? RIGHT_PARENTHESIS durationExpression? groupByExpression? (metricPredicateExpression metricExpectedExpression)?  #atomicMetricExpression
   | metricExpression (MUL|DIV) metricExpression       #arithmeticExpression
   | metricExpression (ADD|SUB) metricExpression       #arithmeticExpression
+  | '(' metricExpression ')'                          #parenthesisMetricExpression
+  | (INTEGER_LITERAL | DECIMAL_LITERAL | PERCENTAGE_LITERAL | SIZE_LITERAL | DURATION_LITERAL) #metricLiteralExpression // This allows to use literal expression in arithmetic expression
   ;
 
 aggregatorExpression

--- a/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
+++ b/server/metric-expression/src/main/antlr4/org/bithon/server/metric/expression/MetricExpression.g4
@@ -9,7 +9,9 @@ alertExpression
 
 // sum by (a,b,c) (metric {})
 metricExpression
-  : aggregatorExpression LEFT_PARENTHESIS metricQNameExpression labelExpression? RIGHT_PARENTHESIS durationExpression? groupByExpression? (metricPredicateExpression metricExpectedExpression)?
+  : aggregatorExpression LEFT_PARENTHESIS metricQNameExpression labelExpression? RIGHT_PARENTHESIS durationExpression? groupByExpression? (metricPredicateExpression metricExpectedExpression)?                               #atomicMetricExpression
+  | metricExpression (MUL|DIV) metricExpression       #arithmeticExpression
+  | metricExpression (ADD|SUB) metricExpression       #arithmeticExpression
   ;
 
 aggregatorExpression
@@ -76,6 +78,11 @@ BY: B Y;
 AND : A N D;
 OR: O R;
 ID: [A-Z];
+
+ADD: '+' ;
+SUB: '-';
+MUL: '*' ;
+DIV: '/';
 
 LEFT_PARENTHESIS: '(';
 RIGHT_PARENTHESIS: ')';

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpression.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpression.java
@@ -126,7 +126,7 @@ public class MetricExpression implements IExpression {
             sb.append(StringUtils.format(" BY (%s) ", String.join(",", this.groupBy)));
         }
 
-        if (includePredication) {
+        if (includePredication && predicate != null) {
             sb.append(' ');
             sb.append(predicate);
             sb.append(' ');
@@ -204,7 +204,6 @@ public class MetricExpression implements IExpression {
 
     @Override
     public void accept(IExpressionInDepthVisitor visitor) {
-
     }
 
     @Override

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpression.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpression.java
@@ -27,6 +27,7 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
 import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.component.commons.utils.CollectionUtils;
 import org.bithon.component.commons.utils.HumanReadableDuration;
 import org.bithon.component.commons.utils.StringUtils;
@@ -37,7 +38,6 @@ import org.bithon.server.web.service.datasource.api.QueryField;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * <p>
@@ -70,7 +70,7 @@ public class MetricExpression implements IExpression {
      * Post filter
      */
     private PredicateEnum predicate;
-    private LiteralExpression expected;
+    private LiteralExpression<?> expected;
 
     /**
      * The offset time duration of the expected value.
@@ -101,8 +101,8 @@ public class MetricExpression implements IExpression {
     }
 
     @Override
-    public String serializeToText(Function<String, String> quoteIdentifier) {
-        return serializeToText(true);
+    public void serializeToText(ExpressionSerializer serializer) {
+        serializer.append(serializeToText(true));
     }
 
     public String serializeToText(boolean includePredication) {
@@ -161,7 +161,7 @@ public class MetricExpression implements IExpression {
     static class LabelSelectorExpressionSerializer extends ExpressionSerializer {
 
         public LabelSelectorExpressionSerializer() {
-            super(null);
+            super(IdentifierQuotaStrategy.NONE);
         }
 
         @Override
@@ -207,7 +207,7 @@ public class MetricExpression implements IExpression {
 
     @Override
     public void accept(IExpressionInDepthVisitor visitor) {
-        throw new UnsupportedOperationException();
+
     }
 
     @Override

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpression.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpression.java
@@ -146,7 +146,7 @@ public class MetricExpression implements IExpression {
         }
 
         @Override
-        public boolean visit(LiteralExpression<?> expression) {
+        public void serialize(LiteralExpression<?> expression) {
             if (expression instanceof LiteralExpression.StringLiteral stringLiteral) {
                 sb.append('\'');
                 sb.append(StringUtils.escape(stringLiteral.getValue(), '\\', '\''));
@@ -154,7 +154,6 @@ public class MetricExpression implements IExpression {
             } else {
                 sb.append(expression.getValue());
             }
-            return false;
         }
     }
 
@@ -165,19 +164,18 @@ public class MetricExpression implements IExpression {
         }
 
         @Override
-        public boolean visit(LogicalExpression expression) {
+        public void serialize(LogicalExpression expression) {
             for (int i = 0, size = expression.getOperands().size(); i < size; i++) {
                 if (i > 0) {
                     sb.append(", ");
                 }
-                expression.getOperands().get(i).accept(this);
+                expression.getOperands().get(i).serializeToText(this);
             }
-            return false;
         }
 
         // Use double quote to serialize the expression by default
         @Override
-        public boolean visit(LiteralExpression<?> expression) {
+        public void serialize(LiteralExpression<?> expression) {
             if (expression instanceof LiteralExpression.StringLiteral stringLiteral) {
                 sb.append('"');
                 sb.append(StringUtils.escape(stringLiteral.getValue(), '\\', '"'));
@@ -185,7 +183,6 @@ public class MetricExpression implements IExpression {
             } else {
                 sb.append(expression.getValue());
             }
-            return false;
         }
     }
 

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpressionASTBuilder.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/MetricExpressionASTBuilder.java
@@ -89,6 +89,10 @@ public class MetricExpressionASTBuilder {
         return metricExpression.accept(new BuilderImpl());
     }
 
+    public static IExpression build(MetricExpressionParser.AtomicMetricExpressionImplContext metricExpression) {
+        return metricExpression.accept(new BuilderImpl());
+    }
+
     private static class BuilderImpl extends MetricExpressionBaseVisitor<IExpression> {
         @Override
         public IExpression visitMetricLiteralExpression(MetricExpressionParser.MetricLiteralExpressionContext ctx) {
@@ -117,7 +121,12 @@ public class MetricExpressionASTBuilder {
         }
 
         @Override
-        public MetricExpression visitAtomicMetricExpression(MetricExpressionParser.AtomicMetricExpressionContext ctx) {
+        public IExpression visitAtomicMetricExpression(MetricExpressionParser.AtomicMetricExpressionContext ctx) {
+            return visitAtomicMetricExpressionImpl(ctx.atomicMetricExpressionImpl());
+        }
+
+        @Override
+        public IExpression visitAtomicMetricExpressionImpl(MetricExpressionParser.AtomicMetricExpressionImplContext ctx) {
             String[] names = ctx.metricQNameExpression().getText().split("\\.");
             String from = names[0];
             String metric = names[1];

--- a/server/metric-expression/src/main/java/org/bithon/server/metric/expression/api/MetricQueryApi.java
+++ b/server/metric-expression/src/main/java/org/bithon/server/metric/expression/api/MetricQueryApi.java
@@ -25,6 +25,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.bithon.component.commons.Experimental;
 import org.bithon.component.commons.concurrency.NamedThreadFactory;
+import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.utils.HumanReadableDuration;
 import org.bithon.component.commons.utils.HumanReadablePercentage;
 import org.bithon.server.commons.time.TimeSpan;
@@ -97,7 +98,10 @@ public class MetricQueryApi {
     @Experimental
     @PostMapping("/api/metric/timeseries")
     public QueryResponse timeSeries(@Validated @RequestBody MetricQueryRequest request) throws Exception {
-        MetricExpression metricExpression = MetricExpressionASTBuilder.parse(request.getExpression());
+        IExpression expression = MetricExpressionASTBuilder.parse(request.getExpression());
+        if (!(expression instanceof MetricExpression metricExpression)) {
+            throw new IllegalArgumentException("Invalid metric expression: " + request.getExpression());
+        }
 
         String filterExpression = Stream.of(metricExpression.getWhereText(), request.getCondition())
                                         .filter(Objects::nonNull)

--- a/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
+++ b/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
@@ -16,6 +16,7 @@
 
 package org.bithon.server.metric.expression;
 
+import org.bithon.component.commons.expression.ArithmeticExpression;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
 import org.bithon.component.commons.utils.HumanReadableNumber;
@@ -350,5 +351,100 @@ public class MetricExpressionASTBuilderTest {
         Assert.assertEquals("avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] > -5%[-1d]",
                             MetricExpressionASTBuilder.parse("avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] > -5%[-1d]")
                                                       .serializeToText());
+    }
+
+    @Test
+    public void test_ADD_Literal() {
+        {
+            String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5";
+            IExpression ast = MetricExpressionASTBuilder.parse(expr);
+            Assert.assertTrue(ast instanceof ArithmeticExpression);
+        }
+
+        // Human readable literal
+        {
+            String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5MiB";
+            IExpression ast = MetricExpressionASTBuilder.parse(expr);
+            Assert.assertTrue(ast instanceof ArithmeticExpression);
+        }
+
+        // Human readable literal
+        {
+            String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5Mi";
+            IExpression ast = MetricExpressionASTBuilder.parse(expr);
+            Assert.assertTrue(ast instanceof ArithmeticExpression);
+        }
+
+        // Human readable literal
+        {
+            String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5G";
+            IExpression ast = MetricExpressionASTBuilder.parse(expr);
+            Assert.assertTrue(ast instanceof ArithmeticExpression);
+        }
+
+        // Percentage literal
+        {
+            String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5%";
+            IExpression ast = MetricExpressionASTBuilder.parse(expr);
+            Assert.assertTrue(ast instanceof ArithmeticExpression);
+        }
+
+        // duration literal
+        {
+            String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5h";
+            IExpression ast = MetricExpressionASTBuilder.parse(expr);
+            Assert.assertTrue(ast instanceof ArithmeticExpression);
+        }
+
+        // TODO：need to refactor the serializer, pass serializer to the serializeText method
+        //Assert.assertEquals(expr, ast.serializeToText(new ExpressionSerializer()));
+    }
+
+    @Test
+    public void test_SUB_Literal() {
+        String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] - 5";
+        IExpression ast = MetricExpressionASTBuilder.parse(expr);
+        Assert.assertTrue(ast instanceof ArithmeticExpression);
+
+        // TODO：need to refactor the serializer, pass serializer to the serializeText method
+        //Assert.assertEquals(expr, ast.serializeToText());
+    }
+
+    @Test
+    public void test_MUL_Literal() {
+        String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] / 5";
+        IExpression ast = MetricExpressionASTBuilder.parse(expr);
+        Assert.assertTrue(ast instanceof ArithmeticExpression);
+
+        // TODO：need to refactor the serializer, pass serializer to the serializeText method
+        //Assert.assertEquals(expr, ast.serializeToText());
+    }
+
+    @Test
+    public void test_DIV_Literal() {
+        String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] / 5";
+        IExpression ast = MetricExpressionASTBuilder.parse(expr);
+        Assert.assertTrue(ast instanceof ArithmeticExpression);
+
+        // TODO：need to refactor the serializer, pass serializer to the serializeText method
+        //Assert.assertEquals(expr, ast.serializeToText());
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void test_DIV_BY_Zero() {
+        String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] / 0";
+        IExpression ast = MetricExpressionASTBuilder.parse(expr);
+    }
+
+    @Test
+    public void test_HybridExpression() {
+        String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] * "
+                      + "(avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] - avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m])";
+        IExpression ast = MetricExpressionASTBuilder.parse(expr);
+
+        Assert.assertTrue(ast instanceof ArithmeticExpression.MUL);
+        ArithmeticExpression.MUL mul = (ArithmeticExpression.MUL) ast;
+        Assert.assertTrue(mul.getLhs() instanceof MetricExpression);
+        Assert.assertTrue(mul.getRhs() instanceof ArithmeticExpression.SUB);
     }
 }

--- a/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
+++ b/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
@@ -19,6 +19,7 @@ package org.bithon.server.metric.expression;
 import org.bithon.component.commons.expression.ArithmeticExpression;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.component.commons.utils.HumanReadableNumber;
 import org.junit.Assert;
 import org.junit.Test;
@@ -151,7 +152,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_ContainsPredicateExpression() {
         MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a'})[5m] is null");
-        Assert.assertEquals("appName contains 'a'", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("appName contains 'a'", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         // contains require string literal
         Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 5})[5m]"));
@@ -160,7 +161,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_StartsWithPredicateExpression() {
         MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName startsWith 'a'})[5m] is null");
-        Assert.assertEquals("appName startsWith 'a'", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("appName startsWith 'a'", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         // startsWith require string literal
         Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName startsWith 5})[5m]"));
@@ -169,7 +170,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_EnsWithPredicateExpression() {
         MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName endsWith 'a'})[5m] is null");
-        Assert.assertEquals("appName endsWith 'a'", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("appName endsWith 'a'", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         // startsWith require string literal
         Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName endsWith 5})[5m]"));
@@ -178,7 +179,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_hasTokenPredicateExpression() {
         MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 'a', instanceName hasToken '192.'})[5m] > 1");
-        Assert.assertEquals("(appName hasToken 'a') AND (instanceName hasToken '192.')", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("(appName hasToken 'a') AND (instanceName hasToken '192.')", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         // hasToken require string literal
         Assert.assertThrows(InvalidExpressionException.class, () -> MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 5})[5m] > 1"));
@@ -188,19 +189,19 @@ public class MetricExpressionASTBuilderTest {
     public void test_NotPredicateExpression() {
         // not contains
         MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not contains 'a'})[5m] is null");
-        Assert.assertEquals("NOT (appName contains 'a')", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("NOT (appName contains 'a')", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         // not startsWith
         expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not startsWith 'a'})[5m] is null");
-        Assert.assertEquals("NOT (appName startsWith 'a')", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("NOT (appName startsWith 'a')", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         // not endsWith
         expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not endsWith 'a'})[5m] is null");
-        Assert.assertEquals("NOT (appName endsWith 'a')", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("NOT (appName endsWith 'a')", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         // not hasToken
         expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not hasToken 'a'})[5m] is null");
-        Assert.assertEquals("NOT (appName hasToken 'a')", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("NOT (appName hasToken 'a')", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -221,7 +222,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_InExpression() {
         MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName in ('a')})[5m] is null");
-        Assert.assertEquals("appName in ('a')", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("appName in ('a')", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName in ('a', 'b')})[5m] is null");
         MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName in (1)})[5m] is null");
@@ -233,7 +234,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_NotInExpression() {
         MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not in ('a')})[5m] is null");
-        Assert.assertEquals("appName not in ('a')", expression.getLabelSelectorExpression().serializeToText(null));
+        Assert.assertEquals("appName not in ('a')", expression.getLabelSelectorExpression().serializeToText(IdentifierQuotaStrategy.NONE));
 
         MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not in ('a', 'b')})[5m] is null");
 
@@ -274,21 +275,21 @@ public class MetricExpressionASTBuilderTest {
         {
             MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu)[5m] > 10%[-7m]");
             Assert.assertEquals("avg(jvm-metrics.cpu)[5m] > 10%[-7m]",
-                                expression.serializeToText(null));
+                                expression.serializeToText(IdentifierQuotaStrategy.NONE));
         }
 
         // One filter
         {
             MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName = 'a'})[5m] > 10%[-5m]");
             Assert.assertEquals("avg(jvm-metrics.cpu{appName = \"a\"})[5m] > 10%[-5m]",
-                                expression.serializeToText(null));
+                                expression.serializeToText(IdentifierQuotaStrategy.NONE));
         }
 
         // Two filters
         {
             MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 10%[-5m]");
             Assert.assertEquals("avg(jvm-metrics.cpu{appName contains \"a\", instanceName contains \"192.\"})[5m] > 10%[-5m]",
-                                expression.serializeToText(null));
+                                expression.serializeToText(IdentifierQuotaStrategy.NONE));
         }
 
 
@@ -310,7 +311,7 @@ public class MetricExpressionASTBuilderTest {
     public void test_MultipleSelector() {
         MetricExpression alertExpression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(http-metrics.responseTime{appName='a', instance='localhost', url='http://localhost/test'})[5m] > 1%[-7m]");
         IExpression whereExpression = alertExpression.getLabelSelectorExpression();
-        Assert.assertEquals("(appName = 'a') AND (instance = 'localhost') AND (url = 'http://localhost/test')", whereExpression.serializeToText(null));
+        Assert.assertEquals("(appName = 'a') AND (instance = 'localhost') AND (url = 'http://localhost/test')", whereExpression.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test

--- a/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
+++ b/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
@@ -37,8 +37,8 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_Expression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName = 'a'}) > 1");
-        Assert.assertTrue(expression != null);
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName = 'a'}) > 1");
+        Assert.assertNotNull(expression);
         Assert.assertEquals("jvm-metrics", expression.getFrom());
         Assert.assertEquals("avg", expression.getMetric().getAggregator());
         Assert.assertEquals("cpu", expression.getMetric().getField());
@@ -48,8 +48,8 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_NoPredicateExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName = 'a'})");
-        Assert.assertTrue(expression != null);
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName = 'a'})");
+        Assert.assertNotNull(expression);
         Assert.assertEquals("jvm-metrics", expression.getFrom());
         Assert.assertEquals("avg", expression.getMetric().getAggregator());
         Assert.assertEquals("cpu", expression.getMetric().getField());
@@ -58,7 +58,7 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_EmptyWhereExpression() {
         IExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu) > 1%");
-        Assert.assertTrue(expression != null);
+        Assert.assertNotNull(expression);
 
         MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{}) > 1%");
     }
@@ -66,15 +66,15 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_Percentage() {
         IExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu) > 1%[-1m]");
-        Assert.assertTrue(expression != null);
+        Assert.assertNotNull(expression);
 
         MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu) > 101%[-1m]");
     }
 
     @Test
     public void test_WithLabelSelectorExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <> 'a'}) > 1");
-        Assert.assertTrue(expression != null);
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <> 'a'}) > 1");
+        Assert.assertNotNull(expression);
         Assert.assertEquals("jvm-metrics", expression.getFrom());
         Assert.assertEquals("avg", expression.getMetric().getAggregator());
         Assert.assertEquals("cpu", expression.getMetric().getField());
@@ -90,13 +90,13 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_DurationExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5m] > 1");
-        Assert.assertTrue(expression != null);
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5m] > 1");
+        Assert.assertNotNull(expression);
         Assert.assertEquals(5, expression.getWindow().getDuration().toMinutes());
         Assert.assertEquals(TimeUnit.MINUTES, expression.getWindow().getUnit());
 
-        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5h] > 1");
-        Assert.assertTrue(expression != null);
+        expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5h] > 1");
+        Assert.assertNotNull(expression);
         Assert.assertEquals(5, expression.getWindow().getDuration().toHours());
         Assert.assertEquals(TimeUnit.HOURS, expression.getWindow().getUnit());
 
@@ -108,23 +108,23 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_HumanReadableSizeExpression() {
         // binary format
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5m] > 1MiB");
-        Assert.assertTrue(expression != null);
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5m] > 1MiB");
+        Assert.assertNotNull(expression);
         Assert.assertEquals(5, expression.getWindow().getDuration().toMinutes());
         Assert.assertEquals(TimeUnit.MINUTES, expression.getWindow().getUnit());
         Assert.assertEquals(HumanReadableNumber.of("1MiB"), expression.getExpected().getValue());
         Assert.assertEquals("avg(jvm-metrics.cpu{appName <= \"a\"})[5m] > 1MiB", expression.serializeToText());
 
         // decimal format
-        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5h] > 7K");
-        Assert.assertTrue(expression != null);
+        expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5h] > 7K");
+        Assert.assertNotNull(expression);
         Assert.assertEquals(5, expression.getWindow().getDuration().toHours());
         Assert.assertEquals(HumanReadableNumber.of("7K"), expression.getExpected().getValue());
         Assert.assertEquals("avg(jvm-metrics.cpu{appName <= \"a\"})[5h] > 7K", expression.serializeToText());
 
         // simplified binary format
-        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5h] > 100Gi");
-        Assert.assertTrue(expression != null);
+        expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName <= 'a'})[5h] > 100Gi");
+        Assert.assertNotNull(expression);
         Assert.assertEquals(5, expression.getWindow().getDuration().toHours());
         Assert.assertEquals(HumanReadableNumber.of("100Gi"), expression.getExpected().getValue());
         Assert.assertEquals("avg(jvm-metrics.cpu{appName <= \"a\"})[5h] > 100Gi", expression.serializeToText());
@@ -149,7 +149,7 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_ContainsPredicateExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a'})[5m] is null");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a'})[5m] is null");
         Assert.assertEquals("appName contains 'a'", expression.getLabelSelectorExpression().serializeToText(null));
 
         // contains require string literal
@@ -158,7 +158,7 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_StartsWithPredicateExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName startsWith 'a'})[5m] is null");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName startsWith 'a'})[5m] is null");
         Assert.assertEquals("appName startsWith 'a'", expression.getLabelSelectorExpression().serializeToText(null));
 
         // startsWith require string literal
@@ -167,7 +167,7 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_EnsWithPredicateExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName endsWith 'a'})[5m] is null");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName endsWith 'a'})[5m] is null");
         Assert.assertEquals("appName endsWith 'a'", expression.getLabelSelectorExpression().serializeToText(null));
 
         // startsWith require string literal
@@ -176,7 +176,7 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_hasTokenPredicateExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 'a', instanceName hasToken '192.'})[5m] > 1");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName hasToken 'a', instanceName hasToken '192.'})[5m] > 1");
         Assert.assertEquals("(appName hasToken 'a') AND (instanceName hasToken '192.')", expression.getLabelSelectorExpression().serializeToText(null));
 
         // hasToken require string literal
@@ -186,19 +186,19 @@ public class MetricExpressionASTBuilderTest {
     @Test
     public void test_NotPredicateExpression() {
         // not contains
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not contains 'a'})[5m] is null");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not contains 'a'})[5m] is null");
         Assert.assertEquals("NOT (appName contains 'a')", expression.getLabelSelectorExpression().serializeToText(null));
 
         // not startsWith
-        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not startsWith 'a'})[5m] is null");
+        expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not startsWith 'a'})[5m] is null");
         Assert.assertEquals("NOT (appName startsWith 'a')", expression.getLabelSelectorExpression().serializeToText(null));
 
         // not endsWith
-        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not endsWith 'a'})[5m] is null");
+        expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not endsWith 'a'})[5m] is null");
         Assert.assertEquals("NOT (appName endsWith 'a')", expression.getLabelSelectorExpression().serializeToText(null));
 
         // not hasToken
-        expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not hasToken 'a'})[5m] is null");
+        expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not hasToken 'a'})[5m] is null");
         Assert.assertEquals("NOT (appName hasToken 'a')", expression.getLabelSelectorExpression().serializeToText(null));
     }
 
@@ -219,7 +219,7 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_InExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName in ('a')})[5m] is null");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName in ('a')})[5m] is null");
         Assert.assertEquals("appName in ('a')", expression.getLabelSelectorExpression().serializeToText(null));
 
         MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName in ('a', 'b')})[5m] is null");
@@ -231,7 +231,7 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_NotInExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not in ('a')})[5m] is null");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not in ('a')})[5m] is null");
         Assert.assertEquals("appName not in ('a')", expression.getLabelSelectorExpression().serializeToText(null));
 
         MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName not in ('a', 'b')})[5m] is null");
@@ -254,7 +254,7 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_OffsetExpression() {
-        MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 1%[-7m]");
+        MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 1%[-7m]");
         Assert.assertNotNull(expression.getOffset());
         Assert.assertEquals(-7, expression.getOffset().getDuration().toMinutes());
 
@@ -271,21 +271,21 @@ public class MetricExpressionASTBuilderTest {
     public void test_ExpressionSerialization() {
         // No filter
         {
-            MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu)[5m] > 10%[-7m]");
+            MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu)[5m] > 10%[-7m]");
             Assert.assertEquals("avg(jvm-metrics.cpu)[5m] > 10%[-7m]",
                                 expression.serializeToText(null));
         }
 
         // One filter
         {
-            MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName = 'a'})[5m] > 10%[-5m]");
+            MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName = 'a'})[5m] > 10%[-5m]");
             Assert.assertEquals("avg(jvm-metrics.cpu{appName = \"a\"})[5m] > 10%[-5m]",
                                 expression.serializeToText(null));
         }
 
         // Two filters
         {
-            MetricExpression expression = MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 10%[-5m]");
+            MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m] > 10%[-5m]");
             Assert.assertEquals("avg(jvm-metrics.cpu{appName contains \"a\", instanceName contains \"192.\"})[5m] > 10%[-5m]",
                                 expression.serializeToText(null));
         }
@@ -293,7 +293,7 @@ public class MetricExpressionASTBuilderTest {
 
         // count aggregator
         {
-            MetricExpression expression = MetricExpressionASTBuilder.parse("count(   jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m]  >  1");
+            MetricExpression expression = (MetricExpression) MetricExpressionASTBuilder.parse("count(   jvm-metrics.cpu{appName contains 'a', instanceName contains '192.'})[5m]  >  1");
             Assert.assertEquals("count(jvm-metrics.cpu{appName contains \"a\", instanceName contains \"192.\"})[5m] > 1",
                                 expression.serializeToText());
         }
@@ -307,21 +307,21 @@ public class MetricExpressionASTBuilderTest {
 
     @Test
     public void test_MultipleSelector() {
-        MetricExpression alertExpression = MetricExpressionASTBuilder.parse("avg(http-metrics.responseTime{appName='a', instance='localhost', url='http://localhost/test'})[5m] > 1%[-7m]");
+        MetricExpression alertExpression = (MetricExpression) MetricExpressionASTBuilder.parse("avg(http-metrics.responseTime{appName='a', instance='localhost', url='http://localhost/test'})[5m] > 1%[-7m]");
         IExpression whereExpression = alertExpression.getLabelSelectorExpression();
         Assert.assertEquals("(appName = 'a') AND (instance = 'localhost') AND (url = 'http://localhost/test')", whereExpression.serializeToText(null));
     }
 
     @Test
     public void test_ByExpression() {
-        MetricExpression expr = MetricExpressionASTBuilder.parse("avg (http-metrics.responseTime{appName='a'})[5m] by (instance) > 1");
+        MetricExpression expr = (MetricExpression) MetricExpressionASTBuilder.parse("avg (http-metrics.responseTime{appName='a'})[5m] by (instance) > 1");
         Assert.assertEquals(Collections.singleton("instance"), expr.getGroupBy());
 
-        expr = MetricExpressionASTBuilder.parse("avg (http-metrics.responseTime{appName='a'})[5m] by (instance, url) > 1");
+        expr = (MetricExpression) MetricExpressionASTBuilder.parse("avg (http-metrics.responseTime{appName='a'})[5m] by (instance, url) > 1");
         Assert.assertEquals(new HashSet<>(Arrays.asList("instance", "url")), expr.getGroupBy());
 
-        expr = MetricExpressionASTBuilder.parse("avg (http-metrics.responseTime{appName='a'})[5m] by (instance, url, method) > 1");
-        Assert.assertEquals(new HashSet(Arrays.asList("instance", "url", "method")), expr.getGroupBy());
+        expr = (MetricExpression) MetricExpressionASTBuilder.parse("avg (http-metrics.responseTime{appName='a'})[5m] by (instance, url, method) > 1");
+        Assert.assertEquals(new HashSet<>(Arrays.asList("instance", "url", "method")), expr.getGroupBy());
     }
 
     @Test

--- a/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
+++ b/server/metric-expression/src/test/java/org/bithon/server/metric/expression/MetricExpressionASTBuilderTest.java
@@ -360,6 +360,7 @@ public class MetricExpressionASTBuilderTest {
             String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5";
             IExpression ast = MetricExpressionASTBuilder.parse(expr);
             Assert.assertTrue(ast instanceof ArithmeticExpression);
+            Assert.assertEquals(expr, ast.serializeToText());
         }
 
         // Human readable literal
@@ -367,6 +368,7 @@ public class MetricExpressionASTBuilderTest {
             String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5MiB";
             IExpression ast = MetricExpressionASTBuilder.parse(expr);
             Assert.assertTrue(ast instanceof ArithmeticExpression);
+            Assert.assertEquals(expr, ast.serializeToText());
         }
 
         // Human readable literal
@@ -374,6 +376,7 @@ public class MetricExpressionASTBuilderTest {
             String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5Mi";
             IExpression ast = MetricExpressionASTBuilder.parse(expr);
             Assert.assertTrue(ast instanceof ArithmeticExpression);
+            Assert.assertEquals(expr, ast.serializeToText());
         }
 
         // Human readable literal
@@ -381,6 +384,7 @@ public class MetricExpressionASTBuilderTest {
             String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5G";
             IExpression ast = MetricExpressionASTBuilder.parse(expr);
             Assert.assertTrue(ast instanceof ArithmeticExpression);
+            Assert.assertEquals(expr, ast.serializeToText());
         }
 
         // Percentage literal
@@ -388,6 +392,7 @@ public class MetricExpressionASTBuilderTest {
             String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5%";
             IExpression ast = MetricExpressionASTBuilder.parse(expr);
             Assert.assertTrue(ast instanceof ArithmeticExpression);
+            Assert.assertEquals(expr, ast.serializeToText());
         }
 
         // duration literal
@@ -395,10 +400,8 @@ public class MetricExpressionASTBuilderTest {
             String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] + 5h";
             IExpression ast = MetricExpressionASTBuilder.parse(expr);
             Assert.assertTrue(ast instanceof ArithmeticExpression);
+            Assert.assertEquals(expr, ast.serializeToText());
         }
-
-        // TODO：need to refactor the serializer, pass serializer to the serializeText method
-        //Assert.assertEquals(expr, ast.serializeToText(new ExpressionSerializer()));
     }
 
     @Test
@@ -406,9 +409,7 @@ public class MetricExpressionASTBuilderTest {
         String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] - 5";
         IExpression ast = MetricExpressionASTBuilder.parse(expr);
         Assert.assertTrue(ast instanceof ArithmeticExpression);
-
-        // TODO：need to refactor the serializer, pass serializer to the serializeText method
-        //Assert.assertEquals(expr, ast.serializeToText());
+        Assert.assertEquals(expr, ast.serializeToText());
     }
 
     @Test
@@ -416,9 +417,7 @@ public class MetricExpressionASTBuilderTest {
         String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] / 5";
         IExpression ast = MetricExpressionASTBuilder.parse(expr);
         Assert.assertTrue(ast instanceof ArithmeticExpression);
-
-        // TODO：need to refactor the serializer, pass serializer to the serializeText method
-        //Assert.assertEquals(expr, ast.serializeToText());
+        Assert.assertEquals(expr, ast.serializeToText());
     }
 
     @Test
@@ -426,15 +425,13 @@ public class MetricExpressionASTBuilderTest {
         String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] / 5";
         IExpression ast = MetricExpressionASTBuilder.parse(expr);
         Assert.assertTrue(ast instanceof ArithmeticExpression);
-
-        // TODO：need to refactor the serializer, pass serializer to the serializeText method
-        //Assert.assertEquals(expr, ast.serializeToText());
+        Assert.assertEquals(expr, ast.serializeToText());
     }
 
     @Test(expected = ArithmeticException.class)
     public void test_DIV_BY_Zero() {
         String expr = "avg(jvm-metrics.activeThreads{appName = \"bithon-web-'local\"})[1m] / 0";
-        IExpression ast = MetricExpressionASTBuilder.parse(expr);
+        MetricExpressionASTBuilder.parse(expr);
     }
 
     @Test
@@ -447,5 +444,6 @@ public class MetricExpressionASTBuilderTest {
         ArithmeticExpression.MUL mul = (ArithmeticExpression.MUL) ast;
         Assert.assertTrue(mul.getLhs() instanceof MetricExpression);
         Assert.assertTrue(mul.getRhs() instanceof ArithmeticExpression.SUB);
+        Assert.assertEquals(expr, ast.serializeToText());
     }
 }

--- a/server/storage-jdbc-clickhouse/src/test/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizerTest.java
+++ b/server/storage-jdbc-clickhouse/src/test/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizerTest.java
@@ -18,6 +18,7 @@ package org.bithon.server.storage.jdbc.clickhouse.common.optimizer;
 
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.function.Functions;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.server.storage.common.expression.ExpressionASTBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, '-ab-')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assertions.assertEquals("a like '%-ab-%'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '%-ab-%'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -45,7 +46,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, '_ab_')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assertions.assertEquals("a like '%\\_ab\\_%'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '%\\_ab\\_%'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -56,7 +57,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .accept(new ClickHouseExpressionOptimizer());
 
         Assertions.assertEquals("hasToken(a, 'SERVER') AND hasToken(a, 'ERROR') AND (a like '%SERVER-ERROR%')",
-                                expr.serializeToText(null));
+                                expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -66,7 +67,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, '_SERVER')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assertions.assertEquals("hasToken(a, 'SERVER') AND (a like '%\\_SERVER%')", expr.serializeToText(null));
+        Assertions.assertEquals("hasToken(a, 'SERVER') AND (a like '%\\_SERVER%')", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -76,7 +77,7 @@ public class ClickHouseExpressionOptimizerTest {
                                                .build("hasToken(a, 'ERROR_')")
                                                .accept(new ClickHouseExpressionOptimizer());
 
-        Assertions.assertEquals("hasToken(a, 'ERROR') AND (a like '%ERROR\\_%')", expr.serializeToText(null));
+        Assertions.assertEquals("hasToken(a, 'ERROR') AND (a like '%ERROR\\_%')", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -88,6 +89,6 @@ public class ClickHouseExpressionOptimizerTest {
 
         Assertions.assertEquals(
             "hasToken(a, 'SERVER') AND hasToken(a, 'ERROR') AND (a like '%SERVER\\_ERROR%') AND hasToken(a, 'EXCEPTION') AND hasToken(a, 'CODE') AND (a like '%EXCEPTION\\_CODE%')",
-            expr.serializeToText(null));
+            expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 }

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/SafeDivisionTransformer.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/SafeDivisionTransformer.java
@@ -86,17 +86,7 @@ public class SafeDivisionTransformer {
 
         @Override
         public void accept(IExpressionInDepthVisitor visitor) {
-            if (!(visitor instanceof ExpressionSerializer serializer)) {
-                throw new UnsupportedOperationException();
-            }
-
-            serializer.append("CASE WHEN ( ");
-            whenExpression.accept(serializer);
-            serializer.append(" ) THEN ( ");
-            thenExpression.accept(serializer);
-            serializer.append(" ) ELSE ( ");
-            elseExpression.accept(serializer);
-            serializer.append(" ) END ");
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -112,11 +102,11 @@ public class SafeDivisionTransformer {
         @Override
         public void serializeToText(ExpressionSerializer serializer) {
             serializer.append("CASE WHEN ( ");
-            whenExpression.accept(serializer);
+            whenExpression.serializeToText(serializer);
             serializer.append(" ) THEN ( ");
-            thenExpression.accept(serializer);
+            thenExpression.serializeToText(serializer);
             serializer.append(" ) ELSE ( ");
-            elseExpression.accept(serializer);
+            elseExpression.serializeToText(serializer);
             serializer.append(" ) END ");
         }
     }

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/SafeDivisionTransformer.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/SafeDivisionTransformer.java
@@ -27,8 +27,6 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MacroExpression;
 import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 
-import java.util.function.Function;
-
 /**
  * @author frank.chen021@outlook.com
  * @date 12/9/24 4:51 pm
@@ -112,8 +110,14 @@ public class SafeDivisionTransformer {
         }
 
         @Override
-        public String serializeToText(Function<String, String> quoteIdentifier) {
-            throw new UnsupportedOperationException();
+        public void serializeToText(ExpressionSerializer serializer) {
+            serializer.append("CASE WHEN ( ");
+            whenExpression.accept(serializer);
+            serializer.append(" ) THEN ( ");
+            thenExpression.accept(serializer);
+            serializer.append(" ) ELSE ( ");
+            elseExpression.accept(serializer);
+            serializer.append(" ) END ");
         }
     }
 }

--- a/server/storage-jdbc-h2/src/test/java/org/bithon/server/storage/jdbc/h2/H2SqlDialectTest.java
+++ b/server/storage-jdbc-h2/src/test/java/org/bithon/server/storage/jdbc/h2/H2SqlDialectTest.java
@@ -21,6 +21,7 @@ import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.function.builtin.StringFunction;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,7 @@ public class H2SqlDialectTest {
         IExpression expr = new H2SqlDialect().transform(new FunctionExpression(StringFunction.StartsWith.INSTANCE,
                                                                                new IdentifierExpression("a"),
                                                                                LiteralExpression.ofString("1231")));
-        Assertions.assertEquals("a like '1231%'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '1231%'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -44,7 +45,7 @@ public class H2SqlDialectTest {
         IExpression expr = new H2SqlDialect().transform(new FunctionExpression(StringFunction.EndsWith.INSTANCE,
                                                                                new IdentifierExpression("a"),
                                                                                LiteralExpression.ofString("1231")));
-        Assertions.assertEquals("a like '%1231'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '%1231'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -52,6 +53,6 @@ public class H2SqlDialectTest {
         IExpression expr = new H2SqlDialect().transform(new FunctionExpression(StringFunction.HasToken.INSTANCE,
                                                                                new IdentifierExpression("a"),
                                                                                LiteralExpression.ofString("1231")));
-        Assertions.assertEquals("a like '%1231%'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '%1231%'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 }

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
@@ -28,6 +28,7 @@ import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
 import org.bithon.component.commons.expression.function.builtin.StringFunction;
 import org.bithon.component.commons.expression.optimzer.ExpressionOptimizer;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
@@ -51,7 +52,7 @@ public class MySQLSqlDialect implements ISqlDialect {
 
     @Override
     public String timeFloorExpression(IExpression timestampExpression, long intervalSeconds) {
-        return StringUtils.format("UNIX_TIMESTAMP(`%s`) div %d * %d", timestampExpression.serializeToText(null), intervalSeconds, intervalSeconds);
+        return StringUtils.format("UNIX_TIMESTAMP(`%s`) div %d * %d", timestampExpression.serializeToText(IdentifierQuotaStrategy.NONE), intervalSeconds, intervalSeconds);
     }
 
     @Override

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/SafeDivisionTransformer.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/SafeDivisionTransformer.java
@@ -86,17 +86,7 @@ public class SafeDivisionTransformer {
 
         @Override
         public void accept(IExpressionInDepthVisitor visitor) {
-            if (!(visitor instanceof ExpressionSerializer serializer)) {
-                throw new UnsupportedOperationException();
-            }
-
-            serializer.append("IF( ");
-            whenExpression.accept(serializer);
-            serializer.append(", ");
-            thenExpression.accept(serializer);
-            serializer.append(", ");
-            elseExpression.accept(serializer);
-            serializer.append(")");
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -112,11 +102,11 @@ public class SafeDivisionTransformer {
         @Override
         public void serializeToText(ExpressionSerializer serializer) {
             serializer.append("IF( ");
-            whenExpression.accept(serializer);
+            whenExpression.serializeToText(serializer);
             serializer.append(", ");
-            thenExpression.accept(serializer);
+            thenExpression.serializeToText(serializer);
             serializer.append(", ");
-            elseExpression.accept(serializer);
+            elseExpression.serializeToText(serializer);
             serializer.append(")");
         }
     }

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/SafeDivisionTransformer.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/SafeDivisionTransformer.java
@@ -27,8 +27,6 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MacroExpression;
 import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 
-import java.util.function.Function;
-
 /**
  * @author frank.chen021@outlook.com
  * @date 12/9/24 4:57 pm
@@ -112,8 +110,14 @@ public class SafeDivisionTransformer {
         }
 
         @Override
-        public String serializeToText(Function<String, String> quoteIdentifier) {
-            throw new UnsupportedOperationException();
+        public void serializeToText(ExpressionSerializer serializer) {
+            serializer.append("IF( ");
+            whenExpression.accept(serializer);
+            serializer.append(", ");
+            thenExpression.accept(serializer);
+            serializer.append(", ");
+            elseExpression.accept(serializer);
+            serializer.append(")");
         }
     }
 }

--- a/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/SafeDivisionTransformer.java
+++ b/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/SafeDivisionTransformer.java
@@ -86,17 +86,7 @@ public class SafeDivisionTransformer {
 
         @Override
         public void accept(IExpressionInDepthVisitor visitor) {
-            if (!(visitor instanceof ExpressionSerializer serializer)) {
-                throw new UnsupportedOperationException();
-            }
-
-            serializer.append("CASE WHEN ( ");
-            whenExpression.accept(serializer);
-            serializer.append(" ) THEN ( ");
-            thenExpression.accept(serializer);
-            serializer.append(" ) ELSE ( ");
-            elseExpression.accept(serializer);
-            serializer.append(" ) END ");
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -112,11 +102,11 @@ public class SafeDivisionTransformer {
         @Override
         public void serializeToText(ExpressionSerializer serializer) {
             serializer.append("CASE WHEN ( ");
-            whenExpression.accept(serializer);
+            whenExpression.serializeToText(serializer);
             serializer.append(" ) THEN ( ");
-            thenExpression.accept(serializer);
+            thenExpression.serializeToText(serializer);
             serializer.append(" ) ELSE ( ");
-            elseExpression.accept(serializer);
+            elseExpression.serializeToText(serializer);
             serializer.append(" ) END ");
         }
     }

--- a/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/SafeDivisionTransformer.java
+++ b/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/SafeDivisionTransformer.java
@@ -27,8 +27,6 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.MacroExpression;
 import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
 
-import java.util.function.Function;
-
 /**
  * @author frank.chen021@outlook.com
  * @date 12/9/24 4:51 pm
@@ -112,8 +110,14 @@ public class SafeDivisionTransformer {
         }
 
         @Override
-        public String serializeToText(Function<String, String> quoteIdentifier) {
-            throw new UnsupportedOperationException();
+        public void serializeToText(ExpressionSerializer serializer) {
+            serializer.append("CASE WHEN ( ");
+            whenExpression.accept(serializer);
+            serializer.append(" ) THEN ( ");
+            thenExpression.accept(serializer);
+            serializer.append(" ) ELSE ( ");
+            elseExpression.accept(serializer);
+            serializer.append(" ) END ");
         }
     }
 }

--- a/server/storage-jdbc-postgresql/src/test/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialectTest.java
+++ b/server/storage-jdbc-postgresql/src/test/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialectTest.java
@@ -21,6 +21,7 @@ import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.function.Functions;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,7 @@ public class PostgresqlDialectTest {
         IExpression expr = new PostgresqlDialect().transform(new FunctionExpression(Functions.getInstance().getFunction("startsWith"),
                                                                                     new IdentifierExpression("a"),
                                                                                     LiteralExpression.ofString("1231")));
-        Assertions.assertEquals("a like '1231%'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '1231%'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -44,7 +45,7 @@ public class PostgresqlDialectTest {
         IExpression expr = new PostgresqlDialect().transform(new FunctionExpression(Functions.getInstance().getFunction("endsWith"),
                                                                                     new IdentifierExpression("a"),
                                                                                     LiteralExpression.ofString("1231")));
-        Assertions.assertEquals("a like '%1231'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '%1231'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -52,6 +53,6 @@ public class PostgresqlDialectTest {
         IExpression expr = new PostgresqlDialect().transform(new FunctionExpression(Functions.getInstance().getFunction("hasToken"),
                                                                                     new IdentifierExpression("a"),
                                                                                     LiteralExpression.ofString("1231")));
-        Assertions.assertEquals("a like '%1231%'", expr.serializeToText(null));
+        Assertions.assertEquals("a like '%1231%'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/IndexedTagQueryBuilder.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/IndexedTagQueryBuilder.java
@@ -17,7 +17,6 @@
 package org.bithon.server.storage.jdbc.tracing.reader;
 
 import org.bithon.component.commons.expression.IExpression;
-import org.bithon.component.commons.expression.IdentifierExpression;
 import org.bithon.server.storage.jdbc.common.dialect.Expression2Sql;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
 import org.bithon.server.storage.jdbc.common.jooq.Tables;
@@ -67,21 +66,6 @@ class IndexedTagQueryBuilder extends NestQueryBuilder {
             }
         } else {
             return this.in;
-        }
-    }
-
-    static class TagFilterSerializer extends Expression2Sql {
-        private final int index;
-
-        TagFilterSerializer(ISqlDialect sqlDialect, int index) {
-            super(null, sqlDialect);
-            this.index = index;
-        }
-
-        @Override
-        public boolean visit(IdentifierExpression expression) {
-            sb.append(this.quoteIdentifier.apply("f" + index));
-            return false;
         }
     }
 }

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionASTBuilderTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionASTBuilderTest.java
@@ -22,6 +22,7 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
 import org.bithon.component.commons.expression.function.Functions;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +59,7 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_ComparisonExpression_FlipGT() {
         IExpression expr = ExpressionASTBuilder.builder().build("5 > a");
-        Assertions.assertEquals("a < 5", expr.serializeToText(null));
+        Assertions.assertEquals("a < 5", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertFalse((boolean) expr.evaluate(a -> 6));
         Assertions.assertFalse((boolean) expr.evaluate(a -> 5));
@@ -68,7 +69,7 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_ComparisonExpression_FlipGTE() {
         IExpression expr = ExpressionASTBuilder.builder().build("5 >= a");
-        Assertions.assertEquals("a <= 5", expr.serializeToText(null));
+        Assertions.assertEquals("a <= 5", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertFalse((boolean) expr.evaluate(a -> 6));
         Assertions.assertTrue((boolean) expr.evaluate(a -> 5));
@@ -78,7 +79,7 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_ComparisonExpression_FlipLT() {
         IExpression expr = ExpressionASTBuilder.builder().build("5 < a");
-        Assertions.assertEquals("a > 5", expr.serializeToText(null));
+        Assertions.assertEquals("a > 5", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertTrue((boolean) expr.evaluate(a -> 6));
         Assertions.assertFalse((boolean) expr.evaluate(a -> 5));
@@ -88,7 +89,7 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_ComparisonExpression_FlipLTE() {
         IExpression expr = ExpressionASTBuilder.builder().build("5 <= a");
-        Assertions.assertEquals("a >= 5", expr.serializeToText(null));
+        Assertions.assertEquals("a >= 5", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertTrue((boolean) expr.evaluate(a -> 6));
         Assertions.assertTrue((boolean) expr.evaluate(a -> 5));
@@ -98,7 +99,7 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_ComparisonExpression_FlipNE() {
         IExpression expr = ExpressionASTBuilder.builder().build("5 <> a");
-        Assertions.assertEquals("a <> 5", expr.serializeToText(null));
+        Assertions.assertEquals("a <> 5", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertTrue((boolean) expr.evaluate(a -> 6));
         Assertions.assertFalse((boolean) expr.evaluate(a -> 5));
@@ -108,7 +109,7 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_ComparisonExpression_Flip_EQ() {
         IExpression expr = ExpressionASTBuilder.builder().build("5 = a");
-        Assertions.assertEquals("a = 5", expr.serializeToText(null));
+        Assertions.assertEquals("a = 5", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertFalse((boolean) expr.evaluate(a -> 6));
         Assertions.assertTrue((boolean) expr.evaluate(a -> 5));
@@ -118,7 +119,7 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_ComparisonExpression_Flip_Non_Literal() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = b");
-        Assertions.assertEquals("a = b", expr.serializeToText(null));
+        Assertions.assertEquals("a = b", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -139,7 +140,7 @@ public class ExpressionASTBuilderTest {
 
         // Logical AND is flattened
         Assertions.assertEquals(4, ((LogicalExpression.AND) expr).getOperands().size());
-        Assertions.assertEquals("(a = 1) AND (b = 1) AND (c = 1) AND (d = 1)", expr.serializeToText(null));
+        Assertions.assertEquals("(a = 1) AND (b = 1) AND (c = 1) AND (d = 1)", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -208,14 +209,14 @@ public class ExpressionASTBuilderTest {
         // The business layer (the layer that uses the AST) needs to handle the escaping
         Assertions.assertEquals("message contains 'a''", ExpressionASTBuilder.builder()
                                                                          .build("message contains 'a\\''")
-                                                                         .serializeToText(null));
+                                                                         .serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_TernaryExpression() {
         IExpression expr = ExpressionASTBuilder.builder().build("a > b ? 1 : 2");
 
-        Assertions.assertEquals("a > b ? 1 : 2", expr.serializeToText(null));
+        Assertions.assertEquals("a > b ? 1 : 2", expr.serializeToText(IdentifierQuotaStrategy.NONE));
         long v = (long) expr.evaluate(name -> {
             if ("a".equals(name)) {
                 return 4;
@@ -229,7 +230,7 @@ public class ExpressionASTBuilderTest {
     public void test_IsNullExpression() {
         IExpression expr = ExpressionASTBuilder.builder().build("a is null");
 
-        Assertions.assertEquals("a IS null", expr.serializeToText(null));
+        Assertions.assertEquals("a IS null", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertTrue((boolean) expr.evaluate((name) -> null));
         Assertions.assertFalse((boolean) expr.evaluate((name) -> "value of a"));
@@ -239,7 +240,7 @@ public class ExpressionASTBuilderTest {
     public void test_LiteralExpression_DurationLiteral() {
         {
             IExpression expr = ExpressionASTBuilder.builder().build("a >= 5m");
-            Assertions.assertEquals("a >= 5m", expr.serializeToText(null));
+            Assertions.assertEquals("a >= 5m", expr.serializeToText(IdentifierQuotaStrategy.NONE));
             Assertions.assertTrue((boolean) expr.evaluate((name) -> 301));
             Assertions.assertTrue((boolean) expr.evaluate((name) -> 300));
             Assertions.assertFalse((boolean) expr.evaluate((name) -> 299));
@@ -247,43 +248,43 @@ public class ExpressionASTBuilderTest {
 
         {
             IExpression expr = ExpressionASTBuilder.builder().build("1h");
-            Assertions.assertEquals("1h", expr.serializeToText(null));
+            Assertions.assertEquals("1h", expr.serializeToText(IdentifierQuotaStrategy.NONE));
             Assertions.assertEquals(1, ((LiteralExpression.ReadableDurationLiteral) expr).getValue().getDuration().toHours());
         }
         {
             IExpression expr = ExpressionASTBuilder.builder().build("7d");
-            Assertions.assertEquals("7d", expr.serializeToText(null));
+            Assertions.assertEquals("7d", expr.serializeToText(IdentifierQuotaStrategy.NONE));
             Assertions.assertEquals(7, ((LiteralExpression.ReadableDurationLiteral) expr).getValue().getDuration().toDays());
         }
         {
             IExpression expr = ExpressionASTBuilder.builder().build("69s");
-            Assertions.assertEquals("69s", expr.serializeToText(null));
+            Assertions.assertEquals("69s", expr.serializeToText(IdentifierQuotaStrategy.NONE));
             Assertions.assertEquals(69, ((LiteralExpression.ReadableDurationLiteral) expr).getValue().getDuration().toSeconds());
         }
         {
             IExpression expr = ExpressionASTBuilder.builder().build("69s.toMilliSeconds");
 
             // The 69s.toMilli is interpreted as toMilliSeconds(69s), which has been optimized to 69_000
-            Assertions.assertEquals("69000", expr.serializeToText(null));
+            Assertions.assertEquals("69000", expr.serializeToText(IdentifierQuotaStrategy.NONE));
         }
         {
             IExpression expr = ExpressionASTBuilder.builder().build("1d .toMicroSeconds");
 
             // The 69s.toMicro is interpreted as toMicroSeconds(1d), which has been optimized to 86400_000_000
-            Assertions.assertEquals("86400000000", expr.serializeToText(null));
+            Assertions.assertEquals("86400000000", expr.serializeToText(IdentifierQuotaStrategy.NONE));
         }
         {
             IExpression expr = ExpressionASTBuilder.builder().build("3m. toNanoSeconds");
 
             // The 69s.toNano is interpreted as toNanoSeconds(3m), which has been optimized to 180_000_000_000
-            Assertions.assertEquals("180000000000", expr.serializeToText(null));
+            Assertions.assertEquals("180000000000", expr.serializeToText(IdentifierQuotaStrategy.NONE));
         }
     }
 
     @Test
     public void test_LiteralExpression_PercentageLiteral() {
         IExpression expr = ExpressionASTBuilder.builder().build("a >= 5%");
-        Assertions.assertEquals("a >= 5%", expr.serializeToText(null));
+        Assertions.assertEquals("a >= 5%", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertTrue((boolean) expr.evaluate((name) -> 0.051f));
         Assertions.assertTrue((boolean) expr.evaluate((name) -> 0.05f));
@@ -293,22 +294,22 @@ public class ExpressionASTBuilderTest {
     @Test
     public void test_LiteralExpression_SizeLiteral() {
         IExpression expr = ExpressionASTBuilder.builder().build("a >= 5Ki");
-        Assertions.assertEquals("a >= 5Ki", expr.serializeToText(null));
+        Assertions.assertEquals("a >= 5Ki", expr.serializeToText(IdentifierQuotaStrategy.NONE));
         Assertions.assertTrue((boolean) expr.evaluate((name) -> 5 * 1024 + 1));
         Assertions.assertTrue((boolean) expr.evaluate((name) -> 5 * 1024));
         Assertions.assertFalse((boolean) expr.evaluate((name) -> 5 * 1024 - 1));
 
-        Assertions.assertEquals("a >= 5K", ExpressionASTBuilder.builder().build("a >= 5K").serializeToText(null));
-        Assertions.assertEquals("a >= 5KiB", ExpressionASTBuilder.builder().build("a >= 5KiB").serializeToText(null));
-        Assertions.assertEquals("a >= 5G", ExpressionASTBuilder.builder().build("a >= 5G").serializeToText(null));
-        Assertions.assertEquals("a >= 5Gi", ExpressionASTBuilder.builder().build("a >= 5Gi").serializeToText(null));
-        Assertions.assertEquals("a >= 5GiB", ExpressionASTBuilder.builder().build("a >= 5GiB").serializeToText(null));
-        Assertions.assertEquals("a >= 5M", ExpressionASTBuilder.builder().build("a >= 5M").serializeToText(null));
-        Assertions.assertEquals("a >= 5Mi", ExpressionASTBuilder.builder().build("a >= 5Mi").serializeToText(null));
-        Assertions.assertEquals("a >= 5MiB", ExpressionASTBuilder.builder().build("a >= 5MiB").serializeToText(null));
-        Assertions.assertEquals("a >= 5P", ExpressionASTBuilder.builder().build("a >= 5P").serializeToText(null));
-        Assertions.assertEquals("a >= 5Pi", ExpressionASTBuilder.builder().build("a >= 5Pi").serializeToText(null));
-        Assertions.assertEquals("a >= 5PiB", ExpressionASTBuilder.builder().build("a >= 5PiB").serializeToText(null));
+        Assertions.assertEquals("a >= 5K", ExpressionASTBuilder.builder().build("a >= 5K").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5KiB", ExpressionASTBuilder.builder().build("a >= 5KiB").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5G", ExpressionASTBuilder.builder().build("a >= 5G").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5Gi", ExpressionASTBuilder.builder().build("a >= 5Gi").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5GiB", ExpressionASTBuilder.builder().build("a >= 5GiB").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5M", ExpressionASTBuilder.builder().build("a >= 5M").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5Mi", ExpressionASTBuilder.builder().build("a >= 5Mi").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5MiB", ExpressionASTBuilder.builder().build("a >= 5MiB").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5P", ExpressionASTBuilder.builder().build("a >= 5P").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5Pi", ExpressionASTBuilder.builder().build("a >= 5Pi").serializeToText(IdentifierQuotaStrategy.NONE));
+        Assertions.assertEquals("a >= 5PiB", ExpressionASTBuilder.builder().build("a >= 5PiB").serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionSerializerTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionSerializerTest.java
@@ -22,6 +22,7 @@ import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.LogicalExpression;
 import org.bithon.component.commons.expression.MapAccessExpression;
 import org.bithon.component.commons.expression.serialization.ExpressionSerializer;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +44,7 @@ public class ExpressionSerializerTest {
     public void testUnQuotedIdentifier() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 1");
 
-        Assertions.assertEquals("a = 1", expr.serializeToText(null));
+        Assertions.assertEquals("a = 1", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -51,13 +52,13 @@ public class ExpressionSerializerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 1");
 
         Assertions.assertEquals("default.a = 1", new ExpressionSerializer("default", null).serialize(expr));
-        Assertions.assertEquals("\"default\".\"a\" = 1", new ExpressionSerializer("default", (s) -> "\"" + s + "\"").serialize(expr));
+        Assertions.assertEquals("\"default\".\"a\" = 1", new ExpressionSerializer("default", IdentifierQuotaStrategy.DOUBLE_QUOTE).serialize(expr));
     }
 
     @Test
     public void testMapAccessExpression() {
         IExpression expr = ExpressionASTBuilder.builder().build("a ['b']");
-        Assertions.assertEquals("a['b']", expr.serializeToText(null));
+        Assertions.assertEquals("a['b']", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
         expr = ExpressionASTBuilder.builder().build("i > 5 AND colors['today'] = 'red'");
         Assertions.assertInstanceOf(LogicalExpression.AND.class, expr);

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionValidationTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/ExpressionValidationTest.java
@@ -17,6 +17,7 @@
 package org.bithon.server.storage.common.expression;
 
 import org.bithon.component.commons.expression.function.Functions;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.component.commons.expression.validation.ExpressionValidationException;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
@@ -68,18 +69,18 @@ public class ExpressionValidationTest {
                                 ExpressionASTBuilder.builder()
                                                 .schema(schema)
                                                 .build("5 < a")
-                                                .serializeToText(null));
+                                                .serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertEquals("a > '5'", ExpressionASTBuilder.builder()
                                                            .schema(schema)
                                                            .build("a > 5")
-                                                           .serializeToText(null));
+                                                           .serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertEquals("a > '5.3'",
                             ExpressionASTBuilder.builder()
                                                 .schema(schema)
                                                 .build("5.3 < a")
-                                                .serializeToText(null));
+                                                .serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -88,13 +89,13 @@ public class ExpressionValidationTest {
         Assertions.assertEquals("intB > 5", ExpressionASTBuilder.builder()
                                                             .schema(schema)
                                                             .build("intB > '5'")
-                                                            .serializeToText(null));
+                                                            .serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertThrows(ExpressionValidationException.class,
                             () -> ExpressionASTBuilder.builder()
                                                       .schema(schema)
                                                       .build("intB > 'valid'")
-                                                      .serializeToText(null));
+                                                      .serializeToText(IdentifierQuotaStrategy.NONE));
 
     }
 
@@ -108,19 +109,19 @@ public class ExpressionValidationTest {
                             ExpressionASTBuilder.builder()
                                                 .schema(schema)
                                                 .build("timestamp > '2023-01-04 00:00:00'")
-                                                .serializeToText(null));
+                                                .serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertThrows(ExpressionValidationException.class,
                             () -> ExpressionASTBuilder.builder()
                                                       .schema(schema)
                                                       .build("timestamp > 'invalid'")
-                                                      .serializeToText(null));
+                                                      .serializeToText(IdentifierQuotaStrategy.NONE));
 
         Assertions.assertThrows(ExpressionValidationException.class,
                             () -> ExpressionASTBuilder.builder()
                                                       .schema(schema)
                                                       .build("timestamp > not_defined")
-                                                      .serializeToText(null));
+                                                      .serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -131,7 +132,7 @@ public class ExpressionValidationTest {
                             ExpressionASTBuilder.builder()
                                                 .schema(schema)
                                                 .build("timestamp > " + timeSpan.getMilliseconds())
-                                                .serializeToText(null));
+                                                .serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/FunctionsTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/FunctionsTest.java
@@ -19,6 +19,7 @@ package org.bithon.server.storage.common.expression;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.expt.InvalidExpressionException;
 import org.bithon.component.commons.expression.function.Functions;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +49,7 @@ public class FunctionsTest {
     @Test
     public void test_round_ExpressionAsParameter() {
         String expression = "round(a*b/c+d,2)";
-        Assertions.assertEquals("round(((a * b) / c) + d, 2)", builder.build(expression).serializeToText(null));
+        Assertions.assertEquals("round(((a * b) / c) + d, 2)", builder.build(expression).serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -276,7 +277,7 @@ public class FunctionsTest {
     public void test_count() {
         IExpression expr = ExpressionASTBuilder.builder().functions(Functions.getInstance()).build("count(1)");
 
-        Assertions.assertEquals("count(1)", expr.serializeToText(null));
+        Assertions.assertEquals("count(1)", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test

--- a/server/storage/src/test/java/org/bithon/server/storage/common/expression/optimizer/ExpressionOptimizerTest.java
+++ b/server/storage/src/test/java/org/bithon/server/storage/common/expression/optimizer/ExpressionOptimizerTest.java
@@ -22,6 +22,7 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.function.IFunction;
 import org.bithon.component.commons.expression.function.IFunctionProvider;
+import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.server.storage.common.expression.ExpressionASTBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -186,35 +187,35 @@ public class ExpressionOptimizerTest {
     public void test_NotReplaced() {
         IExpression expr = ExpressionASTBuilder.builder().functions(Functions.getInstance()).build("hasToken(a, 'ab')");
 
-        Assertions.assertEquals("hasToken(a, 'ab')", expr.serializeToText(null));
+        Assertions.assertEquals("hasToken(a, 'ab')", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_RemoveAlwaysTrueCondition() {
         IExpression expr = ExpressionASTBuilder.builder().build("1 AND a = 'Good'");
 
-        Assertions.assertEquals("a = 'Good'", expr.serializeToText(null));
+        Assertions.assertEquals("a = 'Good'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_RemoveAlwaysTrueCondition_2() {
         IExpression expr = ExpressionASTBuilder.builder().build("1 = 1 AND a = 'Good'");
 
-        Assertions.assertEquals("a = 'Good'", expr.serializeToText(null));
+        Assertions.assertEquals("a = 'Good'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_RemoveAlwaysTrueCondition_3() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 'Good' AND 1 = 1");
 
-        Assertions.assertEquals("a = 'Good'", expr.serializeToText(null));
+        Assertions.assertEquals("a = 'Good'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_RemoveAlwaysTrueCondition_4() {
         IExpression expr = ExpressionASTBuilder.builder().build("2 > 1 AND 1 = 1");
 
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -222,7 +223,7 @@ public class ExpressionOptimizerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("0 AND a = 'God'");
 
         Assertions.assertInstanceOf(LiteralExpression.class, expr);
-        Assertions.assertEquals("false", expr.serializeToText(null));
+        Assertions.assertEquals("false", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -230,7 +231,7 @@ public class ExpressionOptimizerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 'God' AND b = 'is' AND 'good' = 'bad'");
 
         Assertions.assertInstanceOf(LiteralExpression.class, expr);
-        Assertions.assertEquals("false", expr.serializeToText(null));
+        Assertions.assertEquals("false", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -238,7 +239,7 @@ public class ExpressionOptimizerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("1 OR a = 'Good'");
 
         Assertions.assertInstanceOf(LiteralExpression.class, expr);
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -246,7 +247,7 @@ public class ExpressionOptimizerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("1 = 1 OR a = 'Good'");
 
         Assertions.assertInstanceOf(LiteralExpression.class, expr);
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -254,7 +255,7 @@ public class ExpressionOptimizerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 'Good' OR 1 = 1");
 
         Assertions.assertInstanceOf(LiteralExpression.class, expr);
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -262,70 +263,70 @@ public class ExpressionOptimizerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("2 > 1 OR 1 = 1");
 
         Assertions.assertInstanceOf(LiteralExpression.BooleanLiteral.class, expr);
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_OptimizeOR_5() {
         IExpression expr = ExpressionASTBuilder.builder().build("0 OR a = 'God'");
 
-        Assertions.assertEquals("a = 'God'", expr.serializeToText(null));
+        Assertions.assertEquals("a = 'God'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_OptimizeOR_6() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 'God' OR 1 > 2 OR b = 'c'");
 
-        Assertions.assertEquals("(a = 'God') OR (b = 'c')", expr.serializeToText(null));
+        Assertions.assertEquals("(a = 'God') OR (b = 'c')", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_OptimizeLogical() {
         IExpression expr = ExpressionASTBuilder.builder().build("a = 'God' OR 1 > 2 OR b = 'c' AND 1 = 1");
 
-        Assertions.assertEquals("(a = 'God') OR (b = 'c')", expr.serializeToText(null));
+        Assertions.assertEquals("(a = 'God') OR (b = 'c')", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Optimize_Constant_NOT() {
         IExpression expr = ExpressionASTBuilder.builder().build("NOT 1 = 1");
 
-        Assertions.assertEquals("false", expr.serializeToText(null));
+        Assertions.assertEquals("false", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Optimize_Constant_NOT_2() {
         IExpression expr = ExpressionASTBuilder.builder().build("NOT 1 > 1");
 
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Optimize_Constant_NOT_3() {
         IExpression expr = ExpressionASTBuilder.builder().build("NOT 1 >= 1");
 
-        Assertions.assertEquals("false", expr.serializeToText(null));
+        Assertions.assertEquals("false", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Optimize_Constant_NOT_4() {
         IExpression expr = ExpressionASTBuilder.builder().build("NOT (a = 'God' AND 0)");
 
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Optimize_Constant_NOT_IN() {
         IExpression expr = ExpressionASTBuilder.builder().build("NOT (1 in (1))");
 
-        Assertions.assertEquals("false", expr.serializeToText(null));
+        Assertions.assertEquals("false", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Optimize_Constant_NOT_NOT_IN() {
         IExpression expr = ExpressionASTBuilder.builder().build("NOT (1 not in (1))");
 
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
@@ -333,56 +334,56 @@ public class ExpressionOptimizerTest {
         IExpression expr = ExpressionASTBuilder.builder().build("1 AND 2");
 
         Assertions.assertInstanceOf(LiteralExpression.class, expr);
-        Assertions.assertEquals("true", expr.serializeToText(null));
+        Assertions.assertEquals("true", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Not_NotIn() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a not in (1,2,3)");
-        Assertions.assertEquals("a in (1, 2, 3)", expr.serializeToText(null));
+        Assertions.assertEquals("a in (1, 2, 3)", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Not_NotLike() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a not contains 'a'");
-        Assertions.assertEquals("a contains 'a'", expr.serializeToText(null));
+        Assertions.assertEquals("a contains 'a'", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Not_EQ() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a = b");
-        Assertions.assertEquals("a <> b", expr.serializeToText(null));
+        Assertions.assertEquals("a <> b", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Not_NE() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a <> b");
-        Assertions.assertEquals("a = b", expr.serializeToText(null));
+        Assertions.assertEquals("a = b", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Not_GT() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a > b");
-        Assertions.assertEquals("a <= b", expr.serializeToText(null));
+        Assertions.assertEquals("a <= b", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Not_GTE() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a >= b");
-        Assertions.assertEquals("a < b", expr.serializeToText(null));
+        Assertions.assertEquals("a < b", expr.serializeToText(IdentifierQuotaStrategy.NONE));
 
     }
 
     @Test
     public void test_Not_LT() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a < b");
-        Assertions.assertEquals("a >= b", expr.serializeToText(null));
+        Assertions.assertEquals("a >= b", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test
     public void test_Not_LTE() {
         IExpression expr = ExpressionASTBuilder.builder().build("not a <= b");
-        Assertions.assertEquals("a > b", expr.serializeToText(null));
+        Assertions.assertEquals("a > b", expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 
     @Test


### PR DESCRIPTION
Eliminated the VISITOR on serializer so that  expressions outside the core module can still customize the serialization