### PR TITLE
[codex] bump dependency baselines

### DIFF
--- a/agent/agent-sdk/pom.xml
+++ b/agent/agent-sdk/pom.xml
@@ -58,13 +58,13 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.9.8.1</version>
+        <version>4.8.3.0</version>
         <dependencies>
           <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.9.8</version>
+            <version>4.8.3</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/agent/agent-sdk/pom.xml
+++ b/agent/agent-sdk/pom.xml
@@ -58,13 +58,13 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.8.3.0</version>
+        <version>4.9.8.1</version>
         <dependencies>
           <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.8.3</version>
+            <version>4.9.8</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/component/component-commons/pom.xml
+++ b/component/component-commons/pom.xml
@@ -24,19 +24,19 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.18.0</version>
+      <version>2.26.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.25.4</version>
+      <version>2.26.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.18.0</version>
+      <version>2.26.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
          during test discovery on newer JDK builds (for example JDK21 in CI). -->
     <junit.jupiter.version>5.10.2</junit.jupiter.version>
     <junit.platform.version>1.10.2</junit.platform.version>
-    <lombok.version>1.18.38</lombok.version>
+    <lombok.version>1.18.46</lombok.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -343,7 +343,7 @@
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.8.3</version>
+            <version>4.9.8</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.9.8</version>
+            <version>4.8.3</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/server/alerting/notification/pom.xml
+++ b/server/alerting/notification/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.17.0</version>
+            <version>2.21.0</version>
         </dependency>
     </dependencies>
 

--- a/server/collector/pom.xml
+++ b/server/collector/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.26.2</version>
+      <version>1.28.0</version>
     </dependency>
 
     <!-- Jaeger Thrift Dependencies -->

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -27,7 +27,7 @@
     <!-- Maven release: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot -->
     <!-- Maven release: https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies -->
     <spring-boot.version>4.0.0</spring-boot.version>
-    <spring-cloud.version>2025.1.0</spring-cloud.version>
+    <spring-cloud.version>2025.1.1</spring-cloud.version>
 
     <!-- The Alibaba Nacos is used -->
     <!-- Dependency Note: https://github.com/alibaba/spring-cloud-alibaba/wiki/%E7%89%88%E6%9C%AC%E8%AF%B4%E6%98%8E -->

--- a/server/server-starter/pom.xml
+++ b/server/server-starter/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>9.0.0.Final</version>
+      <version>9.0.1.Final</version>
     </dependency>
 
     <!-- DEV TOOLS -->

--- a/shaded/shaded-bytebuddy/pom.xml
+++ b/shaded/shaded-bytebuddy/pom.xml
@@ -15,12 +15,12 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.17.7</version>
+      <version>1.17.8</version>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.17.7</version>
+      <version>1.17.8</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Summary
- Bump Lombok from `1.18.38` to `1.18.46`.
- Align Log4j artifacts in `component-commons` from `2.18.0` / `2.25.4` to `2.26.0`.
- Bump Spring Cloud BOM from `2025.1.0` to `2025.1.1` while leaving Spring Boot at `4.0.0`.
- Bump focused patch/minor dependencies: Byte Buddy `1.17.7` to `1.17.8`, Commons Compress `1.26.2` to `1.28.0`, Commons IO `2.17.0` to `2.21.0`, Hibernate Validator `9.0.0.Final` to `9.0.1.Final`.

## Scope and risk
- Excluded `agent/agent-plugins/**` from the sweep per automation rule.
- Chose the smallest viable upgrade set: patch/minor-compatible direct POM bumps only.
- No migrations are expected for the selected bumps, but Log4j alignment and the Spring Cloud BOM patch should get normal integration coverage because they affect shared runtime dependency resolution.
- Deferred higher-risk upgrade tracks that need separate migration review: JUnit/Platform, Mockito inline, ClickHouse JDBC, JJWT, protobuf/gRPC, Spring Boot, Spring Cloud Alibaba, and SpotBugs.

## CI follow-up
- Removed the SpotBugs bump after CI showed the newer detector reporting existing findings in `component-commons` and `agent-instrumentation`.
- The SpotBugs findings should be handled separately as a static-analysis cleanup instead of expanding this dependency PR.

## Validation
- Passed: `mvn -B -Pcomponent,agent,server,shaded -pl :component-commons,:shaded-bytebuddy,:agent-sdk,:server-alerting-notification -am -DskipTests -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dforbiddenapis.skip=true -Dlicense.skip=true package`
- Passed: `mvn -B -Pserver -pl :server-collector,:server-starter -Dincludes=org.apache.commons:commons-compress,org.hibernate.validator:hibernate-validator dependency:tree`
- Passed after CI patch: `JAVA_HOME=$(/usr/libexec/java_home -v21) mvn --ntp -T 1C -P-agent animal-sniffer:check checkstyle:checkstyle com.github.spotbugs:spotbugs-maven-plugin:check`
- Agent Build SpotBugs check was rerun locally with JDK17 far enough to confirm the CI-blocking SpotBugs findings no longer appear; the full local combined Agent Build code-check command then hit a dependency-analysis precondition because the local run did not execute the workflow's compile/install setup first.
- Broader attempted build including `server-collector` still fails because the `opentelemetry` module packages an empty jar after generated proto sources are added, so `server-collector` cannot resolve `io.opentelemetry.proto.*`. The failure reproduces with `maven-compiler-plugin` left at the repo's current `3.14.0`, so this PR does not include a compiler plugin bump.
