### PR TITLE
Use trace span schema store for direct trace queries

### DIFF
--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
@@ -136,7 +136,8 @@ public class TraceJdbcReader implements ITraceReader {
                                                           IExpression filter,
                                                           TimeSpan start,
                                                           TimeSpan end) {
-        SelectConditionStep<Record> sql = dslContext.selectFrom(DSL.name(getTraceSpanStore()))
+        SelectConditionStep<Record> sql = dslContext.select(traceSpanSelectFields())
+                                                    .from(DSL.name(getTraceSpanStore()))
                                                     .where(traceSpanStringField(Tables.BITHON_TRACE_SPAN.TRACEID.getName()).eq(traceId));
         if (start != null) {
             // NOTE: we don't use Tables.BITHON_TRACE_SPAN.TIMESTAMP.ge(start) because the generated SQL might turn the start into a date time string which might cause time zone issues
@@ -301,7 +302,8 @@ public class TraceJdbcReader implements ITraceReader {
 
     @Override
     public List<TraceSpan> getTraceByParentSpanId(String parentSpanId) {
-        return dslContext.selectFrom(DSL.name(getTraceSpanStore()))
+        return dslContext.select(traceSpanSelectFields())
+                         .from(DSL.name(getTraceSpanStore()))
                          .where(traceSpanStringField(Tables.BITHON_TRACE_SPAN.PARENTSPANID.getName()).eq(parentSpanId))
                          // For spans coming from the same application instance, sort them by the start time
                          .orderBy(traceSpanField(this.traceSpanSchema.getTimestampSpec().getColumnName()).asc(),
@@ -365,9 +367,9 @@ public class TraceJdbcReader implements ITraceReader {
             String columnName = column.getName();
             groupByFields.add(columnName);
             if (columnName.equals(group)) {
-                selectStatement.getSelectorList().add(new org.bithon.server.datasource.query.ast.Column(columnName), column.getDataType());
+                selectStatement.getSelectorList().add(new Column(columnName), column.getDataType());
             } else {
-                selectStatement.getSelectorList().add(new org.bithon.server.datasource.query.ast.Column(columnName), group, column.getDataType());
+                selectStatement.getSelectorList().add(new Column(columnName), group, column.getDataType());
             }
         }
 
@@ -436,6 +438,15 @@ public class TraceJdbcReader implements ITraceReader {
 
     private Field<?> traceSpanField(String columnName) {
         return DSL.field(DSL.name(getTraceSpanColumnName(columnName)));
+    }
+
+    private List<Field<?>> traceSpanSelectFields() {
+        Field<?>[] fields = Tables.BITHON_TRACE_SPAN.fields();
+        List<Field<?>> selectFields = new ArrayList<>(fields.length);
+        for (Field<?> field : fields) {
+            selectFields.add(DSL.field(DSL.name(field.getName()), field.getDataType()));
+        }
+        return selectFields;
     }
 
     private String getTraceSpanColumnName(String columnName) {

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
@@ -41,6 +41,7 @@ import org.bithon.component.commons.utils.CollectionUtils;
 import org.bithon.component.commons.utils.StringUtils;
 import org.bithon.server.commons.time.TimeSpan;
 import org.bithon.server.datasource.ISchema;
+import org.bithon.server.datasource.column.IColumn;
 import org.bithon.server.datasource.query.DataRow;
 import org.bithon.server.datasource.query.IDataSourceReader;
 import org.bithon.server.datasource.query.Interval;
@@ -134,33 +135,35 @@ public class TraceJdbcReader implements ITraceReader {
                                                           IExpression filter,
                                                           TimeSpan start,
                                                           TimeSpan end) {
-        SelectConditionStep<Record> sql = dslContext.selectFrom(Tables.BITHON_TRACE_SPAN.getUnqualifiedName().quotedName())
-                                                    .where(Tables.BITHON_TRACE_SPAN.TRACEID.eq(traceId));
+        SelectConditionStep<Record> sql = dslContext.selectFrom(DSL.name(getTraceSpanStore()))
+                                                    .where(traceSpanStringField(Tables.BITHON_TRACE_SPAN.TRACEID.getName()).eq(traceId));
         if (start != null) {
             // NOTE: we don't use Tables.BITHON_TRACE_SPAN.TIMESTAMP.ge(start) because the generated SQL might turn the start into a date time string which might cause time zone issues
             IExpression expr = new ComparisonExpression.GTE(
-                new IdentifierExpression(Tables.BITHON_TRACE_SPAN.TIMESTAMP.getName()),
+                new IdentifierExpression(this.traceSpanSchema.getTimestampSpec().getColumnName()),
                 sqlDialect.toISO8601TimestampExpression(start)
             );
             sql = sql.and(sqlDialect.createSqlSerializer(null).serialize(expr));
         }
         if (end != null) {
             IExpression expr = new ComparisonExpression.LT(
-                new IdentifierExpression(Tables.BITHON_TRACE_SPAN.TIMESTAMP.getName()),
+                new IdentifierExpression(this.traceSpanSchema.getTimestampSpec().getColumnName()),
                 sqlDialect.toISO8601TimestampExpression(end)
             );
             sql = sql.and(sqlDialect.createSqlSerializer(null).serialize(expr));
         }
 
         if (filter != null) {
-            sql = sql.and(Expression2Sql.from(Tables.BITHON_TRACE_SPAN.getName(), sqlDialect, filter));
+            sql = sql.and(Expression2Sql.from(this.traceSpanSchema, sqlDialect, filter));
         }
 
         // For spans coming from the same application instance, sort them by the start time
-        Cursor<Record> cursor = sql.orderBy(Tables.BITHON_TRACE_SPAN.TIMESTAMP.asc(),
-                                            Tables.BITHON_TRACE_SPAN.INSTANCENAME,
-                                            Tables.BITHON_TRACE_SPAN.STARTTIMEUS)
-                                   .fetchLazy();
+        Select<Record> traceQuery = sql.orderBy(traceSpanField(this.traceSpanSchema.getTimestampSpec().getColumnName()).asc(),
+                                                traceSpanField(Tables.BITHON_TRACE_SPAN.INSTANCENAME.getName()),
+                                                traceSpanField(Tables.BITHON_TRACE_SPAN.STARTTIMEUS.getName()));
+        String traceSql = toSQL(traceQuery);
+        log.info("Get trace by trace id: {}", traceSql);
+        Cursor<Record> cursor = dslContext.fetchLazy(traceSql);
 
         return CloseableIterator.transform(cursor.iterator(),
                                            (record) -> toTraceSpan(record, TraceSpanRecordAccessor.TABLE_RECORD_ACCESSOR),
@@ -173,26 +176,26 @@ public class TraceJdbcReader implements ITraceReader {
                                  TimeSpan start,
                                  TimeSpan end) {
         SelectConditionStep<Record1<Integer>> sql = dslContext.selectCount()
-                                                              .from(Tables.BITHON_TRACE_SPAN.getUnqualifiedName().quotedName())
-                                                              .where(Tables.BITHON_TRACE_SPAN.TRACEID.eq(traceId));
+                                                              .from(DSL.name(getTraceSpanStore()))
+                                                              .where(traceSpanStringField(Tables.BITHON_TRACE_SPAN.TRACEID.getName()).eq(traceId));
         if (start != null) {
             // NOTE: we don't use Tables.BITHON_TRACE_SPAN.TIMESTAMP.ge(start) because the generated SQL might turn the start into a date time string which might cause time zone issues
             IExpression expr = new ComparisonExpression.GTE(
-                new IdentifierExpression(Tables.BITHON_TRACE_SPAN.TIMESTAMP.getName()),
+                new IdentifierExpression(this.traceSpanSchema.getTimestampSpec().getColumnName()),
                 sqlDialect.toISO8601TimestampExpression(start)
             );
             sql = sql.and(sqlDialect.createSqlSerializer(null).serialize(expr));
         }
         if (end != null) {
             IExpression expr = new ComparisonExpression.LT(
-                new IdentifierExpression(Tables.BITHON_TRACE_SPAN.TIMESTAMP.getName()),
+                new IdentifierExpression(this.traceSpanSchema.getTimestampSpec().getColumnName()),
                 sqlDialect.toISO8601TimestampExpression(end)
             );
             sql = sql.and(sqlDialect.createSqlSerializer(null).serialize(expr));
         }
 
         if (filter != null) {
-            sql = sql.and(Expression2Sql.from(Tables.BITHON_TRACE_SPAN.getName(), sqlDialect, filter));
+            sql = sql.and(Expression2Sql.from(this.traceSpanSchema, sqlDialect, filter));
         }
 
         Record1<Integer> record = sql.fetchOne();
@@ -295,12 +298,12 @@ public class TraceJdbcReader implements ITraceReader {
 
     @Override
     public List<TraceSpan> getTraceByParentSpanId(String parentSpanId) {
-        return dslContext.selectFrom(Tables.BITHON_TRACE_SPAN.getUnqualifiedName().quotedName())
-                         .where(Tables.BITHON_TRACE_SPAN.PARENTSPANID.eq(parentSpanId))
+        return dslContext.selectFrom(DSL.name(getTraceSpanStore()))
+                         .where(traceSpanStringField(Tables.BITHON_TRACE_SPAN.PARENTSPANID.getName()).eq(parentSpanId))
                          // For spans coming from the same application instance, sort them by the start time
-                         .orderBy(Tables.BITHON_TRACE_SPAN.TIMESTAMP.asc(),
-                                  Tables.BITHON_TRACE_SPAN.INSTANCENAME,
-                                  Tables.BITHON_TRACE_SPAN.STARTTIMEUS)
+                         .orderBy(traceSpanField(this.traceSpanSchema.getTimestampSpec().getColumnName()).asc(),
+                                  traceSpanField(Tables.BITHON_TRACE_SPAN.INSTANCENAME.getName()),
+                                  traceSpanField(Tables.BITHON_TRACE_SPAN.STARTTIMEUS.getName()))
                          .fetch((record) -> toTraceSpan(record, TraceSpanRecordAccessor.TABLE_RECORD_ACCESSOR));
     }
 
@@ -328,21 +331,21 @@ public class TraceJdbcReader implements ITraceReader {
                                                               Collection<String> groups) {
         List<IExpression> where = new ArrayList<>();
         where.add(new ComparisonExpression.EQ(
-            new IdentifierExpression(Tables.BITHON_TRACE_SPAN.TRACEID.getName()),
+            new IdentifierExpression(getTraceSpanColumnName(Tables.BITHON_TRACE_SPAN.TRACEID.getName())),
             new LiteralExpression.StringLiteral(traceId)
         ));
 
         if (start != null) {
             // NOTE: we don't use Tables.BITHON_TRACE_SPAN.TIMESTAMP.ge(start) because the generated SQL might turn the start into a date time string which might cause time zone issues
             IExpression expr = new ComparisonExpression.GTE(
-                new IdentifierExpression(Tables.BITHON_TRACE_SPAN.TIMESTAMP.getName()),
+                new IdentifierExpression(this.traceSpanSchema.getTimestampSpec().getColumnName()),
                 sqlDialect.toISO8601TimestampExpression(start)
             );
             where.add(expr);
         }
         if (end != null) {
             IExpression expr = new ComparisonExpression.LT(
-                new IdentifierExpression(Tables.BITHON_TRACE_SPAN.TIMESTAMP.getName()),
+                new IdentifierExpression(this.traceSpanSchema.getTimestampSpec().getColumnName()),
                 sqlDialect.toISO8601TimestampExpression(end)
             );
             where.add(expr);
@@ -359,7 +362,7 @@ public class TraceJdbcReader implements ITraceReader {
 
         IExpression countExpression = new FunctionExpression(AggregateFunction.Count.INSTANCE, new LiteralExpression.LongLiteral(1));
         selectStatement.getSelectorList().add(new ExpressionNode(countExpression), "count", IDataType.LONG);
-        selectStatement.getFrom().setExpression(new TableIdentifier(Tables.BITHON_TRACE_SPAN.getUnqualifiedName().last()));
+        selectStatement.getFrom().setExpression(new TableIdentifier(this.traceSpanSchema.getDataStoreSpec().getStore()));
         selectStatement.getWhere().and(where);
         selectStatement.getGroupBy().addFields(groups);
         selectStatement.setOrderBy(new OrderByClause("count", Order.desc));
@@ -410,6 +413,23 @@ public class TraceJdbcReader implements ITraceReader {
 
     protected IDataSourceReader getDataSourceReader() {
         return new JdbcDataSourceReader(this.dslContext, this.sqlDialect, this.querySettings);
+    }
+
+    private String getTraceSpanStore() {
+        return this.traceSpanSchema.getDataStoreSpec().getStore();
+    }
+
+    private Field<String> traceSpanStringField(String columnName) {
+        return DSL.field(DSL.name(getTraceSpanColumnName(columnName)), String.class);
+    }
+
+    private Field<Object> traceSpanField(String columnName) {
+        return DSL.field(DSL.name(getTraceSpanColumnName(columnName)));
+    }
+
+    private String getTraceSpanColumnName(String columnName) {
+        IColumn column = this.traceSpanSchema.getColumnByName(columnName);
+        return column == null ? columnName : column.getName();
     }
 
     @Override

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
@@ -161,9 +161,8 @@ public class TraceJdbcReader implements ITraceReader {
         Select<Record> traceQuery = sql.orderBy(traceSpanField(this.traceSpanSchema.getTimestampSpec().getColumnName()).asc(),
                                                 traceSpanField(Tables.BITHON_TRACE_SPAN.INSTANCENAME.getName()),
                                                 traceSpanField(Tables.BITHON_TRACE_SPAN.STARTTIMEUS.getName()));
-        String traceSql = toSQL(traceQuery);
-        log.info("Get trace by trace id: {}", traceSql);
-        Cursor<Record> cursor = dslContext.fetchLazy(traceSql);
+        log.info("Get trace by trace id: {}", toSQL(traceQuery));
+        Cursor<Record> cursor = dslContext.fetchLazy(toExecutableSQL(traceQuery), traceQuery.getBindValues().toArray());
 
         return CloseableIterator.transform(cursor.iterator(),
                                            (record) -> toTraceSpan(record, TraceSpanRecordAccessor.TABLE_RECORD_ACCESSOR),
@@ -287,9 +286,12 @@ public class TraceJdbcReader implements ITraceReader {
                                            cursor);
     }
 
-    @SuppressWarnings("rawtypes")
-    private String toSQL(Select selectQuery) {
+    private String toSQL(Select<?> selectQuery) {
         return decorateSQL(dslContext.renderInlined(selectQuery));
+    }
+
+    private String toExecutableSQL(Select<?> selectQuery) {
+        return decorateSQL(dslContext.render(selectQuery));
     }
 
     protected String decorateSQL(String sql) {
@@ -356,15 +358,23 @@ public class TraceJdbcReader implements ITraceReader {
         }
 
         SelectStatement selectStatement = new SelectStatement();
+        List<String> groupByFields = new ArrayList<>(groups.size());
         for (String group : groups) {
-            selectStatement.getSelectorList().add(new org.bithon.server.datasource.query.ast.Column(group), IDataType.STRING);
+            IColumn column = getTraceSpanColumn(group);
+            String columnName = column.getName();
+            groupByFields.add(columnName);
+            if (columnName.equals(group)) {
+                selectStatement.getSelectorList().add(new org.bithon.server.datasource.query.ast.Column(columnName), column.getDataType());
+            } else {
+                selectStatement.getSelectorList().add(new org.bithon.server.datasource.query.ast.Column(columnName), group, column.getDataType());
+            }
         }
 
         IExpression countExpression = new FunctionExpression(AggregateFunction.Count.INSTANCE, new LiteralExpression.LongLiteral(1));
         selectStatement.getSelectorList().add(new ExpressionNode(countExpression), "count", IDataType.LONG);
         selectStatement.getFrom().setExpression(new TableIdentifier(this.traceSpanSchema.getDataStoreSpec().getStore()));
         selectStatement.getWhere().and(where);
-        selectStatement.getGroupBy().addFields(groups);
+        selectStatement.getGroupBy().addFields(groupByFields);
         selectStatement.setOrderBy(new OrderByClause("count", Order.desc));
 
         String sql = selectStatement.toSQL(this.sqlDialect);
@@ -430,6 +440,14 @@ public class TraceJdbcReader implements ITraceReader {
     private String getTraceSpanColumnName(String columnName) {
         IColumn column = this.traceSpanSchema.getColumnByName(columnName);
         return column == null ? columnName : column.getName();
+    }
+
+    private IColumn getTraceSpanColumn(String columnName) {
+        IColumn column = this.traceSpanSchema.getColumnByName(columnName);
+        if (column == null) {
+            throw new IllegalArgumentException("Invalid trace span field: " + columnName);
+        }
+        return column;
     }
 
     @Override

--- a/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
+++ b/server/storage-jdbc/src/main/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReader.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.bithon.component.commons.exception.HttpMappableException;
 import org.bithon.component.commons.expression.ComparisonExpression;
 import org.bithon.component.commons.expression.ConditionalExpression;
 import org.bithon.component.commons.expression.ExpressionList;
@@ -433,7 +434,7 @@ public class TraceJdbcReader implements ITraceReader {
         return DSL.field(DSL.name(getTraceSpanColumnName(columnName)), String.class);
     }
 
-    private Field<Object> traceSpanField(String columnName) {
+    private Field<?> traceSpanField(String columnName) {
         return DSL.field(DSL.name(getTraceSpanColumnName(columnName)));
     }
 
@@ -445,7 +446,7 @@ public class TraceJdbcReader implements ITraceReader {
     private IColumn getTraceSpanColumn(String columnName) {
         IColumn column = this.traceSpanSchema.getColumnByName(columnName);
         if (column == null) {
-            throw new IllegalArgumentException("Invalid trace span field: " + columnName);
+            throw new HttpMappableException(400, "Invalid trace span field: %s", columnName);
         }
         return column;
     }

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
@@ -58,6 +58,8 @@ class TraceJdbcReaderSchemaStoreTest {
         newReader(sqls).getTraceByTraceId("trace-1", null, null, null).close();
 
         assertUsesCustomTraceSpanStore(sqls.get(0));
+        assertTrue(sqls.get(0).contains("?"), sqls.get(0));
+        assertFalse(sqls.get(0).contains("'trace-1'"), sqls.get(0));
     }
 
     @Test
@@ -85,6 +87,18 @@ class TraceJdbcReaderSchemaStoreTest {
         newReader(sqls).getTraceSpanDistribution("trace-1", null, null, null, List.of("appName"));
 
         assertUsesCustomTraceSpanStore(sqls.get(0));
+    }
+
+    @Test
+    void getTraceSpanDistributionResolvesGroupAlias() {
+        List<String> sqls = new ArrayList<>();
+
+        newReader(sqls).getTraceSpanDistribution("trace-1", null, null, null, List.of("url"));
+
+        String sql = sqls.get(0);
+        assertTrue(sql.contains("\"normalizedUrl\" AS \"url\""), sql);
+        assertTrue(sql.contains("GROUP BY \"normalizedUrl\""), sql);
+        assertFalse(sql.contains("GROUP BY \"url\""), sql);
     }
 
     private static TraceJdbcReader newReader(List<String> sqls) {
@@ -133,7 +147,7 @@ class TraceJdbcReaderSchemaStoreTest {
         @Override
         public IColumn getColumnByName(String name) {
             return getColumns().stream()
-                               .filter(column -> column.getName().equals(name))
+                               .filter(column -> column.getName().equals(name) || column.getAlias().equals(name))
                                .findFirst()
                                .orElse(null);
         }
@@ -144,6 +158,7 @@ class TraceJdbcReaderSchemaStoreTest {
                            new StringColumn("appName", "appName"),
                            new StringColumn("instanceName", "instanceName"),
                            new StringColumn("name", "name"),
+                           new StringColumn("normalizedUrl", "url"),
                            new StringColumn("kind", "kind"),
                            new LongColumn("timestamp", "timestamp"),
                            new LongColumn("startTimeUs", "startTimeUs"),

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
@@ -61,6 +61,7 @@ class TraceJdbcReaderSchemaStoreTest {
         newReader(sqls).getTraceByTraceId("trace-1", null, null, null).close();
 
         assertUsesCustomTraceSpanStore(sqls.get(0));
+        assertSelectsTraceSpanFields(sqls.get(0));
         assertTrue(sqls.get(0).contains("?"), sqls.get(0));
         assertFalse(sqls.get(0).contains("'trace-1'"), sqls.get(0));
     }
@@ -81,6 +82,7 @@ class TraceJdbcReaderSchemaStoreTest {
         newReader(sqls).getTraceByParentSpanId("span-1");
 
         assertUsesCustomTraceSpanStore(sqls.get(0));
+        assertSelectsTraceSpanFields(sqls.get(0));
     }
 
     @Test
@@ -139,6 +141,12 @@ class TraceJdbcReaderSchemaStoreTest {
     private static void assertUsesCustomTraceSpanStore(String sql) {
         assertTrue(sql.contains(CUSTOM_TRACE_SPAN_STORE), sql);
         assertFalse(sql.contains("bithon_trace_span"), sql);
+    }
+
+    private static void assertSelectsTraceSpanFields(String sql) {
+        assertTrue(sql.startsWith("select \"timestamp\", \"appName\", \"instanceName\""), sql);
+        assertTrue(sql.contains("\"tags\", \"attributes\""), sql);
+        assertFalse(sql.startsWith("select *"), sql);
     }
 
     private static ISchema schema(String name, String store, String timestampColumn) {

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
@@ -1,0 +1,255 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.server.storage.jdbc.tracing.reader;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bithon.component.commons.expression.IExpression;
+import org.bithon.component.commons.expression.LiteralExpression;
+import org.bithon.server.commons.time.Period;
+import org.bithon.server.commons.time.TimeSpan;
+import org.bithon.server.datasource.ISchema;
+import org.bithon.server.datasource.TimestampSpec;
+import org.bithon.server.datasource.column.IColumn;
+import org.bithon.server.datasource.column.LongColumn;
+import org.bithon.server.datasource.column.ObjectColumn;
+import org.bithon.server.datasource.column.StringColumn;
+import org.bithon.server.datasource.query.IDataSourceReader;
+import org.bithon.server.datasource.query.setting.QuerySettings;
+import org.bithon.server.datasource.reader.jdbc.dialect.ISqlDialect;
+import org.bithon.server.datasource.reader.jdbc.statement.ast.WindowFunctionExpression;
+import org.bithon.server.storage.tracing.TraceStorageConfig;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.MockConnection;
+import org.jooq.tools.jdbc.MockResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraceJdbcReaderSchemaStoreTest {
+
+    private static final String CUSTOM_TRACE_SPAN_STORE = "custom_trace_span";
+
+    @Test
+    void getTraceByTraceIdUsesTraceSpanSchemaStore() throws Exception {
+        List<String> sqls = new ArrayList<>();
+
+        newReader(sqls).getTraceByTraceId("trace-1", null, null, null).close();
+
+        assertUsesCustomTraceSpanStore(sqls.get(0));
+    }
+
+    @Test
+    void getTraceSpanCountUsesTraceSpanSchemaStore() {
+        List<String> sqls = new ArrayList<>();
+
+        newReader(sqls).getTraceSpanCount("trace-1", null, null, null);
+
+        assertUsesCustomTraceSpanStore(sqls.get(0));
+    }
+
+    @Test
+    void getTraceByParentSpanIdUsesTraceSpanSchemaStore() {
+        List<String> sqls = new ArrayList<>();
+
+        newReader(sqls).getTraceByParentSpanId("span-1");
+
+        assertUsesCustomTraceSpanStore(sqls.get(0));
+    }
+
+    @Test
+    void getTraceSpanDistributionUsesTraceSpanSchemaStore() {
+        List<String> sqls = new ArrayList<>();
+
+        newReader(sqls).getTraceSpanDistribution("trace-1", null, null, null, List.of("appName"));
+
+        assertUsesCustomTraceSpanStore(sqls.get(0));
+    }
+
+    private static TraceJdbcReader newReader(List<String> sqls) {
+        DSLContext dslContext = DSL.using(new MockConnection(context -> {
+            sqls.add(context.sql());
+            return new MockResult[] {
+                new MockResult(0, DSL.using(SQLDialect.H2).newResult())
+            };
+        }), SQLDialect.H2);
+
+        return new TraceJdbcReader(dslContext,
+                                   new ObjectMapper(),
+                                   schema("trace_span_summary", "custom_trace_span_summary", "startTimeUs"),
+                                   schema("trace_span", CUSTOM_TRACE_SPAN_STORE, "timestamp"),
+                                   schema("trace_span_tag_index", "custom_trace_span_tag_index", "timestamp"),
+                                   new TraceStorageConfig(),
+                                   new TestSqlDialect(),
+                                   QuerySettings.DEFAULT);
+    }
+
+    private static void assertUsesCustomTraceSpanStore(String sql) {
+        assertTrue(sql.contains(CUSTOM_TRACE_SPAN_STORE), sql);
+        assertFalse(sql.contains("bithon_trace_span"), sql);
+    }
+
+    private static ISchema schema(String name, String store, String timestampColumn) {
+        return new TestSchema(name, store, timestampColumn);
+    }
+
+    private record TestSchema(String name, String store, String timestampColumn) implements ISchema {
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getDisplayText() {
+            return name;
+        }
+
+        @Override
+        public TimestampSpec getTimestampSpec() {
+            return new TimestampSpec(timestampColumn);
+        }
+
+        @Override
+        public IColumn getColumnByName(String name) {
+            return getColumns().stream()
+                               .filter(column -> column.getName().equals(name))
+                               .findFirst()
+                               .orElse(null);
+        }
+
+        @Override
+        public Collection<IColumn> getColumns() {
+            return List.of(new StringColumn("traceId", "traceId"),
+                           new StringColumn("appName", "appName"),
+                           new StringColumn("instanceName", "instanceName"),
+                           new StringColumn("name", "name"),
+                           new StringColumn("kind", "kind"),
+                           new LongColumn("timestamp", "timestamp"),
+                           new LongColumn("startTimeUs", "startTimeUs"),
+                           new ObjectColumn("attributes", "tags"));
+        }
+
+        @Override
+        public JsonNode getInputSourceSpec() {
+            return null;
+        }
+
+        @Override
+        public TestDataStoreSpec getDataStoreSpec() {
+            return new TestDataStoreSpec(store);
+        }
+
+        @Override
+        public ISchema withDataStore(org.bithon.server.datasource.store.IDataStoreSpec spec) {
+            return this;
+        }
+
+        @Override
+        public void setSignature(String signature) {
+        }
+
+        @Override
+        public String getSignature() {
+            return null;
+        }
+
+        @Override
+        public Period getTtl() {
+            return null;
+        }
+    }
+
+    private record TestDataStoreSpec(String store) implements org.bithon.server.datasource.store.IDataStoreSpec {
+        @Override
+        public String getStore() {
+            return store;
+        }
+
+        @Override
+        public void setSchema(ISchema schema) {
+        }
+
+        @Override
+        public boolean isInternal() {
+            return true;
+        }
+
+        @Override
+        public IDataSourceReader createReader() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class TestSqlDialect implements ISqlDialect {
+        @Override
+        public String quoteIdentifier(String identifier) {
+            return "\"" + identifier + "\"";
+        }
+
+        @Override
+        public String toUnixTimestamp(IExpression timestampExpression, long intervalSeconds) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public IExpression timeFloor(IExpression timestampExpression, long intervalSeconds) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isAliasAllowedInWhereClause() {
+            return true;
+        }
+
+        @Override
+        public boolean needTableAlias() {
+            return false;
+        }
+
+        @Override
+        public IExpression toISO8601TimestampExpression(TimeSpan timeSpan) {
+            return new LiteralExpression.TimestampLiteral(timeSpan.getMilliseconds());
+        }
+
+        @Override
+        public String stringAggregator(String field) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public WindowFunctionExpression firstWindowFunction(String field, long window) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String formatDateTime(LiteralExpression.TimestampLiteral expression) {
+            return expression.getValue().toString();
+        }
+
+        @Override
+        public char getEscapeCharacter4SingleQuote() {
+            return '\\';
+        }
+    }
+}

--- a/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
+++ b/server/storage-jdbc/src/test/java/org/bithon/server/storage/jdbc/tracing/reader/TraceJdbcReaderSchemaStoreTest.java
@@ -18,6 +18,7 @@ package org.bithon.server.storage.jdbc.tracing.reader;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bithon.component.commons.exception.HttpMappableException;
 import org.bithon.component.commons.expression.IExpression;
 import org.bithon.component.commons.expression.LiteralExpression;
 import org.bithon.server.commons.time.Period;
@@ -44,7 +45,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TraceJdbcReaderSchemaStoreTest {
@@ -99,6 +102,20 @@ class TraceJdbcReaderSchemaStoreTest {
         assertTrue(sql.contains("\"normalizedUrl\" AS \"url\""), sql);
         assertTrue(sql.contains("GROUP BY \"normalizedUrl\""), sql);
         assertFalse(sql.contains("GROUP BY \"url\""), sql);
+    }
+
+    @Test
+    void getTraceSpanDistributionRejectsInvalidGroup() {
+        TraceJdbcReader reader = newReader(new ArrayList<>());
+
+        HttpMappableException exception = assertThrows(HttpMappableException.class,
+                                                       () -> reader.getTraceSpanDistribution("trace-1",
+                                                                                             null,
+                                                                                             null,
+                                                                                             null,
+                                                                                             List.of("unknown")));
+
+        assertEquals(400, exception.getStatusCode());
     }
 
     private static TraceJdbcReader newReader(List<String> sqls) {

--- a/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceTableSchema.java
+++ b/server/storage/src/main/java/org/bithon/server/storage/tracing/TraceTableSchema.java
@@ -153,6 +153,7 @@ public class TraceTableSchema implements ISchema {
 
     public static TraceTableSchema createTraceSpanTableSchema(ITraceStorage traceStorage) {
         return new TraceTableSchema(TRACE_SPAN_SCHEMA_NAME,
+                                    TRACE_SPAN_SCHEMA_NAME,
                                     traceStorage,
                                     getTraceSpanColumns(),
                                     "timestamp");


### PR DESCRIPTION
## Summary
- Read direct trace span queries from the trace span schema store instead of hard-coded bithon_trace_span
- Use unqualified jOOQ fields so query predicates/order-by match the schema-selected FROM table
- Add coverage for getTraceByTraceId, getTraceSpanCount, getTraceByParentSpanId, and getTraceSpanDistribution

## Test
- mvn -pl server/storage-jdbc -am -Dtest=TraceJdbcReaderSchemaStoreTest -Dsurefire.failIfNoSpecifiedTests=false test