### PR TITLE
Support NOT expression for tags

### DIFF
--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/reader/TraceFilterSplitter.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/reader/TraceFilterSplitter.java
@@ -173,7 +173,7 @@ public class TraceFilterSplitter {
 
         @Override
         public Boolean visit(LogicalExpression expression) {
-            if (!(expression instanceof LogicalExpression.AND)) {
+            if (!(expression instanceof LogicalExpression.AND) && !(expression instanceof LogicalExpression.NOT)) {
                 throw new RuntimeException("Only AND operator is supported to search tracing.");
             }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable `NOT` in trace filter splitting and add `CONTAINS` support for map tag comparisons via `LIKE`, keeping other operators unsupported.
> 
> - **Tracing Storage**:
>   - `TraceFilterSplitter`: Accepts `NOT` in logical expressions (previously only `AND`).
> - **JDBC Dialect**:
>   - `MapAccessExpressionTransformer`:
>     - `EQ` remains translated to `LIKE` on JSON-backed map columns.
>     - Adds `CONTAINS` support translated to `LIKE` with wildcards around the value.
>     - Other operators still rejected with an `UnsupportedOperationException`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4939816109019daeb233188eaa3cd3862544564a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->