### PR TITLE
[codex] Upgrade Checkstyle baseline

### DIFF
--- a/agent/agent-controller/src/main/java/org/bithon/agent/controller/cmd/profiling/asyncprofiler/jfr/event/InitialSystemProperty.java
+++ b/agent/agent-controller/src/main/java/org/bithon/agent/controller/cmd/profiling/asyncprofiler/jfr/event/InitialSystemProperty.java
@@ -22,8 +22,9 @@ import one.jfr.event.Event;
 /**
  * Represents initial system property event from JFR (jdk.InitialSystemProperty)
  * This event captures system properties that were set when the JVM started.
- * 
- * @see https://bestsolution-at.github.io/jfr-doc/openjdk-17.html#jdk.InitialSystemProperty
+ *
+ * @see <a href="https://bestsolution-at.github.io/jfr-doc/openjdk-17.html#jdk.InitialSystemProperty">JFR Event
+ * Documentation</a>
  * @author frank.chen021@outlook.com
  * @date 2025/1/12
  */

--- a/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/declaration/AbstractInterceptor.java
+++ b/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/declaration/AbstractInterceptor.java
@@ -32,7 +32,7 @@ public abstract class AbstractInterceptor {
     private static final ILogger LOG = LoggerFactory.getLogger(AbstractInterceptor.class);
 
     private final LongAdder hitCount = new LongAdder();
-    private long lastHitTime;
+    private volatile long lastHitTime;
 
     // Statistics for exceptions thrown from the interceptor
     private long exceptionCount;

--- a/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/installer/DynamicInterceptorInstaller.java
+++ b/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/installer/DynamicInterceptorInstaller.java
@@ -54,6 +54,9 @@ public class DynamicInterceptorInstaller {
         return INSTANCE;
     }
 
+    private DynamicInterceptorInstaller() {
+    }
+
     /**
      * Install one interceptor
      */

--- a/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/precondition/TypeResolver.java
+++ b/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/aop/interceptor/precondition/TypeResolver.java
@@ -34,6 +34,9 @@ public class TypeResolver {
         return INSTANCE;
     }
 
+    private TypeResolver() {
+    }
+
     public boolean isResolved(ClassLoader classLoader, String clazz) {
         if (classLoader == null) {
             classLoader = BootstrapClassLoader.INSTANCE;

--- a/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/utils/PropertyFileReader.java
+++ b/agent/agent-instrumentation/src/main/java/org/bithon/agent/instrumentation/utils/PropertyFileReader.java
@@ -16,8 +16,6 @@
 
 package org.bithon.agent.instrumentation.utils;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -29,7 +27,6 @@ import java.util.Properties;
  * @date 2025/8/10 21:53
  */
 public class PropertyFileReader {
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE")
     public static Properties read(ClassLoader classLoader, String propertyFile) throws IOException {
         try (InputStream inputStream = classLoader.getResourceAsStream(propertyFile)) {
             if (inputStream == null) {

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/context/AppInstance.java
@@ -41,8 +41,8 @@ public class AppInstance {
     private final String qualifiedName;
     private final String env;
     private final List<IAppInstanceChangedListener> listeners = Collections.synchronizedList(new ArrayList<>());
-    private int port;
-    private String instanceName;
+    private volatile int port;
+    private volatile String instanceName;
     private final boolean useExternalInstanceName;
 
     private AppInstance(AppConfig appConfig) {

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/metric/model/generator/IAggregate.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/metric/model/generator/IAggregate.java
@@ -16,8 +16,6 @@
 
 package org.bithon.agent.observability.metric.model.generator;
 
-import java.util.function.BiFunction;
-
 /**
  * @author frank.chen021@outlook.com
  * @date 2025/2/13 20:23
@@ -26,8 +24,8 @@ public interface IAggregate<T> {
     /**
      * TODO:
      * change the return type to T
-     * so that it matches the BiFunction<T,T,T> signature which can be directly used as the 3nd parameter of
-     * {@link java.util.Map#merge(Object, Object, BiFunction)}
+     * so that it matches the {@link java.util.function.BiFunction} signature which can be directly used as the 3nd
+     * parameter of {@link java.util.Map#merge(Object, Object, java.util.function.BiFunction)}
      *
      * @param prev
      * @param now

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/metric/model/generator/IAggregate.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/metric/model/generator/IAggregate.java
@@ -24,7 +24,7 @@ public interface IAggregate<T> {
     /**
      * TODO:
      * change the return type to T
-     * so that it matches the {@link java.util.function.BiFunction} signature which can be directly used as the 3nd
+     * so that it matches the {@link java.util.function.BiFunction} signature which can be directly used as the 3rd
      * parameter of {@link java.util.Map#merge(Object, Object, java.util.function.BiFunction)}
      *
      * @param prev

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/TraceContextListener.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/tracing/context/TraceContextListener.java
@@ -40,7 +40,7 @@ public class TraceContextListener {
 
     private final IListener spanDebugListener = new SpanEventDebugLogger();
 
-    public TraceContextListener() {
+    private TraceContextListener() {
         ConfigurationManager.getInstance()
                             .addConfigurationChangedListener("tracing.debug", this::addOrRemoveDebugListener);
         addOrRemoveDebugListener();

--- a/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/context/GrpcClientMetricStorage.java
+++ b/agent/agent-plugins/grpc/src/main/java/org/bithon/agent/plugin/grpc/client/context/GrpcClientMetricStorage.java
@@ -33,7 +33,7 @@ public class GrpcClientMetricStorage extends AbstractMetricStorage<GrpcMetrics> 
 
     private static volatile GrpcClientMetricStorage INSTANCE;
 
-    public GrpcClientMetricStorage() {
+    private GrpcClientMetricStorage() {
         super(NAME,
               Arrays.asList("service", "method", "status", "server"),
               GrpcMetrics.class,

--- a/agent/agent-plugins/httpclient/jdk/src/main/java/org/bithon/agent/plugin/httpclient/jdk/interceptor/HttpsClient$New.java
+++ b/agent/agent-plugins/httpclient/jdk/src/main/java/org/bithon/agent/plugin/httpclient/jdk/interceptor/HttpsClient$New.java
@@ -19,15 +19,9 @@ package org.bithon.agent.plugin.httpclient.jdk.interceptor;
 import org.bithon.agent.instrumentation.aop.IBithonObject;
 import org.bithon.agent.instrumentation.aop.context.AopContext;
 import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
-import sun.net.www.protocol.http.HttpURLConnection;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSocketFactory;
-import java.net.Proxy;
-import java.net.URL;
 
 /**
- * {@link {@link sun.net.www.protocol.https.HttpsClient#New(SSLSocketFactory sf, URL url, HostnameVerifier hv, Proxy p, boolean useCache, int connectTimeout, HttpURLConnection httpuc)}
+ * Intercepts {@code sun.net.www.protocol.https.HttpsClient#New(...)}.
  *
  * @author frank.chen021@outlook.com
  * @date 2021/3/14 11:13 下午

--- a/agent/agent-plugins/httpclient/okhttp-3.2/src/main/java/org/bithon/agent/plugin/httpclient/okhttp32/RealCall$GetResponseWithInterceptorChain.java
+++ b/agent/agent-plugins/httpclient/okhttp-3.2/src/main/java/org/bithon/agent/plugin/httpclient/okhttp32/RealCall$GetResponseWithInterceptorChain.java
@@ -44,7 +44,7 @@ import java.util.Locale;
 
 /**
  * 3.2+ {@link okhttp3.RealCall}
- * 4.4+ {@link okhttp3.internal.connection.RealCall()}
+ * 4.4+ {@code okhttp3.internal.connection.RealCall}
  *
  * @author frankchen
  */

--- a/agent/agent-sdk/pom.xml
+++ b/agent/agent-sdk/pom.xml
@@ -41,6 +41,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.deploy.skip>false</maven.deploy.skip>
+    <spotbugs.version>4.9.8</spotbugs.version>
+    <spotbugs.maven.plugin.version>4.9.8.1</spotbugs.maven.plugin.version>
   </properties>
 
   <build>
@@ -58,13 +60,13 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.9.8.1</version>
+        <version>${spotbugs.maven.plugin.version}</version>
         <dependencies>
           <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.9.8</version>
+            <version>${spotbugs.version}</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/agent/agent-sdk/pom.xml
+++ b/agent/agent-sdk/pom.xml
@@ -58,13 +58,13 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.8.3.0</version>
+        <version>4.9.8.1</version>
         <dependencies>
           <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.8.3</version>
+            <version>4.9.8</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
+++ b/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
@@ -83,7 +83,7 @@ public class BrpcClient implements IBrpcChannel, Closeable {
      */
     private final Headers headers = new Headers();
 
-    private long connectionTimestamp;
+    private volatile long connectionTimestamp;
 
     private final InvocationManager invocationManager;
 

--- a/component/component-commons/src/main/java/org/bithon/component/commons/concurrency/PeriodicTask.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/concurrency/PeriodicTask.java
@@ -33,6 +33,7 @@ public abstract class PeriodicTask {
     private final String name;
 
     private volatile boolean running = false;
+    private boolean wakeup = false;
     private final boolean autoShutdown;
 
     public PeriodicTask(String name,
@@ -89,7 +90,10 @@ public abstract class PeriodicTask {
     private void waitTimeout() {
         synchronized (locker) {
             try {
-                locker.wait(period);
+                if (!wakeup) {
+                    locker.wait(period);
+                }
+                wakeup = false;
             } catch (InterruptedException ignored) {
             }
         }
@@ -100,7 +104,8 @@ public abstract class PeriodicTask {
      */
     public final void runImmediately() {
         synchronized (locker) {
-            locker.notify();
+            wakeup = true;
+            locker.notifyAll();
         }
     }
 

--- a/component/component-commons/src/main/java/org/bithon/component/commons/expression/ConditionalExpression.java
+++ b/component/component-commons/src/main/java/org/bithon/component/commons/expression/ConditionalExpression.java
@@ -24,7 +24,7 @@ import java.util.Set;
 /**
  * IN/NOT IN
  * LIKE/NOT LIKE
- * Comparison: >/>=/</<=/<>/=
+ * Comparison: &gt;/&gt;=/&lt;/&lt;=/&lt;&gt;/=
  *
  * @author Frank Chen
  * @date 20/1/24 10:50 pm

--- a/dev/spotbugs-exclude.xml
+++ b/dev/spotbugs-exclude.xml
@@ -113,6 +113,12 @@
     <Bug pattern="DB_DUPLICATE_BRANCHES"/>
   </Match>
 
+  <!-- agent-sentinel -->
+  <Match>
+    <Class name="org.bithon.agent.sentinel.SentinelRuleManager"/>
+    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
+  </Match>
+
   <!-- component-commons -->
   <Match>
     <Class name="org.bithon.component.commons.logging.LoggerConfiguration"/>
@@ -125,6 +131,10 @@
   <Match>
     <Class name="org.bithon.component.commons.tracing.Tags$Exception"/>
     <Bug pattern="NM_CLASS_NOT_EXCEPTION"/>
+  </Match>
+  <Match>
+    <Class name="org.bithon.component.commons.expression.function.Functions"/>
+    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
   </Match>
 
   <!-- Agent RPC -->

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>5.2.0</version>
+        <version>5.6.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -343,7 +343,7 @@
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.8.3</version>
+            <version>4.9.8</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>9.3</version>
+            <version>13.4.2</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,9 @@
     <junit.jupiter.version>5.10.5</junit.jupiter.version>
     <junit.platform.version>1.10.5</junit.platform.version>
     <lombok.version>1.18.46</lombok.version>
+    <checkstyle.version>12.3.1</checkstyle.version>
+    <spotbugs.version>4.9.8</spotbugs.version>
+    <spotbugs.maven.plugin.version>4.9.8.1</spotbugs.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -52,7 +55,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.9.8</version> <!-- Use the latest version -->
+        <version>${spotbugs.version}</version> <!-- Use the latest version -->
         <scope>provided</scope>
       </dependency>
 
@@ -187,12 +190,12 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.9.8.1</version>
+          <version>${spotbugs.maven.plugin.version}</version>
           <dependencies>
             <dependency>
               <groupId>com.github.spotbugs</groupId>
               <artifactId>spotbugs</artifactId>
-              <version>4.9.8</version>
+              <version>${spotbugs.version}</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -252,7 +255,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>13.4.2</version>
+            <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
         <executions>
@@ -343,7 +346,7 @@
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.9.8</version>
+            <version>${spotbugs.version}</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/server/collector/src/main/java/org/bithon/server/collector/brpc/BrpcCollectorServer.java
+++ b/server/collector/src/main/java/org/bithon/server/collector/brpc/BrpcCollectorServer.java
@@ -84,7 +84,7 @@ public class BrpcCollectorServer {
          */
         private final Map<String, Object> services = new HashMap<>();
         private BrpcServer brpcServer;
-        private int port;
+        private volatile int port;
 
         public void start(Integer port) {
             for (Object implementation : services.values()) {

--- a/server/datasource/common/src/main/java/org/bithon/server/datasource/query/DataRow.java
+++ b/server/datasource/common/src/main/java/org/bithon/server/datasource/query/DataRow.java
@@ -35,9 +35,10 @@ public class DataRow {
 
     /**
      * Either:
-     * 1. a Map<String, Object> for {@link DataRowType#PROGRESS} type
-     * 2. List<ColumnMetadata> for {@link DataRowType#META} type
-     * 3. Map<String, Object>/Object[] for {@link DataRowType#DATA} type determined by the given {@link ResultFormat}
+     * 1. a {@code Map<String, Object>} for {@link DataRowType#PROGRESS} type
+     * 2. {@code List<ColumnMetadata>} for {@link DataRowType#META} type
+     * 3. {@code Map<String, Object>}/{@code Object[]} for {@link DataRowType#DATA} type determined by the given
+     * {@link ResultFormat}
      */
     private final Object payload;
 

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/common/pipeline/AbstractPipeline.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/common/pipeline/AbstractPipeline.java
@@ -57,7 +57,7 @@ public abstract class AbstractPipeline<RECEIVER extends IReceiver, EXPORTER exte
     protected final List<RECEIVER> receivers;
     private List<ITransformer> processors;
     protected final List<EXPORTER> exporters = new ArrayList<>();
-    private boolean isRunning = false;
+    private volatile boolean isRunning = false;
     private final String pipelineConfigPrefix;
 
     protected AbstractPipeline(Class<RECEIVER> receiverClass,

--- a/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/MetricMessageHandlers.java
+++ b/server/pipeline/src/main/java/org/bithon/server/pipeline/metrics/exporter/MetricMessageHandlers.java
@@ -34,7 +34,7 @@ public class MetricMessageHandlers {
 
     private final Map<String, MetricMessageHandler> handlers = new ConcurrentHashMap<>();
 
-    public MetricMessageHandlers() {
+    private MetricMessageHandlers() {
     }
 
     public void add(MetricMessageHandler handler) {


### PR DESCRIPTION
## Summary
- Upgrade the Checkstyle dependency used by `maven-checkstyle-plugin` from 9.3 to 12.3.1.
- Fix the Javadoc/import issues surfaced by newer Checkstyle's stricter parsing.
- Upgrade the root EasyMock test dependency from 5.2.0 to 5.6.0.
- Align SpotBugs tool versions through properties: SpotBugs runtime/annotations 4.9.8 and SpotBugs Maven plugin 4.9.8.1. The standalone `agent-sdk` POM uses the same property names and values because it does not inherit the root POM.
- Fix the SpotBugs 4.9.8 CI findings with minimal source changes: volatile cross-thread state, private singleton constructors, removal of a stale suppression, stateful `PeriodicTask` wakeups, and narrow filter entries for intentional singleton/test-only cases.

## Breaking-change risk
- Checkstyle 13.x requires Java 21 at runtime, but Agent Build CI runs under Java 17. This PR uses Checkstyle 12.3.1, the newest 12.x line available locally and compatible with Java 17+.
- Newer Checkstyle versions have stricter Javadoc parsing. The PR fixes the current repo violations found in the `component`, `agent`, and `server` profiles.
- EasyMock remains on the 5.x line and is only managed as a test dependency. No test-code migration was found.
- SpotBugs remains on the 4.x line. The newer analyzer reports additional concurrency/singleton patterns; the PR fixes the actionable cases and filters only the intentional `Functions` and test-only `SentinelRuleManager` constructor cases.
- SpotBugs still prints some missing auxiliary class warnings for optional/transitive annotation or generated-query classes during JDK21 analysis. The exact CI command passes with zero SpotBugs bug instances after the source fixes, so this PR does not add dependencies solely to silence those warnings.
- No Checkstyle config migration was required for the existing Maven plugin setup.

## Validation
- `git diff --check`
- `mvn -ntp -B -DskipTests -Pcomponent,agent,server validate`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.0.4.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/jdk-17.0.4.jdk/Contents/Home/bin:$PATH mvn -ntp -T 1C -P-server com.github.spotbugs:spotbugs-maven-plugin:check dependency:analyze-only`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home/bin:$PATH mvn --ntp -T 1C -P-agent animal-sniffer:check checkstyle:checkstyle com.github.spotbugs:spotbugs-maven-plugin:check`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.0.4.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/jdk-17.0.4.jdk/Contents/Home/bin:$PATH mvn clean install -T 1C -ntp --activate-profiles shaded -Dmaven.javadoc.skip=true -DskipTests`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.0.4.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/jdk-17.0.4.jdk/Contents/Home/bin:$PATH mvn clean install -T 1C -ntp --activate-profiles agent,component -Dmaven.javadoc.skip=true -DskipTests`
- `mvn -ntp -B -DskipTests -Pcomponent,agent,server -pl :component-commons,:agent-observability,:agent-controller,:agent-plugin-httpclient-okhttp-3.2,:agent-plugin-httpclient-jdk,:datasource-common -am package`
- `mvn -ntp -B -DskipTests -Pcomponent,agent,server -pl :agent-sdk,:server-alerting-manager -am package`
- `mvn -ntp -B -DskipTests -pl :agent-sdk spotbugs:check`

Tests were skipped in the Maven package/validate runs via `-DskipTests`.
