### PR TITLE
[codex] Bump Guava and Jakarta Validation baselines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,13 @@
       <dependency>
         <groupId>jakarta.validation</groupId>
         <artifactId>jakarta.validation-api</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
       </dependency>
 
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.5.0-jre</version>
+        <version>33.6.0-jre</version>
       </dependency>
 
       <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -123,7 +123,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.5.0-jre</version>
+        <version>33.6.0-jre</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changed
- bump  from  to  in root dependency management
- bump  from  to  in root dependency management

## Why
These are the remaining low-risk follow-up upgrades after the earlier baseline sweep already landed on .

## Impact
This keeps the shared dependency baseline current with minimal scope. The change is limited to root-managed versions and does not touch plugin modules under .

## Validation
- [INFO] Scanning for projects...
[INFO] 
[INFO] -------------------------< org.bithon:bithon >--------------------------
[INFO] Building Bithon 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- checkstyle:3.4.0:check (validate) @ bithon ---
[INFO] Starting audit...
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.706 s
[INFO] Finished at: 2026-05-01T20:55:41+08:00
[INFO] ------------------------------------------------------------------------