### PR TITLE
Fix out of range exception

### DIFF
--- a/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
+++ b/server/storage-jdbc-clickhouse/src/main/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizer.java
@@ -88,7 +88,9 @@ public class ClickHouseExpressionOptimizer extends AbstractOptimizer {
                         );
                     }
                 }
-            } else if (expression.getFunction() instanceof AggregateFunction.Count) {
+            } else if (expression.getFunction() instanceof AggregateFunction.Count
+                       // 'count' aggregator can accept zero argument
+                       && !expression.getArgs().isEmpty()) {
                 IExpression inputArgs = expression.getArgs().get(0);
                 if (inputArgs instanceof IdentifierExpression identifier) {
                     IColumn column = schema.getColumnByName(identifier.getIdentifier());

--- a/server/storage-jdbc-clickhouse/src/test/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizerTest.java
+++ b/server/storage-jdbc-clickhouse/src/test/java/org/bithon/server/storage/jdbc/clickhouse/common/optimizer/ClickHouseExpressionOptimizerTest.java
@@ -20,8 +20,16 @@ import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.function.Functions;
 import org.bithon.component.commons.expression.serialization.IdentifierQuotaStrategy;
 import org.bithon.server.storage.common.expression.ExpressionASTBuilder;
+import org.bithon.server.storage.datasource.DefaultSchema;
+import org.bithon.server.storage.datasource.ISchema;
+import org.bithon.server.storage.datasource.TimestampSpec;
+import org.bithon.server.storage.datasource.column.StringColumn;
+import org.bithon.server.storage.datasource.column.aggregatable.sum.AggregateLongSumColumn;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 
 /**
@@ -89,6 +97,24 @@ public class ClickHouseExpressionOptimizerTest {
 
         Assertions.assertEquals(
             "hasToken(a, 'SERVER') AND hasToken(a, 'ERROR') AND (a like '%SERVER\\_ERROR%') AND hasToken(a, 'EXCEPTION') AND hasToken(a, 'CODE') AND (a like '%EXCEPTION\\_CODE%')",
+            expr.serializeToText(IdentifierQuotaStrategy.NONE));
+    }
+
+    @Test
+    public void test_ZeroCountAggregateFunction_OptimizationDoNothing() {
+        ISchema schema = new DefaultSchema("test-metrics",
+                                           "test-metrics",
+                                           new TimestampSpec("timestamp"),
+                                           Arrays.asList(new StringColumn("appName", "appName"), new StringColumn("type", "type")),
+                                           Collections.singletonList(new AggregateLongSumColumn("metric", "metric")));
+
+        IExpression expr = ExpressionASTBuilder.builder()
+                                               .functions(Functions.getInstance())
+                                               .build("count()")
+                                               .accept(new ClickHouseExpressionOptimizer(schema));
+
+        Assertions.assertEquals(
+            "count()",
             expr.serializeToText(IdentifierQuotaStrategy.NONE));
     }
 }


### PR DESCRIPTION
When expression `count()` is given, index out of range exception is thrown. introduced by #1002