### PR TITLE
feat: Propagate WebFlux trace context through Reactor signals

### DIFF
--- a/agent/agent-plugins/spring/webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/context/ReactorTraceContextOperatorHook.java
+++ b/agent/agent-plugins/spring/webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/context/ReactorTraceContextOperatorHook.java
@@ -1,0 +1,110 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.spring.webflux.context;
+
+import org.bithon.agent.observability.tracing.context.ITraceContext;
+import org.bithon.agent.observability.tracing.context.TraceContextHolder;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Propagates the current Bithon trace context to Reactor signal callbacks.
+ */
+public final class ReactorTraceContextOperatorHook {
+    private static final String HOOK_KEY = "bithon-trace-context";
+    public static final Object TRACE_CONTEXT_KEY = ReactorTraceContextOperatorHook.class;
+    private static final AtomicBoolean INSTALLED = new AtomicBoolean(false);
+
+    private ReactorTraceContextOperatorHook() {
+    }
+
+    public static void install() {
+        if (!INSTALLED.compareAndSet(false, true)) {
+            return;
+        }
+
+        Hooks.onEachOperator(HOOK_KEY, Operators.lift((scannable, actual) -> new TraceContextSubscriber<>(actual)));
+    }
+
+    private static class TraceContextSubscriber<T> implements CoreSubscriber<T> {
+        private final CoreSubscriber<? super T> delegate;
+
+        private TraceContextSubscriber(CoreSubscriber<? super T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Context currentContext() {
+            return delegate.currentContext();
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            withTraceContext(() -> delegate.onSubscribe(subscription));
+        }
+
+        @Override
+        public void onNext(T value) {
+            withTraceContext(() -> delegate.onNext(value));
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            withTraceContext(() -> delegate.onError(throwable));
+        }
+
+        @Override
+        public void onComplete() {
+            withTraceContext(delegate::onComplete);
+        }
+
+        private void withTraceContext(Runnable runnable) {
+            Object value = currentContext().getOrDefault(TRACE_CONTEXT_KEY, null);
+            if (!(value instanceof ITraceContext)) {
+                runnable.run();
+                return;
+            }
+
+            ITraceContext traceContext = (ITraceContext) value;
+            if (traceContext.finished()) {
+                runnable.run();
+                return;
+            }
+
+            ITraceContext previous = TraceContextHolder.current();
+            TraceContextHolder.attach(traceContext);
+            try {
+                runnable.run();
+            } finally {
+                restore(previous);
+            }
+        }
+    }
+
+    private static void restore(ITraceContext previous) {
+        if (previous == null) {
+            TraceContextHolder.detach();
+        } else {
+            TraceContextHolder.attach(previous);
+        }
+    }
+}

--- a/agent/agent-plugins/spring/webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/context/TraceContextScopedMono.java
+++ b/agent/agent-plugins/spring/webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/context/TraceContextScopedMono.java
@@ -1,0 +1,108 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.spring.webflux.context;
+
+import org.bithon.agent.observability.tracing.context.ITraceContext;
+import org.bithon.agent.observability.tracing.context.TraceContextHolder;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+/**
+ * Stores Bithon's trace context in Reactor Context so ReactorTraceContextOperatorHook
+ * can restore it during signal callbacks.
+ */
+public class TraceContextScopedMono<T> extends Mono<T> {
+    private final Mono<T> source;
+    private final ITraceContext traceContext;
+
+    public static <T> Mono<T> wrap(Mono<T> source, ITraceContext traceContext) {
+        if (traceContext == null) {
+            return source;
+        }
+        return new TraceContextScopedMono<>(source, traceContext);
+    }
+
+    private TraceContextScopedMono(Mono<T> source, ITraceContext traceContext) {
+        this.source = source;
+        this.traceContext = traceContext;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        ITraceContext previous = TraceContextHolder.current();
+        TraceContextHolder.attach(traceContext);
+        try {
+            if (source == null) {
+                Operators.error(actual, new NullPointerException());
+                return;
+            }
+
+            source.subscribe(new ContextWritingSubscriber<>(actual, traceContext));
+        } catch (Throwable throwable) {
+            Operators.error(actual, throwable);
+        } finally {
+            restore(previous);
+        }
+    }
+
+    private void restore(ITraceContext previous) {
+        if (previous == null) {
+            TraceContextHolder.detach();
+        } else {
+            TraceContextHolder.attach(previous);
+        }
+    }
+
+    private static class ContextWritingSubscriber<T> implements CoreSubscriber<T> {
+        private final CoreSubscriber<? super T> delegate;
+        private final ITraceContext traceContext;
+
+        private ContextWritingSubscriber(CoreSubscriber<? super T> delegate, ITraceContext traceContext) {
+            this.delegate = delegate;
+            this.traceContext = traceContext;
+        }
+
+        @Override
+        public Context currentContext() {
+            return delegate.currentContext()
+                           .put(ReactorTraceContextOperatorHook.TRACE_CONTEXT_KEY, traceContext);
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            delegate.onSubscribe(subscription);
+        }
+
+        @Override
+        public void onNext(T value) {
+            delegate.onNext(value);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            delegate.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            delegate.onComplete();
+        }
+    }
+}

--- a/agent/agent-plugins/spring/webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
+++ b/agent/agent-plugins/spring/webflux/src/main/java/org/bithon/agent/plugin/spring/webflux/interceptor/ReactorHttpHandlerAdapter$Apply.java
@@ -32,6 +32,8 @@ import org.bithon.agent.observability.tracing.context.TraceContextHolder;
 import org.bithon.agent.observability.tracing.context.propagation.ITracePropagator;
 import org.bithon.agent.plugin.spring.webflux.config.ResponseConfigs;
 import org.bithon.agent.plugin.spring.webflux.context.HttpServerContext;
+import org.bithon.agent.plugin.spring.webflux.context.ReactorTraceContextOperatorHook;
+import org.bithon.agent.plugin.spring.webflux.context.TraceContextScopedMono;
 import org.bithon.component.commons.logging.ILogAdaptor;
 import org.bithon.component.commons.logging.LoggerFactory;
 import org.bithon.component.commons.tracing.Components;
@@ -68,6 +70,8 @@ public class ReactorHttpHandlerAdapter$Apply extends AroundInterceptor {
     private final String xforwardTagName;
 
     public ReactorHttpHandlerAdapter$Apply() {
+        ReactorTraceContextOperatorHook.install();
+
         requestFilter = new HttpIncomingFilter();
 
         traceConfig = ConfigurationManager.getInstance().getConfig(TraceConfig.class);
@@ -163,6 +167,7 @@ public class ReactorHttpHandlerAdapter$Apply extends AroundInterceptor {
         if (!(injected instanceof HttpServerContext)) {
             return;
         }
+        ITraceContext traceContext = ((HttpServerContext) injected).getTraceContext();
 
         final long start = aopContext.getStartNanoTime();
         BiConsumer<Void, Throwable> onSuccessOrError = (t, throwable) -> {
@@ -177,9 +182,9 @@ public class ReactorHttpHandlerAdapter$Apply extends AroundInterceptor {
         };
 
         // replace the returned Mono so that we can do sth when this request completes
-        aopContext.setReturning(mono.doOnSuccess((v) -> onSuccessOrError.accept(null, null))
-                                    .doOnError((error) -> onSuccessOrError.accept(null, error))
-        );
+        Mono<Void> tracedMono = mono.doOnSuccess((v) -> onSuccessOrError.accept(null, null))
+                                   .doOnError((error) -> onSuccessOrError.accept(null, error));
+        aopContext.setReturning(TraceContextScopedMono.wrap(tracedMono, traceContext));
     }
 
     private void update(HttpServerRequest request, HttpServerResponse response, long responseTime) {


### PR DESCRIPTION
## Summary

Propagate Bithon's WebFlux server trace context through Reactor signals so downstream asynchronous callbacks can still access the active request trace.

This fixes early WebFlux/Gateway paths where request handling continues after the original thread-local trace scope is no longer available, causing missing or stale trace tags on responses such as 401/400.

## Changes

- Add a Reactor `Hooks.onEachOperator` hook that restores the Bithon trace context from Reactor `Context` during signal callbacks.
- Add `TraceContextScopedMono` to store the request trace context in Reactor `Context` for the returned WebFlux `Mono`.
- Wrap the `Mono` returned from `ReactorHttpHandlerAdapter#apply` so request completion callbacks run with the correct trace context.

## Impact

- All Reactor operator signal callbacks now restore the Bithon trace context from Reactor `Context` when one is present.
- This makes WebFlux/Gateway asynchronous request handling see the correct request trace context across thread hops and delayed callbacks.
- Reactor flows without a Bithon trace context are unchanged; the hook falls through to the original callback behavior.


## Validation

- Built WebFlux plugin:
  - `mvn -pl agent/agent-plugins/spring/webflux -am -DskipTests -Dforbiddenapis.skip=true package`
- Built clean agent distribution:
  - `mvn -pl agent/agent-distribution -am -DskipTests -Dforbiddenapis.skip=true clean package`
- Ran local `bigdataplatform-gateway` with the rebuilt agent and validated:
  - 401 `/dataservice/bbw_a.test/v1`
  - 400 `/oauth/token`
  - 200 `/gateway/routes`
- Confirmed monitor traces include the expected gateway SERVER span tags, including `httpStatusCode` and `apiPattern`.
- Ran a mixed 401/400/200 burst; Prometheus counts and sampled traces stayed correctly separated with no obvious tag bleed.