### PR TITLE
Fix code scanning security alerts

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -25,6 +25,9 @@ on:
       - "pom.xml"
       - ".github/workflows/build-agent.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   # https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.

--- a/.github/workflows/build-server-jdk21.yml
+++ b/.github/workflows/build-server-jdk21.yml
@@ -15,6 +15,9 @@ on:
       - ".github/workflows/build-agent.yml"
       - ".github/workflows/push-docker-agent-images.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   # https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only
   # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.

--- a/.github/workflows/clean-up-docker-agent-images.yml
+++ b/.github/workflows/clean-up-docker-agent-images.yml
@@ -7,6 +7,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scheduled-task:
     runs-on: ubuntu-latest

--- a/.github/workflows/clean-up-docker-server-images.yml
+++ b/.github/workflows/clean-up-docker-server-images.yml
@@ -7,6 +7,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scheduled-task:
     runs-on: ubuntu-latest

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/http/HttpNotificationChannel.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/http/HttpNotificationChannel.java
@@ -253,25 +253,69 @@ public class HttpNotificationChannel implements INotificationChannel {
 
         byte[] bytes = address.getAddress();
         if (bytes.length == 4) {
-            int first = bytes[0] & 0xFF;
-            int second = bytes[1] & 0xFF;
-
-            return first == 0
-                   || first == 10
-                   || first == 127
-                   || (first == 100 && second >= 64 && second <= 127)
-                   || (first == 169 && second == 254)
-                   || (first == 172 && second >= 16 && second <= 31)
-                   || (first == 192 && second == 168)
-                   || (first >= 224);
+            return isBlockedIpv4Address(bytes, 0);
         }
 
         if (address instanceof Inet6Address) {
             int first = bytes[0] & 0xFF;
-            return (first & 0xFE) == 0xFC;
+            return (first & 0xFE) == 0xFC
+                   || isBlockedEmbeddedIpv4Address(bytes);
         }
 
         return false;
+    }
+
+    private static boolean isBlockedIpv4Address(byte[] bytes, int offset) {
+        int first = bytes[offset] & 0xFF;
+        int second = bytes[offset + 1] & 0xFF;
+
+        return first == 0
+               || first == 10
+               || first == 127
+               || (first == 100 && second >= 64 && second <= 127)
+               || (first == 169 && second == 254)
+               || (first == 172 && second >= 16 && second <= 31)
+               || (first == 192 && second == 168)
+               || first >= 224;
+    }
+
+    private static boolean isBlockedEmbeddedIpv4Address(byte[] bytes) {
+        // IPv4-compatible IPv6: ::a.b.c.d
+        if (isZero(bytes, 0, 12) && isBlockedIpv4Address(bytes, 12)) {
+            return true;
+        }
+
+        // IPv4-mapped IPv6: ::ffff:a.b.c.d
+        if (isZero(bytes, 0, 10)
+            && (bytes[10] & 0xFF) == 0xFF
+            && (bytes[11] & 0xFF) == 0xFF
+            && isBlockedIpv4Address(bytes, 12)) {
+            return true;
+        }
+
+        // Well-known NAT64 prefixes: 64:ff9b::/96 and 64:ff9b:1::/48
+        if ((bytes[0] & 0xFF) == 0x00
+            && (bytes[1] & 0xFF) == 0x64
+            && (bytes[2] & 0xFF) == 0xFF
+            && (bytes[3] & 0xFF) == 0x9B
+            && ((isZero(bytes, 4, 8) && isBlockedIpv4Address(bytes, 12))
+                || ((bytes[4] & 0xFF) == 0x00 && (bytes[5] & 0xFF) == 0x01 && isBlockedIpv4Address(bytes, 12)))) {
+            return true;
+        }
+
+        // 6to4 addresses: 2002:a.b.c.d::/48
+        return (bytes[0] & 0xFF) == 0x20
+               && (bytes[1] & 0xFF) == 0x02
+               && isBlockedIpv4Address(bytes, 2);
+    }
+
+    private static boolean isZero(byte[] bytes, int offset, int length) {
+        for (int i = offset; i < offset + length; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static class RestrictedDnsResolver implements DnsResolver {

--- a/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/http/HttpNotificationChannel.java
+++ b/server/alerting/notification/src/main/java/org/bithon/server/alerting/notification/channel/http/HttpNotificationChannel.java
@@ -33,6 +33,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.DnsResolver;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -46,8 +47,11 @@ import org.bithon.server.alerting.notification.message.NotificationMessage;
 import org.bithon.server.storage.alerting.pojo.AlertStatus;
 
 import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
@@ -108,14 +112,8 @@ public class HttpNotificationChannel implements INotificationChannel {
         this.props = Preconditions.checkNotNull(props, "props property can not be null.");
         Preconditions.checkIfTrue(!StringUtils.isBlank(this.props.url), "The url property can not be empty");
 
-        try {
-            URL url = new URL(props.url.trim());
-            Preconditions.checkIfTrue(!StringUtils.isEmpty(url.getHost()), "Invalid URL: %s. Missing host", props.url);
-        } catch (MalformedURLException e) {
-            throw new Preconditions.InvalidValueException("Invalid URL: %s", props.url);
-        }
-
         this.props.url = props.url.trim();
+        validateTargetUrl(this.props.url);
         this.props.headers = props.headers == null ? Collections.emptyMap() : props.headers;
 
         this.notificationProperties = notificationProperties;
@@ -181,7 +179,12 @@ public class HttpNotificationChannel implements INotificationChannel {
                                                    .setSocketTimeout((int) timeout.toMillis())
                                                    .setConnectTimeout(1000)
                                                    .build();
-        try (CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build()) {
+        validateTargetUrl(this.props.url);
+        try (CloseableHttpClient client = HttpClientBuilder.create()
+                                                           .disableRedirectHandling()
+                                                           .setDnsResolver(new RestrictedDnsResolver())
+                                                           .setDefaultRequestConfig(requestConfig)
+                                                           .build()) {
             HttpPost request = new HttpPost(this.props.url);
 
             // Custom headers
@@ -205,6 +208,84 @@ public class HttpNotificationChannel implements INotificationChannel {
                                                               response.getStatusLine().getStatusCode(),
                                                               IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8)));
             }
+        }
+    }
+
+    private static void validateTargetUrl(String targetUrl) {
+        URL url;
+        try {
+            url = new URL(targetUrl);
+        } catch (MalformedURLException e) {
+            throw new Preconditions.InvalidValueException("Invalid URL: %s", targetUrl);
+        }
+
+        String protocol = url.getProtocol();
+        Preconditions.checkIfTrue("http".equals(protocol) || "https".equals(protocol),
+                                  "Invalid URL: %s. Only http and https schemes are supported",
+                                  targetUrl);
+        Preconditions.checkIfTrue(!StringUtils.isEmpty(url.getHost()), "Invalid URL: %s. Missing host", targetUrl);
+
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(url.getHost());
+        } catch (UnknownHostException e) {
+            throw new Preconditions.InvalidValueException("Invalid URL: %s. Unknown host", targetUrl);
+        }
+        validateResolvedAddresses(targetUrl, addresses);
+    }
+
+    private static void validateResolvedAddresses(String targetUrl, InetAddress[] addresses) {
+        for (InetAddress address : addresses) {
+            Preconditions.checkIfTrue(!isBlockedAddress(address),
+                                      "Invalid URL: %s. Host resolves to a restricted address",
+                                      targetUrl);
+        }
+    }
+
+    private static boolean isBlockedAddress(InetAddress address) {
+        if (address.isAnyLocalAddress()
+            || address.isLoopbackAddress()
+            || address.isLinkLocalAddress()
+            || address.isSiteLocalAddress()
+            || address.isMulticastAddress()) {
+            return true;
+        }
+
+        byte[] bytes = address.getAddress();
+        if (bytes.length == 4) {
+            int first = bytes[0] & 0xFF;
+            int second = bytes[1] & 0xFF;
+
+            return first == 0
+                   || first == 10
+                   || first == 127
+                   || (first == 100 && second >= 64 && second <= 127)
+                   || (first == 169 && second == 254)
+                   || (first == 172 && second >= 16 && second <= 31)
+                   || (first == 192 && second == 168)
+                   || (first >= 224);
+        }
+
+        if (address instanceof Inet6Address) {
+            int first = bytes[0] & 0xFF;
+            return (first & 0xFE) == 0xFC;
+        }
+
+        return false;
+    }
+
+    private static class RestrictedDnsResolver implements DnsResolver {
+        @Override
+        public InetAddress[] resolve(String host) throws UnknownHostException {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            try {
+                validateResolvedAddresses(host, addresses);
+            } catch (Preconditions.InvalidValueException e) {
+                UnknownHostException unknownHostException = new UnknownHostException(host);
+                unknownHostException.initCause(e);
+                throw unknownHostException;
+            }
+            return addresses;
         }
     }
 

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/alerting/NotificationChannelJdbcStorage.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/alerting/NotificationChannelJdbcStorage.java
@@ -19,11 +19,6 @@ package org.bithon.server.storage.jdbc.alerting;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.OptBoolean;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.utils.SqlLikeExpression;
 import org.bithon.server.datasource.query.Order;
@@ -213,22 +208,7 @@ public class NotificationChannelJdbcStorage implements IAlertNotificationChannel
         }
     }
 
-    @Getter
-    @Setter
-    @Builder
-    static class HttpNotificationProps {
-        private String url;
-        private String body;
-    }
-
     protected void initialChannel() {
-        try {
-            HttpNotificationProps props = HttpNotificationProps.builder()
-                                                               .url(StringUtils.format("http://localhost:%d/api/alerting/channel/blackhole", serverProperties.getPort()))
-                                                               .body("[{alert.status}] {alert.name}\n{alert.expr}\n{alert.message}\n{alert.url}")
-                                                               .build();
-            this.createChannel("http", "test", new ObjectMapper().writeValueAsString(props));
-        } catch (JsonProcessingException ignored) {
-        }
+        this.createChannel("console", "test", "{}");
     }
 }

--- a/server/web-security/src/main/java/org/bithon/server/web/security/cookie/CookieHelper.java
+++ b/server/web-security/src/main/java/org/bithon/server/web/security/cookie/CookieHelper.java
@@ -20,6 +20,7 @@ package org.bithon.server.web.security.cookie;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 
 /**
  * @author Frank Chen
@@ -29,6 +30,8 @@ public class CookieHelper {
 
     public static class Builder {
         private Cookie cookie;
+        private String sameSite = "Lax";
+        private boolean secure;
 
         public static Builder newCookie(String name, String content) {
             Builder builder = new Builder();
@@ -47,8 +50,29 @@ public class CookieHelper {
             return this;
         }
 
+        public Builder sameSite(String sameSite) {
+            this.sameSite = sameSite;
+            return this;
+        }
+
+        public Builder secure(boolean secure) {
+            this.secure = secure;
+            return this;
+        }
+
         public void addTo(HttpServletResponse response) {
-            response.addCookie(cookie);
+            ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie.from(cookie.getName(), cookie.getValue())
+                                                                               .httpOnly(cookie.isHttpOnly())
+                                                                               .secure(secure)
+                                                                               .sameSite(sameSite);
+            if (cookie.getPath() != null) {
+                cookieBuilder.path(cookie.getPath());
+            }
+            if (cookie.getMaxAge() >= 0) {
+                cookieBuilder.maxAge(cookie.getMaxAge());
+            }
+
+            response.addHeader("Set-Cookie", cookieBuilder.build().toString());
         }
     }
 
@@ -67,14 +91,22 @@ public class CookieHelper {
     }
 
     public static void delete(HttpServletRequest request, HttpServletResponse response, String cookieName) {
+        delete(request, response, cookieName, false);
+    }
+
+    public static void delete(HttpServletRequest request, HttpServletResponse response, String cookieName, boolean secure) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (cookie.getName().equals(cookieName)) {
-                    cookie.setValue("");
-                    cookie.setPath("/");
-                    cookie.setMaxAge(0);
-                    response.addCookie(cookie);
+                    ResponseCookie responseCookie = ResponseCookie.from(cookieName, "")
+                                                                  .httpOnly(true)
+                                                                  .secure(secure)
+                                                                  .path("/")
+                                                                  .maxAge(0)
+                                                                  .sameSite("Lax")
+                                                                  .build();
+                    response.addHeader("Set-Cookie", responseCookie.toString());
                 }
             }
         }

--- a/server/web-security/src/main/java/org/bithon/server/web/security/filter/JwtAuthenticationFilter.java
+++ b/server/web-security/src/main/java/org/bithon/server/web/security/filter/JwtAuthenticationFilter.java
@@ -91,7 +91,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         if (!authenticated && req.getRequestURI().contains("/api/")) {
-            // For API endpoints, returns the 403
+            // For API endpoints, returns the 401
             // For other endpoints, we continue the processing, and a login filter will be triggered to log in
             res.setStatus(HttpStatus.UNAUTHORIZED.value());
             res.setContentType(MediaType.TEXT_PLAIN_VALUE);

--- a/server/web-security/src/main/java/org/bithon/server/web/security/filter/JwtAuthenticationFilter.java
+++ b/server/web-security/src/main/java/org/bithon/server/web/security/filter/JwtAuthenticationFilter.java
@@ -94,8 +94,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // For API endpoints, returns the 403
             // For other endpoints, we continue the processing, and a login filter will be triggered to log in
             res.setStatus(HttpStatus.UNAUTHORIZED.value());
-            res.setContentType(MediaType.TEXT_PLAIN.getType());
-            res.getWriter().println(StringUtils.format("%s not authorized.", req.getRequestURI()));
+            res.setContentType(MediaType.TEXT_PLAIN_VALUE);
+            res.setHeader("X-Content-Type-Options", "nosniff");
+            res.getWriter().println("Unauthorized.");
             return;
         }
 


### PR DESCRIPTION
## Summary
- restrict HTTP notification targets to public http/https destinations and disable redirects
- switch the seeded test notification channel to console so localhost HTTP is not required
- add SameSite cookie handling while keeping HTTP deployments compatible by leaving Secure configurable
- return a generic unauthorized API response and add explicit read-only GitHub Actions permissions

Note: issues.md is intentionally excluded per request.

## Test
- mvn -pl server/alerting/notification,server/web-security -am -DskipTests -Dmaven.javadoc.skip=true -ntp compile
- git diff --check