### PR TITLE
Potential fix for code scanning alert no. 26: Use of externally-controlled format string

### DIFF
--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/ding/DingNotificationChannel.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/ding/DingNotificationChannel.java
@@ -113,7 +113,7 @@ public class DingNotificationChannel implements INotificationChannel {
             */
         }
         if (config.getRecordLinkTemplate() != null) {
-            section.add(new TextLine(StringUtils.format("[View Detail](" + config.getRecordLinkTemplate() + ")", message.getAlertRecordId())));
+            section.add(new TextLine(StringUtils.format("[View Detail](%s)", config.getRecordLinkTemplate())));
         }
 
         String content = FreeMarkerUtil.applyTemplate("/templates/alarm-notification.ftl", notificationContent);


### PR DESCRIPTION
Potential fix for [https://github.com/FrankChen021/bithon/security/code-scanning/26](https://github.com/FrankChen021/bithon/security/code-scanning/26)

The vulnerable use is in `StringUtils.format`, where an externally-controlled string is used as the format string argument. The recommended fix is to not treat user-provided (or attacker-controlled) values as format strings.  
Specifically, in `DingNotificationChannel.java`, change lines like:

```java
section.add(new TextLine(StringUtils.format("[View Detail](" + config.getRecordLinkTemplate() + ")", message.getAlertRecordId())));
```

to

```java
section.add(new TextLine(StringUtils.format("[View Detail](%s)", config.getRecordLinkTemplate())));
```

Here, the configuration value is now inserted as an argument, not as the format string, preventing any format specifiers in the user-controlled value from being interpreted.

Edit all regions in the code base where a user-controlled value is used as a format string argument. In this case, the snippet of concern is in `DingNotificationChannel.java`, specifically line 116.  
No new libraries are needed; this is a safe and local change, using basic string formatting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
