### PR TITLE
[codex] bump safe dependency patches

### DIFF
--- a/agent/agent-observability/pom.xml
+++ b/agent/agent-observability/pom.xml
@@ -61,13 +61,13 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>1.36</version>
+      <version>1.37</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>1.36</version>
+      <version>1.37</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -83,7 +83,7 @@
             <path>
               <groupId>org.openjdk.jmh</groupId>
               <artifactId>jmh-generator-annprocess</artifactId>
-              <version>1.36</version>
+              <version>1.37</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <!-- Agent modules still build/test on JDK8/9, so keep JUnit on the last compatible line.
          JUnit Jupiter 5.10.x must be paired with JUnit Platform 1.10.x to avoid runtime NoSuchMethodError
          during test discovery on newer JDK builds (for example JDK21 in CI). -->
-    <junit.jupiter.version>5.10.2</junit.jupiter.version>
-    <junit.platform.version>1.10.2</junit.platform.version>
+    <junit.jupiter.version>5.10.5</junit.jupiter.version>
+    <junit.platform.version>1.10.5</junit.platform.version>
     <lombok.version>1.18.46</lombok.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/server/server-commons/pom.xml
+++ b/server/server-commons/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.12.7</version>
+      <version>2.14.2</version>
     </dependency>
 
     <dependency>

--- a/shaded/shaded-alibaba-sentinel/pom.xml
+++ b/shaded/shaded-alibaba-sentinel/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.alibaba.csp</groupId>
       <artifactId>sentinel-core</artifactId>
-      <version>1.8.1</version>
+      <version>1.8.8</version>
     </dependency>
   </dependencies>
 

--- a/shaded/shaded-jackson/pom.xml
+++ b/shaded/shaded-jackson/pom.xml
@@ -12,14 +12,14 @@
   <artifactId>shaded-jackson</artifactId>
 
   <properties>
-    <jackson.version>2.13.4</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/shaded/shaded-protobuf/pom.xml
+++ b/shaded/shaded-protobuf/pom.xml
@@ -16,7 +16,7 @@
     <java.version>8</java.version>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <proto.version>3.25.5</proto.version>
+    <proto.version>3.25.8</proto.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary
- Bump the JUnit 5.10.x/JUnit Platform 1.10.x test baseline while staying on the repo's JDK8/9-compatible line.
- Align shaded Jackson on 2.13.5 and bump shaded protobuf and Sentinel patch versions.
- Bump test-only JMH dependencies and Joda-Time in server commons.

## Scope and risk
This intentionally keeps the upgrade set small. It avoids migration-heavy updates such as JJWT 0.12.x, SLF4J/Logback 2.x, Netty 4.2.x, Spring BOM changes, and the coordinated server gRPC/protobuf line.

No source migrations are expected for these same-line patch upgrades. The only notable behavior surface is shaded artifact contents, so the agent/shaded build was validated through package phase.

## Checks
- `git diff --check`
- `mvn -B -Dstyle.color=never -DskipTests -Pcomponent,agent,server,shaded -pl :shaded-jackson,:shaded-protobuf,:shaded-alibaba-sentinel,:agent-observability,:server-commons -am package`
- `mvn -B -Dstyle.color=never -Pcomponent,server -pl :server-commons -am test`
- `mvn -B -Dstyle.color=never -Pcomponent,agent,shaded -pl :agent-observability -am package`