### PR TITLE
[codex] Bump Maven dependency baselines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,13 @@
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.9.8.1</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs</artifactId>
+              <version>4.9.8</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.9.3</version> <!-- Use the latest version -->
+        <version>4.9.8</version> <!-- Use the latest version -->
         <scope>provided</scope>
       </dependency>
 
@@ -72,7 +72,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.3.1-jre</version>
+        <version>33.5.0-jre</version>
       </dependency>
 
       <dependency>
@@ -175,7 +175,7 @@
         <plugin>
           <groupId>org.antlr</groupId>
           <artifactId>antlr4-maven-plugin</artifactId>
-          <version>4.9.3</version>
+          <version>4.13.2</version>
         </plugin>
 
         <plugin>
@@ -187,7 +187,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.8.3.0</version>
+          <version>4.9.8.1</version>
         </plugin>
 
         <plugin>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -112,18 +112,18 @@
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
-        <version>4.9.3</version>
+        <version>4.13.2</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4</artifactId> <!-- for grammar interpreter -->
-        <version>4.9.3</version>
+        <version>4.13.2</version>
       </dependency>
 
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>32.0.0-jre</version>
+        <version>33.5.0-jre</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changed
- bumped `com.github.spotbugs:spotbugs-annotations` from `4.9.3` to `4.9.8`
- bumped `com.github.spotbugs:spotbugs-maven-plugin` from `4.8.3.0` to `4.9.8.1`
- aligned Guava to `33.5.0-jre` in the root and server dependency management sections
- bumped ANTLR to `4.13.2` for the Maven plugin, `antlr4-runtime`, and `antlr4`

## Why
This keeps the dependency sweep intentionally small while covering the low-risk build/runtime updates we reviewed:
- SpotBugs plugin is safe because CI runs the SpotBugs check on JDK 17/21
- ANTLR generated sources are produced during the build, so upgrading the generator/runtime together is the right migration path here
- Guava is kept on a single current 33.x line instead of split root/server pins

## Validation
- fetched and based the branch on the latest `origin/master`
- `mvn -ntp -T 1C -Dmaven.repo.local=/tmp/bithon-m2 -DskipTests -Dmaven.javadoc.skip=true test-compile --activate-profiles shaded,component,server`
- observed `antlr4:4.13.2:antlr4` run successfully for `server/datasource/common`

## Notes
The full reactor still fails later in `component-brpc` because shaded packages are unresolved in this environment. That failure is outside the files changed in this PR, but it means validation here is partial rather than full-green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily dependency/version bumps, but Guava and ANTLR upgrades can introduce subtle compile/runtime behavior changes and affect generated parser sources.
> 
> **Overview**
> Updates Maven dependency baselines: bumps `spotbugs-annotations` to `4.9.8` and upgrades `spotbugs-maven-plugin` to `4.9.8.1` (explicitly pinning `com.github.spotbugs:spotbugs` to `4.9.8`).
> 
> Aligns Guava to `33.5.0-jre` and upgrades ANTLR to `4.13.2` for both the `antlr4-maven-plugin` and server runtime dependencies (`antlr4-runtime`/`antlr4`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c776b9bfd664d45e31c0f1c6da9fef9cd46e3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->