### PR TITLE
Apply optimization for function expressions

### DIFF
--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/ClickHouseSqlDialect.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/ClickHouseSqlDialect.java
@@ -23,6 +23,7 @@ import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.component.commons.expression.function.builtin.TimeFunction;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
+import org.bithon.server.storage.datasource.ISchema;
 import org.bithon.server.storage.jdbc.clickhouse.common.optimizer.ClickHouseExpressionOptimizer;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
 
@@ -111,7 +112,7 @@ public class ClickHouseSqlDialect implements ISqlDialect {
     }
 
     @Override
-    public IExpression transform(IExpression expression) {
-        return expression == null ? null : expression.accept(new ClickHouseExpressionOptimizer());
+    public IExpression transform(ISchema schema, IExpression expression) {
+        return expression == null ? null : expression.accept(new ClickHouseExpressionOptimizer(schema));
     }
 }

--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
@@ -81,7 +81,7 @@ public class ClickHouseExpressionOptimizer extends AbstractOptimizer {
                 IExpression inputArgs = expression.getArgs().get(0);
                 if (inputArgs instanceof IdentifierExpression identifier) {
                     IColumn column = schema.getColumnByName(identifier.getIdentifier());
-                    if (column instanceof AggregateFunctionColumn aggregateFunctionColumn) {
+                    if (column instanceof AggregateFunctionColumn) {
                         return new FunctionExpression(
                             AggregateFunctionColumn.SumMergeFunction.INSTANCE,
                             identifier
@@ -92,7 +92,7 @@ public class ClickHouseExpressionOptimizer extends AbstractOptimizer {
                 IExpression inputArgs = expression.getArgs().get(0);
                 if (inputArgs instanceof IdentifierExpression identifier) {
                     IColumn column = schema.getColumnByName(identifier.getIdentifier());
-                    if (column instanceof AggregateFunctionColumn aggregateFunctionColumn) {
+                    if (column instanceof AggregateFunctionColumn) {
                         return new FunctionExpression(
                             AggregateFunctionColumn.CountMergeFunction.INSTANCE,
                             identifier

--- a/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
+++ b/server/storage-jdbc-h2/src/main/java/org/bithon/server/storage/jdbc/h2/H2SqlDialect.java
@@ -31,6 +31,7 @@ import org.bithon.component.commons.expression.optimzer.AbstractOptimizer;
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
+import org.bithon.server.storage.datasource.ISchema;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
 import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
@@ -98,7 +99,7 @@ public class H2SqlDialect implements ISqlDialect {
     }
 
     @Override
-    public IExpression transform(IExpression expression) {
+    public IExpression transform(ISchema schema, IExpression expression) {
         return expression == null ? null : expression.accept(new AbstractOptimizer() {
             /**
              * H2 does not support Map, the JSON formatted string is stored in the column.

--- a/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
+++ b/server/storage-jdbc-mysql/src/main/java/org/bithon/server/storage/jdbc/mysql/MySQLSqlDialect.java
@@ -32,6 +32,7 @@ import org.bithon.component.commons.expression.serialization.IdentifierQuotaStra
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
+import org.bithon.server.storage.datasource.ISchema;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
 import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
@@ -99,7 +100,7 @@ public class MySQLSqlDialect implements ISqlDialect {
     }
 
     @Override
-    public IExpression transform(IExpression expression) {
+    public IExpression transform(ISchema schema, IExpression expression) {
         return expression == null ? null : expression.accept(new AbstractOptimizer() {
             /**
              * MYSQL does not support Map, the JSON formatted string is stored in the column.

--- a/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialect.java
+++ b/server/storage-jdbc-postgresql/src/main/java/org/bithon/server/storage/jdbc/postgresql/PostgresqlDialect.java
@@ -31,6 +31,7 @@ import org.bithon.component.commons.expression.optimzer.AbstractOptimizer;
 import org.bithon.component.commons.time.DateTime;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
+import org.bithon.server.storage.datasource.ISchema;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
 import org.bithon.server.storage.jdbc.common.dialect.LikeOperator;
 import org.bithon.server.storage.jdbc.common.dialect.MapAccessExpressionTransformer;
@@ -99,7 +100,7 @@ public class PostgresqlDialect implements ISqlDialect {
     }
 
     @Override
-    public IExpression transform(IExpression expression) {
+    public IExpression transform(ISchema schema, IExpression expression) {
         return expression == null ? null : expression.accept(new AbstractOptimizer() {
             /**
              * H2 does not support Map, the JSON formatted string is stored in the column.

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/Expression2Sql.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/Expression2Sql.java
@@ -33,17 +33,23 @@ import org.bithon.server.storage.datasource.ISchema;
  */
 public class Expression2Sql extends ExpressionSerializer {
 
-    public static String from(ISchema dataSource, ISqlDialect sqlDialect, IExpression expression) {
-        return from(dataSource.getDataStoreSpec().getStore(), sqlDialect, expression);
+    public static String from(ISchema schema,
+                              ISqlDialect sqlDialect,
+                              IExpression expression) {
+        return from(schema.getDataStoreSpec().getStore(),
+                    sqlDialect,
+                    expression);
     }
 
-    public static String from(String qualifier, ISqlDialect sqlDialect, IExpression expression) {
+    public static String from(String qualifier,
+                              ISqlDialect sqlDialect,
+                              IExpression expression) {
         if (expression == null) {
             return null;
         }
 
         // Apply DB-related transformation on general AST
-        IExpression transformed = sqlDialect.transform(expression);
+        IExpression transformed = sqlDialect.transform(null, expression);
 
         return new Expression2Sql(qualifier, sqlDialect).serialize(transformed);
     }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/ISqlDialect.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/ISqlDialect.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.server.commons.time.TimeSpan;
+import org.bithon.server.storage.datasource.ISchema;
 
 /**
  * Since we're writing some complex SQLs, we have to deal with different SQL syntax on different DBMS
@@ -63,7 +64,7 @@ public interface ISqlDialect {
     /**
      * Transform expressions for the target dialect
      */
-    default IExpression transform(IExpression expression) {
+    default IExpression transform(ISchema schema, IExpression expression) {
         return expression;
     }
 

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/ISqlDialect.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/dialect/ISqlDialect.java
@@ -64,6 +64,9 @@ public interface ISqlDialect {
     /**
      * Transform expressions for the target dialect
      */
+    default IExpression transform(IExpression expression) {
+        return transform(null, expression);
+    }
     default IExpression transform(ISchema schema, IExpression expression) {
         return expression;
     }

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/Expression2SqlSerializer.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/Expression2SqlSerializer.java
@@ -1,0 +1,110 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.storage.jdbc.common.statement;
+
+
+import org.bithon.component.commons.expression.FunctionExpression;
+import org.bithon.component.commons.expression.IExpression;
+import org.bithon.component.commons.expression.IdentifierExpression;
+import org.bithon.component.commons.expression.MacroExpression;
+import org.bithon.component.commons.expression.function.builtin.AggregateFunction;
+import org.bithon.component.commons.utils.StringUtils;
+import org.bithon.server.storage.datasource.query.ast.QueryStageFunctions;
+import org.bithon.server.storage.jdbc.common.dialect.Expression2Sql;
+import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+import org.bithon.server.storage.metrics.Interval;
+
+import java.util.Map;
+
+/**
+ * @author frank.chen021@outlook.com
+ * @date 12/4/25 9:57 am
+ */
+class Expression2SqlSerializer extends Expression2Sql {
+    protected final Map<String, Object> variables;
+    private long windowFunctionLength;
+
+    Expression2SqlSerializer(ISqlDialect sqlDialect, Map<String, Object> variables, Interval interval) {
+        super(null, sqlDialect);
+        this.variables = variables;
+
+        if (interval.getStep() != null) {
+            windowFunctionLength = interval.getStep().getSeconds();
+        } else {
+            /**
+             * For Window functions, since the timestamp of records might cross two windows,
+             * we need to make sure the record in the given time range has only one window.
+             */
+            long endTime = interval.getEndTime().getMilliseconds();
+            long startTime = interval.getStartTime().getMilliseconds();
+            windowFunctionLength = (endTime - startTime) / 1000;
+            while (startTime / windowFunctionLength != endTime / windowFunctionLength) {
+                windowFunctionLength *= 2;
+            }
+        }
+    }
+
+    @Override
+    public String serialize(IExpression expression) {
+        // Apply optimization for different DBMS first
+        sqlDialect.transform(expression).serializeToText(this);
+        return sb.toString();
+    }
+
+    @Override
+    public void serialize(MacroExpression expression) {
+        Object variableValue = variables.get(expression.getMacro());
+        if (variableValue == null) {
+            throw new RuntimeException(StringUtils.format("variable (%s) not provided in context",
+                                                          expression.getMacro()));
+        }
+        sb.append(variableValue);
+    }
+
+    @Override
+    public void serialize(FunctionExpression expression) {
+        if (expression.getFunction() instanceof QueryStageFunctions.Cardinality) {
+            sb.append("count(distinct ");
+            expression.getArgs().get(0).serializeToText(this);
+            sb.append(")");
+            return;
+        }
+
+        if (expression.getFunction() instanceof QueryStageFunctions.GroupConcat) {
+            // Currently, only identifier expression is supported in the group concat aggregator
+            String column = ((IdentifierExpression) expression.getArgs().get(0)).getIdentifier();
+            sb.append(this.sqlDialect.stringAggregator(column));
+            return;
+        }
+
+        if (expression.getFunction() instanceof AggregateFunction.Last) {
+            // Currently, only identifier expression is supported in the last aggregator
+            String column = ((IdentifierExpression) expression.getArgs().get(0)).getIdentifier();
+            sb.append(this.sqlDialect.lastAggregator(column, windowFunctionLength));
+            return;
+        }
+
+        if (expression.getFunction() instanceof AggregateFunction.First) {
+            // Currently, only identifier expression is supported in the first aggregator
+            String column = ((IdentifierExpression) expression.getArgs().get(0)).getIdentifier();
+            sb.append(this.sqlDialect.firstAggregator(column, windowFunctionLength));
+            return;
+        }
+
+        super.serialize(expression);
+    }
+}

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/Expression2SqlSerializer.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/Expression2SqlSerializer.java
@@ -61,7 +61,7 @@ class Expression2SqlSerializer extends Expression2Sql {
     @Override
     public String serialize(IExpression expression) {
         // Apply optimization for different DBMS first
-        sqlDialect.transform(expression).serializeToText(this);
+        sqlDialect.transform(null, expression).serializeToText(this);
         return sb.toString();
     }
 

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilder.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilder.java
@@ -81,8 +81,8 @@ public class SelectStatementBuilder {
         return new SelectStatementBuilder();
     }
 
-    public SelectStatementBuilder dataSource(ISchema dataSource) {
-        this.schema = dataSource;
+    public SelectStatementBuilder schema(ISchema schema) {
+        this.schema = schema;
         return this;
     }
 

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilder.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilder.java
@@ -350,7 +350,7 @@ public class SelectStatementBuilder {
 
         if (this.filter != null) {
             // Apply dialect's transformation on general AST
-            this.filter = sqlDialect.transform(this.filter);
+            this.filter = sqlDialect.transform(this.schema, this.filter);
 
             this.filter.accept(new IExpressionInDepthVisitor() {
                 @Override
@@ -382,8 +382,11 @@ public class SelectStatementBuilder {
         // Round 1, determine aggregation steps
         for (Selector selector : this.selectors) {
             IASTNode selectExpression = selector.getSelectExpression();
-            if (selectExpression instanceof Expression) {
-                IExpression parsedExpression = ((Expression) selectExpression).getParsedExpression();
+            if (selectExpression instanceof Expression expression) {
+                IExpression parsedExpression = expression.getParsedExpression();
+
+                // Apply dialect's transformation first
+                expression.setParsedExpression(sqlDialect.transform(this.schema, parsedExpression));
 
                 if (parsedExpression instanceof FunctionExpression functionExpression) {
                     if (!functionExpression.getFunction().isAggregator()) {

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementPipeline.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementPipeline.java
@@ -1,0 +1,64 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.storage.jdbc.common.statement;
+
+
+import org.bithon.server.storage.datasource.query.ast.FromClause;
+import org.bithon.server.storage.datasource.query.ast.SelectStatement;
+import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author frank.chen021@outlook.com
+ * @date 12/4/25 9:55 am
+ */
+class SelectStatementPipeline {
+    final SelectStatement aggregation = new SelectStatement();
+    SelectStatement windowAggregation;
+    SelectStatement postAggregation;
+    SelectStatement outermost;
+    SelectStatement innermost;
+
+    int nestIndex = 0;
+
+    public void chain(ISqlDialect sqlDialect) {
+        List<SelectStatement> pipelines = new ArrayList<>();
+        if (windowAggregation != null) {
+            pipelines.add(windowAggregation);
+        }
+
+        pipelines.add(aggregation);
+
+        if (postAggregation != null) {
+            pipelines.add(postAggregation);
+        }
+
+        for (int i = 1; i < pipelines.size(); i++) {
+            FromClause from = pipelines.get(i).getFrom();
+            from.setExpression(pipelines.get(i - 1));
+
+            if (sqlDialect.needTableAlias()) {
+                from.setAlias("tbl" + nestIndex++);
+            }
+        }
+
+        this.outermost = pipelines.get(pipelines.size() - 1);
+        this.innermost = pipelines.get(0);
+    }
+}

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SqlGenerator.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/common/statement/SqlGenerator.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package org.bithon.server.storage.jdbc.metric;
+package org.bithon.server.storage.jdbc.common.statement;
 
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.utils.CollectionUtils;
@@ -27,7 +27,7 @@ import org.bithon.server.storage.datasource.query.ast.HavingClause;
 import org.bithon.server.storage.datasource.query.ast.IASTNodeVisitor;
 import org.bithon.server.storage.datasource.query.ast.LimitClause;
 import org.bithon.server.storage.datasource.query.ast.OrderByClause;
-import org.bithon.server.storage.datasource.query.ast.QueryExpression;
+import org.bithon.server.storage.datasource.query.ast.SelectStatement;
 import org.bithon.server.storage.datasource.query.ast.Selector;
 import org.bithon.server.storage.datasource.query.ast.TableIdentifier;
 import org.bithon.server.storage.datasource.query.ast.TextNode;
@@ -57,7 +57,7 @@ public class SqlGenerator implements IASTNodeVisitor {
     }
 
     @Override
-    public void before(QueryExpression queryExpression) {
+    public void before(SelectStatement selectStatement) {
         if (nestedSelect++ > 0) {
             sql.append('\n');
             sql.append(indent);
@@ -70,12 +70,12 @@ public class SqlGenerator implements IASTNodeVisitor {
     }
 
     @Override
-    public void visit(QueryExpression select) {
+    public void visit(SelectStatement select) {
         select.accept(this);
     }
 
     @Override
-    public void after(QueryExpression queryExpression) {
+    public void after(SelectStatement selectStatement) {
         if (--nestedSelect > 0) {
             indent = indent.substring(0, indent.length() - 2);
 

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
@@ -108,7 +108,7 @@ public class MetricJdbcReader implements IDataSourceReader {
     @Override
     public List<Map<String, Object>> timeseries(Query query) {
         SelectStatement selectStatement = SelectStatementBuilder.builder()
-                                                                .dataSource(query.getSchema())
+                                                                .schema(query.getSchema())
                                                                 .fields(query.getSelectors())
                                                                 .filter(query.getFilter())
                                                                 .interval(query.getInterval())
@@ -125,7 +125,7 @@ public class MetricJdbcReader implements IDataSourceReader {
     @Override
     public List<?> groupBy(Query query) {
         SelectStatement selectStatement = SelectStatementBuilder.builder()
-                                                                .dataSource(query.getSchema())
+                                                                .schema(query.getSchema())
                                                                 .fields(query.getSelectors())
                                                                 .filter(query.getFilter())
                                                                 .interval(query.getInterval())

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
@@ -30,11 +30,13 @@ import org.bithon.server.storage.datasource.query.Order;
 import org.bithon.server.storage.datasource.query.OrderBy;
 import org.bithon.server.storage.datasource.query.Query;
 import org.bithon.server.storage.datasource.query.ast.OrderByClause;
-import org.bithon.server.storage.datasource.query.ast.QueryExpression;
+import org.bithon.server.storage.datasource.query.ast.SelectStatement;
 import org.bithon.server.storage.datasource.query.ast.Selector;
 import org.bithon.server.storage.datasource.query.ast.TableIdentifier;
 import org.bithon.server.storage.datasource.query.ast.TextNode;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
+import org.bithon.server.storage.jdbc.common.statement.SelectStatementBuilder;
+import org.bithon.server.storage.jdbc.common.statement.SqlGenerator;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
@@ -105,7 +107,7 @@ public class MetricJdbcReader implements IDataSourceReader {
 
     @Override
     public List<Map<String, Object>> timeseries(Query query) {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .dataSource(query.getSchema())
                                                                 .fields(query.getSelectors())
                                                                 .filter(query.getFilter())
@@ -116,13 +118,13 @@ public class MetricJdbcReader implements IDataSourceReader {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(this.sqlDialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
         return executeSql(sqlGenerator.getSQL());
     }
 
     @Override
     public List<?> groupBy(Query query) {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .dataSource(query.getSchema())
                                                                 .fields(query.getSelectors())
                                                                 .filter(query.getFilter())
@@ -134,7 +136,7 @@ public class MetricJdbcReader implements IDataSourceReader {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(this.sqlDialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
         return fetch(sqlGenerator.getSQL(), query.getResultFormat());
     }
 
@@ -142,18 +144,18 @@ public class MetricJdbcReader implements IDataSourceReader {
     public List<?> select(Query query) {
         IdentifierExpression timestampCol = IdentifierExpression.of(query.getSchema().getTimestampSpec().getColumnName());
 
-        QueryExpression queryExpression = new QueryExpression();
-        queryExpression.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
         for (Selector selector : query.getSelectors()) {
-            queryExpression.getSelectorList().add(selector.getSelectExpression(), selector.getOutput(), selector.getDataType());
+            selectStatement.getSelectorList().add(selector.getSelectExpression(), selector.getOutput(), selector.getDataType());
         }
-        queryExpression.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
-        queryExpression.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
-        queryExpression.getWhere().and(sqlDialect.transform(query.getFilter()));
-        queryExpression.setLimit(query.getLimit().toLimitClause());
-        queryExpression.setOrderBy(query.getOrderBy().toOrderByClause());
+        selectStatement.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
+        selectStatement.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
+        selectStatement.getWhere().and(sqlDialect.transform(query.getFilter()));
+        selectStatement.setLimit(query.getLimit().toLimitClause());
+        selectStatement.setOrderBy(query.getOrderBy().toOrderByClause());
         SqlGenerator generator = new SqlGenerator(sqlDialect);
-        queryExpression.accept(generator);
+        selectStatement.accept(generator);
         String sql = generator.getSQL();
 
         return executeSql(sql);
@@ -163,14 +165,14 @@ public class MetricJdbcReader implements IDataSourceReader {
     public int count(Query query) {
         IdentifierExpression timestampCol = IdentifierExpression.of(query.getSchema().getTimestampSpec().getColumnName());
 
-        QueryExpression queryExpression = new QueryExpression();
-        queryExpression.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
-        queryExpression.getSelectorList().add(new TextNode("count(1)"), IDataType.LONG);
-        queryExpression.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
-        queryExpression.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
-        queryExpression.getWhere().and(sqlDialect.transform(query.getFilter()));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
+        selectStatement.getSelectorList().add(new TextNode("count(1)"), IDataType.LONG);
+        selectStatement.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
+        selectStatement.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
+        selectStatement.getWhere().and(sqlDialect.transform(query.getFilter()));
         SqlGenerator generator = new SqlGenerator(sqlDialect);
-        queryExpression.accept(generator);
+        selectStatement.accept(generator);
         String sql = generator.getSQL();
 
         log.info("Executing {}", sql);
@@ -219,16 +221,16 @@ public class MetricJdbcReader implements IDataSourceReader {
 
         String dimension = query.getSelectors().get(0).getOutputName();
 
-        QueryExpression queryExpression = new QueryExpression();
-        queryExpression.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
-        queryExpression.getSelectorList().add(new TextNode(StringUtils.format("DISTINCT(%s)", sqlDialect.quoteIdentifier(dimension))), dimension, IDataType.STRING);
-        queryExpression.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
-        queryExpression.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
-        queryExpression.getWhere().and(sqlDialect.transform(query.getFilter()));
-        queryExpression.getWhere().and(new ComparisonExpression.NE(IdentifierExpression.of(dimension), new LiteralExpression.StringLiteral("")));
-        queryExpression.setOrderBy(new OrderByClause(dimension, Order.asc));
+        SelectStatement selectStatement = new SelectStatement();
+        selectStatement.getFrom().setExpression(new TableIdentifier(query.getSchema().getDataStoreSpec().getStore()));
+        selectStatement.getSelectorList().add(new TextNode(StringUtils.format("DISTINCT(%s)", sqlDialect.quoteIdentifier(dimension))), dimension, IDataType.STRING);
+        selectStatement.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
+        selectStatement.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
+        selectStatement.getWhere().and(sqlDialect.transform(query.getFilter()));
+        selectStatement.getWhere().and(new ComparisonExpression.NE(IdentifierExpression.of(dimension), new LiteralExpression.StringLiteral("")));
+        selectStatement.setOrderBy(new OrderByClause(dimension, Order.asc));
         SqlGenerator generator = new SqlGenerator(sqlDialect);
-        queryExpression.accept(generator);
+        selectStatement.accept(generator);
         String sql = generator.getSQL();
 
         log.info("Executing {}", sql);

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/metric/MetricJdbcReader.java
@@ -151,7 +151,7 @@ public class MetricJdbcReader implements IDataSourceReader {
         }
         selectStatement.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
         selectStatement.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
-        selectStatement.getWhere().and(sqlDialect.transform(query.getFilter()));
+        selectStatement.getWhere().and(sqlDialect.transform(query.getSchema(), query.getFilter()));
         selectStatement.setLimit(query.getLimit().toLimitClause());
         selectStatement.setOrderBy(query.getOrderBy().toOrderByClause());
         SqlGenerator generator = new SqlGenerator(sqlDialect);
@@ -170,7 +170,7 @@ public class MetricJdbcReader implements IDataSourceReader {
         selectStatement.getSelectorList().add(new TextNode("count(1)"), IDataType.LONG);
         selectStatement.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
         selectStatement.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
-        selectStatement.getWhere().and(sqlDialect.transform(query.getFilter()));
+        selectStatement.getWhere().and(sqlDialect.transform(query.getSchema(), query.getFilter()));
         SqlGenerator generator = new SqlGenerator(sqlDialect);
         selectStatement.accept(generator);
         String sql = generator.getSQL();
@@ -226,7 +226,7 @@ public class MetricJdbcReader implements IDataSourceReader {
         selectStatement.getSelectorList().add(new TextNode(StringUtils.format("DISTINCT(%s)", sqlDialect.quoteIdentifier(dimension))), dimension, IDataType.STRING);
         selectStatement.getWhere().and(new ComparisonExpression.GTE(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getStartTime())));
         selectStatement.getWhere().and(new ComparisonExpression.LT(timestampCol, sqlDialect.toTimestampExpression(query.getInterval().getEndTime())));
-        selectStatement.getWhere().and(sqlDialect.transform(query.getFilter()));
+        selectStatement.getWhere().and(sqlDialect.transform(query.getSchema(), query.getFilter()));
         selectStatement.getWhere().and(new ComparisonExpression.NE(IdentifierExpression.of(dimension), new LiteralExpression.StringLiteral("")));
         selectStatement.setOrderBy(new OrderByClause(dimension, Order.asc));
         SqlGenerator generator = new SqlGenerator(sqlDialect);

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilderTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilderTest.java
@@ -40,8 +40,8 @@ import org.bithon.server.storage.datasource.query.Order;
 import org.bithon.server.storage.datasource.query.OrderBy;
 import org.bithon.server.storage.datasource.query.ast.Alias;
 import org.bithon.server.storage.datasource.query.ast.Expression;
-import org.bithon.server.storage.datasource.query.ast.SelectStatement;
 import org.bithon.server.storage.datasource.query.ast.QueryStageFunctions;
+import org.bithon.server.storage.datasource.query.ast.SelectStatement;
 import org.bithon.server.storage.datasource.query.ast.Selector;
 import org.bithon.server.storage.datasource.store.IDataStoreSpec;
 import org.bithon.server.storage.jdbc.common.dialect.ISqlDialect;
@@ -49,7 +49,6 @@ import org.bithon.server.storage.metrics.Interval;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
 
 import java.time.Duration;
 import java.util.Arrays;

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilderTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilderTest.java
@@ -316,7 +316,7 @@ public class SelectStatementBuilderTest {
                                                                                       TimeSpan.fromISO8601(
                                                                                           "2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -344,7 +344,7 @@ public class SelectStatementBuilderTest {
                                                                                       TimeSpan.fromISO8601(
                                                                                           "2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -376,7 +376,7 @@ public class SelectStatementBuilderTest {
                                                                                           "timestamp")
                                                                 ))
                                                                 .groupBy(List.of("appName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -407,7 +407,7 @@ public class SelectStatementBuilderTest {
                                                                                       TimeSpan.fromISO8601(
                                                                                           "2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -445,7 +445,7 @@ public class SelectStatementBuilderTest {
                                                                                       TimeSpan.fromISO8601(
                                                                                           "2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -486,7 +486,7 @@ public class SelectStatementBuilderTest {
                                                                                       new IdentifierExpression(
                                                                                           "timestamp")))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -526,7 +526,7 @@ public class SelectStatementBuilderTest {
                                                                                       TimeSpan.fromISO8601(
                                                                                           "2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -565,7 +565,7 @@ public class SelectStatementBuilderTest {
                                                                                       TimeSpan.fromISO8601(
                                                                                           "2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -605,7 +605,7 @@ public class SelectStatementBuilderTest {
                                                                 .groupBy(List.of("appName", "instanceName"))
                                                                 .filter(new ComparisonExpression.GT(new IdentifierExpression(
                                                                     "a"), new LiteralExpression.LongLiteral(5)))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -641,7 +641,7 @@ public class SelectStatementBuilderTest {
                                                                                       TimeSpan.fromISO8601(
                                                                                           "2024-07-26T21:32:00.000+0800")))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(clickHouseDialect);
@@ -675,7 +675,7 @@ public class SelectStatementBuilderTest {
                                                                                       new IdentifierExpression(
                                                                                           "timestamp")))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -718,7 +718,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("timestamp")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -768,7 +768,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("timestamp")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(clickHouseDialect);
@@ -811,7 +811,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("timestamp")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -861,7 +861,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("timestamp")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(mysql);
@@ -912,7 +912,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("appName")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -956,7 +956,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("appName")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -989,7 +989,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("appName")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -1039,7 +1039,7 @@ public class SelectStatementBuilderTest {
                                                                                 .name("appName")
                                                                                 .order(Order.asc)
                                                                                 .build())
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -1085,7 +1085,7 @@ public class SelectStatementBuilderTest {
                                                                     )
                                                                 )
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -1131,7 +1131,7 @@ public class SelectStatementBuilderTest {
                                                                 .filter(new ComparisonExpression.GT(new IdentifierExpression(
                                                                     "cnt"), new LiteralExpression.LongLiteral(1000)))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -1168,7 +1168,7 @@ public class SelectStatementBuilderTest {
                                                                                                     new LiteralExpression.LongLiteral(
                                                                                                         1000)))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -1202,7 +1202,7 @@ public class SelectStatementBuilderTest {
                                                                                             .functions(Functions.getInstance())
                                                                                             .build("avgResponseTime > 5"))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
@@ -1251,7 +1251,7 @@ public class SelectStatementBuilderTest {
                                                                                             .functions(Functions.getInstance())
                                                                                             .build("avgResponseTime > 5"))
                                                                 .groupBy(List.of("appName", "instanceName"))
-                                                                .dataSource(schema)
+                                                                .schema(schema)
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(clickHouseDialect);

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilderTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/common/statement/SelectStatementBuilderTest.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package org.bithon.server.storage.jdbc.metric;
+package org.bithon.server.storage.jdbc.common.statement;
 
 import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.IExpression;
@@ -40,7 +40,7 @@ import org.bithon.server.storage.datasource.query.Order;
 import org.bithon.server.storage.datasource.query.OrderBy;
 import org.bithon.server.storage.datasource.query.ast.Alias;
 import org.bithon.server.storage.datasource.query.ast.Expression;
-import org.bithon.server.storage.datasource.query.ast.QueryExpression;
+import org.bithon.server.storage.datasource.query.ast.SelectStatement;
 import org.bithon.server.storage.datasource.query.ast.QueryStageFunctions;
 import org.bithon.server.storage.datasource.query.ast.Selector;
 import org.bithon.server.storage.datasource.store.IDataStoreSpec;
@@ -61,7 +61,7 @@ import java.util.TimeZone;
  * @author frank.chen021@outlook.com
  * @date 26/7/24 10:44 am
  */
-public class QueryExpressionBuilderTest {
+public class SelectStatementBuilderTest {
 
     private final ISchema schema = new DefaultSchema("bithon-jvm-metrics",
                                                      "bithon-jvm-metrics",
@@ -307,7 +307,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testSimpleAggregation_GroupBy() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -321,7 +321,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -335,7 +335,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testExpressionInAggregation_GroupBy() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -349,7 +349,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -363,7 +363,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testSimpleAggregation_TimeSeries() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -381,7 +381,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT UNIX_TIMESTAMP("timestamp")/ 10 * 10 AS "_timestamp",
@@ -396,7 +396,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testPostAggregation_GroupBy() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -412,7 +412,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -434,7 +434,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testPostAggregation_GroupBy_NestedFunction() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -450,7 +450,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -472,7 +472,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testPostAggregation_TimeSeries() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -491,7 +491,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "_timestamp",
@@ -515,7 +515,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testPostFunctionExpression_GroupBy() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -531,7 +531,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -553,7 +553,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testDuplicateAggregations() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(List.of(new Selector(new Expression(schema,
                                                                                                             "sum(count4xx) + sum(count5xx)"),
@@ -570,7 +570,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -594,7 +594,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testWindowFunction_GroupBy() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -610,7 +610,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -632,7 +632,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testWindowFunction_GroupBy_NoUseWindowAggregator() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(clickHouseDialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -646,7 +646,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(clickHouseDialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -661,7 +661,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testWindowFunction_TimeSeries() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -680,7 +680,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "_timestamp",
@@ -703,7 +703,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testWindowFunction_WithAggregator() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -723,7 +723,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -753,7 +753,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testWindowFunction_NoUseWindowAggregator_WithAggregator() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(clickHouseDialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -773,7 +773,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(clickHouseDialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -796,7 +796,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testWindowFunctionAfterAggregator() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -816,7 +816,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -846,7 +846,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testWindowFunctionAfterAggregator_MySQL() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(mysql)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -866,7 +866,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(mysql);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -896,7 +896,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testAggregationWithMacroExpression() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -917,7 +917,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "_timestamp",
@@ -941,7 +941,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testCardinalityAggregation() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -961,7 +961,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -976,7 +976,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testCountAggregation() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -994,7 +994,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -1009,7 +1009,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testHumanReadableLiteral() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -1044,7 +1044,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -1062,7 +1062,7 @@ public class QueryExpressionBuilderTest {
      */
     @Test
     public void testPostFilter_UseExpressionVariable() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -1090,7 +1090,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT *
@@ -1120,7 +1120,7 @@ public class QueryExpressionBuilderTest {
      */
     @Test
     public void testPostFilter_UseAggregationAliasInFilter() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -1136,7 +1136,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -1155,7 +1155,7 @@ public class QueryExpressionBuilderTest {
      */
     @Test
     public void testPostFilter_UseAggregationFilter() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -1173,7 +1173,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         Assertions.assertEquals("""
                                     SELECT "appName",
@@ -1189,7 +1189,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testPostFilter_FilterNotInTheSelectList_H2() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(h2Dialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -1207,7 +1207,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(h2Dialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         // NOTE that in the WHERE clause, the rhs is 5.0, however, our input is 5
         // This is because the avgResponse is defined as DOUBLE,
@@ -1238,7 +1238,7 @@ public class QueryExpressionBuilderTest {
 
     @Test
     public void testPostFilter_FilterNotInTheSelectList_CK() {
-        QueryExpression queryExpression = QueryExpressionBuilder.builder()
+        SelectStatement selectStatement = SelectStatementBuilder.builder()
                                                                 .sqlDialect(clickHouseDialect)
                                                                 .fields(Collections.singletonList(new Selector(new Expression(
                                                                     schema,
@@ -1256,7 +1256,7 @@ public class QueryExpressionBuilderTest {
                                                                 .build();
 
         SqlGenerator sqlGenerator = new SqlGenerator(clickHouseDialect);
-        queryExpression.accept(sqlGenerator);
+        selectStatement.accept(sqlGenerator);
 
         // NOTE that in the WHERE clause, the rhs is 5.0, however, our input is 5
         // This is because the avgResponse is defined as DOUBLE,

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/IASTNodeVisitor.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/IASTNodeVisitor.java
@@ -22,11 +22,11 @@ package org.bithon.server.storage.datasource.query.ast;
  */
 public interface IASTNodeVisitor {
 
-    void before(QueryExpression queryExpression);
+    void before(SelectStatement selectStatement);
 
-    void visit(QueryExpression queryExpression);
+    void visit(SelectStatement selectStatement);
 
-    void after(QueryExpression queryExpression);
+    void after(SelectStatement selectStatement);
 
     void visit(OrderByClause orderBy);
 

--- a/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/SelectStatement.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/datasource/query/ast/SelectStatement.java
@@ -29,7 +29,7 @@ import lombok.Getter;
  * @date 2022/9/4 14:55
  */
 @Data
-public class QueryExpression implements IASTNode {
+public class SelectStatement implements IASTNode {
     @Getter
     private final SelectorList selectorList = new SelectorList();
 


### PR DESCRIPTION
Separated from #1000 and apply some refactoring on underlying sql objects.

Background:
at the api layer, we can accept expression like: sum(a), it needs to be turned into sumMerge(a) if a is a AggregateFunction type. This is done if the sum(a) is passed by the aggregator and field property in the QueryField, but missed if it's pass by the expression property.
