### PR TITLE
Fix dropped sub-expression in NOT (... IS NULL) filter

### DIFF
--- a/server/datasource/reader-jdbc/src/main/java/org/bithon/server/datasource/reader/jdbc/statement/builder/SelectStatementBuilder.java
+++ b/server/datasource/reader-jdbc/src/main/java/org/bithon/server/datasource/reader/jdbc/statement/builder/SelectStatementBuilder.java
@@ -189,7 +189,9 @@ public class SelectStatementBuilder {
         public IExpression visit(ConditionalExpression expression) {
             IExpression lhs = expression.getLhs();
             if (!(lhs instanceof IdentifierExpression)) {
-                return null;
+                // If it's non identifier, it may be a compound expression
+                // Keep non-identifier expressions in pre-filter to avoid dropping operands under logical NOT.
+                return expression;
             }
             String identifier = ((IdentifierExpression) lhs).getIdentifier();
 

--- a/server/datasource/reader-jdbc/src/main/java/org/bithon/server/datasource/reader/jdbc/statement/serializer/Expression2Sql.java
+++ b/server/datasource/reader-jdbc/src/main/java/org/bithon/server/datasource/reader/jdbc/statement/serializer/Expression2Sql.java
@@ -68,30 +68,25 @@ public class Expression2Sql extends ExpressionSerializer {
 
     @Override
     public void serialize(LiteralExpression<?> expression) {
-        if (expression instanceof LiteralExpression.StringLiteral stringLiteral) {
-            sb.append('\'');
-            // Escape the single quote to ensure the user input is safe
-            sb.append(StringUtils.escape(stringLiteral.getValue(), sqlDialect.getEscapeCharacter4SingleQuote(), '\''));
-            sb.append('\'');
-        } else if (expression instanceof LiteralExpression.LongLiteral longLiteral) {
-            sb.append(longLiteral.getValue());
-        } else if (expression instanceof LiteralExpression.DoubleLiteral doubleLiteral) {
-            sb.append(doubleLiteral.getValue());
-        } else if (expression instanceof LiteralExpression.BooleanLiteral) {
-            // Some old versions of CK do not support true/false literal, we use integer instead
-            sb.append(expression.asBoolean() ? 1 : 0);
-        } else if (expression instanceof LiteralExpression.TimestampLiteral) {
-            sb.append(sqlDialect.formatDateTime((LiteralExpression.TimestampLiteral) expression));
-        } else if (expression instanceof LiteralExpression.AsteriskLiteral) {
-            sb.append('*');
-        } else if (expression instanceof LiteralExpression.ReadableDurationLiteral durationLiteral) {
-            sb.append(durationLiteral.getValue().getDuration().getSeconds());
-        } else if (expression instanceof LiteralExpression.ReadableNumberLiteral numberLiteral) {
-            sb.append(numberLiteral.getValue().longValue());
-        } else if (expression instanceof LiteralExpression.ReadablePercentageLiteral percentageLiteral) {
-            sb.append(percentageLiteral.getValue().getFraction());
-        } else {
-            throw new RuntimeException("Not supported type " + expression.getDataType());
+        switch (expression) {
+            case LiteralExpression.NullLiteral nullLiteral -> sb.append("NULL");
+            case LiteralExpression.StringLiteral stringLiteral -> {
+                sb.append('\'');
+                // Escape the single quote to ensure the user input is safe
+                sb.append(StringUtils.escape(stringLiteral.getValue(), sqlDialect.getEscapeCharacter4SingleQuote(), '\''));
+                sb.append('\'');
+            }
+            case LiteralExpression.LongLiteral longLiteral -> sb.append(longLiteral.getValue());
+            case LiteralExpression.DoubleLiteral doubleLiteral -> sb.append(doubleLiteral.getValue());
+            case LiteralExpression.BooleanLiteral booleanLiteral ->
+                // Some old versions of CK do not support true/false literal, we use integer instead
+                sb.append(expression.asBoolean() ? 1 : 0);
+            case LiteralExpression.TimestampLiteral timestampLiteral -> sb.append(sqlDialect.formatDateTime(timestampLiteral));
+            case LiteralExpression.AsteriskLiteral asteriskLiteral -> sb.append('*');
+            case LiteralExpression.ReadableDurationLiteral durationLiteral -> sb.append(durationLiteral.getValue().getDuration().getSeconds());
+            case LiteralExpression.ReadableNumberLiteral numberLiteral -> sb.append(numberLiteral.getValue().longValue());
+            case LiteralExpression.ReadablePercentageLiteral percentageLiteral -> sb.append(percentageLiteral.getValue().getFraction());
+            default -> throw new RuntimeException("Not supported type " + expression.getDataType());
         }
     }
 
@@ -137,4 +132,3 @@ public class Expression2Sql extends ExpressionSerializer {
         }
     }
 }
-

--- a/server/datasource/reader-jdbc/src/main/java/org/bithon/server/datasource/reader/jdbc/statement/serializer/Expression2Sql.java
+++ b/server/datasource/reader-jdbc/src/main/java/org/bithon/server/datasource/reader/jdbc/statement/serializer/Expression2Sql.java
@@ -68,25 +68,32 @@ public class Expression2Sql extends ExpressionSerializer {
 
     @Override
     public void serialize(LiteralExpression<?> expression) {
-        switch (expression) {
-            case LiteralExpression.NullLiteral nullLiteral -> sb.append("NULL");
-            case LiteralExpression.StringLiteral stringLiteral -> {
-                sb.append('\'');
-                // Escape the single quote to ensure the user input is safe
-                sb.append(StringUtils.escape(stringLiteral.getValue(), sqlDialect.getEscapeCharacter4SingleQuote(), '\''));
-                sb.append('\'');
-            }
-            case LiteralExpression.LongLiteral longLiteral -> sb.append(longLiteral.getValue());
-            case LiteralExpression.DoubleLiteral doubleLiteral -> sb.append(doubleLiteral.getValue());
-            case LiteralExpression.BooleanLiteral booleanLiteral ->
-                // Some old versions of CK do not support true/false literal, we use integer instead
-                sb.append(expression.asBoolean() ? 1 : 0);
-            case LiteralExpression.TimestampLiteral timestampLiteral -> sb.append(sqlDialect.formatDateTime(timestampLiteral));
-            case LiteralExpression.AsteriskLiteral asteriskLiteral -> sb.append('*');
-            case LiteralExpression.ReadableDurationLiteral durationLiteral -> sb.append(durationLiteral.getValue().getDuration().getSeconds());
-            case LiteralExpression.ReadableNumberLiteral numberLiteral -> sb.append(numberLiteral.getValue().longValue());
-            case LiteralExpression.ReadablePercentageLiteral percentageLiteral -> sb.append(percentageLiteral.getValue().getFraction());
-            default -> throw new RuntimeException("Not supported type " + expression.getDataType());
+        if (expression instanceof LiteralExpression.NullLiteral) {
+            sb.append("NULL");
+        } else if (expression instanceof LiteralExpression.StringLiteral stringLiteral) {
+            sb.append('\'');
+            // Escape the single quote to ensure the user input is safe
+            sb.append(StringUtils.escape(stringLiteral.getValue(), sqlDialect.getEscapeCharacter4SingleQuote(), '\''));
+            sb.append('\'');
+        } else if (expression instanceof LiteralExpression.LongLiteral longLiteral) {
+            sb.append(longLiteral.getValue());
+        } else if (expression instanceof LiteralExpression.DoubleLiteral doubleLiteral) {
+            sb.append(doubleLiteral.getValue());
+        } else if (expression instanceof LiteralExpression.BooleanLiteral) {
+            // Some old versions of CK do not support true/false literal, we use integer instead
+            sb.append(expression.asBoolean() ? 1 : 0);
+        } else if (expression instanceof LiteralExpression.TimestampLiteral timestampLiteral) {
+            sb.append(sqlDialect.formatDateTime(timestampLiteral));
+        } else if (expression instanceof LiteralExpression.AsteriskLiteral) {
+            sb.append('*');
+        } else if (expression instanceof LiteralExpression.ReadableDurationLiteral durationLiteral) {
+            sb.append(durationLiteral.getValue().getDuration().getSeconds());
+        } else if (expression instanceof LiteralExpression.ReadableNumberLiteral numberLiteral) {
+            sb.append(numberLiteral.getValue().longValue());
+        } else if (expression instanceof LiteralExpression.ReadablePercentageLiteral percentageLiteral) {
+            sb.append(percentageLiteral.getValue().getFraction());
+        } else {
+            throw new RuntimeException("Not supported type " + expression.getDataType());
         }
     }
 

--- a/server/server-starter/src/test/java/org/bithon/server/storage/jdbc/common/statement/builder/SelectStatementBuilderTest.java
+++ b/server/server-starter/src/test/java/org/bithon/server/storage/jdbc/common/statement/builder/SelectStatementBuilderTest.java
@@ -24,6 +24,7 @@ import org.bithon.server.datasource.DefaultSchema;
 import org.bithon.server.datasource.ISchema;
 import org.bithon.server.datasource.TimestampSpec;
 import org.bithon.server.datasource.column.ExpressionColumn;
+import org.bithon.server.datasource.column.ObjectColumn;
 import org.bithon.server.datasource.column.StringColumn;
 import org.bithon.server.datasource.column.aggregatable.last.AggregateLongLastColumn;
 import org.bithon.server.datasource.column.aggregatable.sum.AggregateLongSumColumn;
@@ -1905,6 +1906,83 @@ public class SelectStatementBuilderTest {
                                     LIMIT 100
                                     """.trim(),
                                 selectStatement.toSQL(dialect));
+    }
+
+    @Test
+    public void test_NotIsNullOnNonIdentifierExpression() {
+        ISqlDialect dialect = new H2SqlDialect();
+        QueryRequest queryRequest = QueryRequest.builder()
+                                                .fields(List.of(new QueryField("responseTime", "responseTime", null, null)))
+                                                .interval(IntervalRequest.builder()
+                                                                         .startISO8601(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"))
+                                                                         .endISO8601(TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800"))
+                                                                         .build())
+                                                .filterExpression("NOT ((responseTime + 1) is null)")
+                                                .build();
+        SelectStatement selectStatement = SelectStatementBuilder.from(QueryConverter.toQuery(schema, queryRequest, null))
+                                                                .sqlDialect(dialect)
+                                                                .buildSelectStatement();
+        String sql = selectStatement.toSQL(dialect);
+
+        Assertions.assertEquals(sql,
+                                """
+                                    SELECT "responseTime"
+                                    FROM "bithon_http_incoming_metrics"
+                                    WHERE ("timestamp" >= '2024-07-26T21:22:00.000+08:00') AND ("timestamp" < '2024-07-26T21:32:00.000+08:00') AND (NOT (("bithon_http_incoming_metrics"."responseTime" + 1) IS NULL))
+                                    """.trim());
+    }
+
+    @Test
+    public void test_NotIsNullOnMapAccessExpression() {
+        ISqlDialect dialect = new H2SqlDialect();
+        ISchema schemaWithObject = new DefaultSchema("bithon-http-incoming-metrics",
+                                                     "bithon-http-incoming-metrics",
+                                                     new TimestampSpec("timestamp"),
+                                                     Arrays.asList(new StringColumn("appName", "appName"),
+                                                                   new ObjectColumn("obj", "obj")),
+                                                     Arrays.asList(new AggregateLongSumColumn("responseTime", "responseTime")),
+                                                     null,
+                                                     new IDataStoreSpec() {
+                                                         @Override
+                                                         public String getStore() {
+                                                             return "bithon_http_incoming_metrics";
+                                                         }
+
+                                                         @Override
+                                                         public void setSchema(ISchema schema) {
+                                                         }
+
+                                                         @Override
+                                                         public boolean isInternal() {
+                                                             return false;
+                                                         }
+
+                                                         @Override
+                                                         public IDataSourceReader createReader() {
+                                                             return null;
+                                                         }
+                                                     },
+                                                     null,
+                                                     null);
+        QueryRequest queryRequest = QueryRequest.builder()
+                                                .fields(List.of(new QueryField("appName", "appName", null, null)))
+                                                .interval(IntervalRequest.builder()
+                                                                         .startISO8601(TimeSpan.fromISO8601("2024-07-26T21:22:00.000+0800"))
+                                                                         .endISO8601(TimeSpan.fromISO8601("2024-07-26T21:32:00.000+0800"))
+                                                                         .build())
+                                                .filterExpression("NOT (obj['attr'] is null)")
+                                                .build();
+        SelectStatement selectStatement = SelectStatementBuilder.from(QueryConverter.toQuery(schemaWithObject, queryRequest, null))
+                                                                .sqlDialect(dialect)
+                                                                .buildSelectStatement();
+        String sql = selectStatement.toSQL(dialect);
+
+        Assertions.assertEquals(sql,
+                                """
+                                    SELECT "appName"
+                                    FROM "bithon_http_incoming_metrics"
+                                    WHERE ("timestamp" >= '2024-07-26T21:22:00.000+08:00') AND ("timestamp" < '2024-07-26T21:32:00.000+08:00') AND (NOT ("obj"['attr'] IS NULL))
+                                    """.trim());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep non-identifier conditional expressions during SelectStatementBuilder filter splitting so logical NOT does not lose its child
- add NULL literal serialization in JDBC Expression2Sql serializer
- add regression tests for:
  - `NOT ((responseTime + 1) is null)`
  - `NOT (obj['attr'] is null)`

## Notes
- local test execution is blocked in this environment due JDK mismatch (`release version 21 not supported`)
