### PR TITLE
[codex] Add SQLite JDBC agent plugin

### DIFF
--- a/agent/agent-distribution/pom.xml
+++ b/agent/agent-distribution/pom.xml
@@ -259,6 +259,11 @@
     </dependency>
     <dependency>
       <groupId>org.bithon.agent</groupId>
+      <artifactId>agent-plugin-jdbc-sqlite</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bithon.agent</groupId>
       <artifactId>agent-plugin-jersey</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/agent/agent-plugins-test/pom.xml
+++ b/agent/agent-plugins-test/pom.xml
@@ -248,6 +248,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bithon.agent</groupId>
+      <artifactId>agent-plugin-jdbc-sqlite</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Kafka -->
     <dependency>

--- a/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/jdbc/sqlite/SQLiteJdbcPluginTest.java
+++ b/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/jdbc/sqlite/SQLiteJdbcPluginTest.java
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugins.test.jdbc.sqlite;
+
+import org.bithon.agent.instrumentation.aop.interceptor.plugin.IPlugin;
+import org.bithon.agent.plugin.jdbc.sqlite.SQLitePlugin;
+import org.bithon.agent.plugins.test.AbstractPluginInterceptorTest;
+import org.bithon.agent.plugins.test.MavenArtifact;
+import org.bithon.agent.plugins.test.MavenArtifactClassLoader;
+
+/**
+ * Test case for SQLite JDBC plugin.
+ *
+ * @author frankchen
+ */
+public class SQLiteJdbcPluginTest extends AbstractPluginInterceptorTest {
+    @Override
+    protected IPlugin[] getPlugins() {
+        return new IPlugin[]{new SQLitePlugin()};
+    }
+
+    @Override
+    protected ClassLoader getCustomClassLoader() {
+        return MavenArtifactClassLoader.create(
+            MavenArtifact.of("org.xerial",
+                             "sqlite-jdbc",
+                             "3.50.3.0")
+        );
+    }
+}

--- a/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/jdbc/sqlite/SQLiteJdbcPluginTest.java
+++ b/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/jdbc/sqlite/SQLiteJdbcPluginTest.java
@@ -16,11 +16,17 @@
 
 package org.bithon.agent.plugins.test.jdbc.sqlite;
 
+import org.bithon.agent.instrumentation.aop.interceptor.installer.InstallerRecorder;
 import org.bithon.agent.instrumentation.aop.interceptor.plugin.IPlugin;
 import org.bithon.agent.plugin.jdbc.sqlite.SQLitePlugin;
 import org.bithon.agent.plugins.test.AbstractPluginInterceptorTest;
 import org.bithon.agent.plugins.test.MavenArtifact;
 import org.bithon.agent.plugins.test.MavenArtifactClassLoader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Test case for SQLite JDBC plugin.
@@ -40,5 +46,38 @@ public class SQLiteJdbcPluginTest extends AbstractPluginInterceptorTest {
                              "sqlite-jdbc",
                              "3.50.3.0")
         );
+    }
+
+    @Test
+    @Override
+    public void testInterceptorInstallation() {
+        super.testInterceptorInstallation();
+
+        List<InstallerRecorder.InstrumentedMethod> instrumentedMethods = InstallerRecorder.INSTANCE.getInstrumentedMethods();
+        assertInstrumented(instrumentedMethods,
+                           "org.sqlite.jdbc3.JDBC3PreparedStatement",
+                           "executeLargeUpdate",
+                           "org.bithon.agent.plugin.jdbc.sqlite.JDBC3PreparedStatement$Execute");
+        assertInstrumented(instrumentedMethods,
+                           "org.sqlite.core.CorePreparedStatement",
+                           "executeBatch",
+                           "org.bithon.agent.plugin.jdbc.sqlite.CorePreparedStatement$ExecuteBatch");
+        assertInstrumented(instrumentedMethods,
+                           "org.sqlite.core.CorePreparedStatement",
+                           "executeLargeBatch",
+                           "org.bithon.agent.plugin.jdbc.sqlite.CorePreparedStatement$ExecuteBatch");
+    }
+
+    private static void assertInstrumented(List<InstallerRecorder.InstrumentedMethod> instrumentedMethods,
+                                           String type,
+                                           String method,
+                                           String interceptor) {
+        List<InstallerRecorder.InstrumentedMethod> matchingType = instrumentedMethods.stream()
+                                                                                     .filter((m) -> type.equals(m.getType()))
+                                                                                     .collect(Collectors.toList());
+        Assertions.assertTrue(matchingType.stream()
+                                          .anyMatch((m) -> method.equals(m.getMethodName())
+                                                           && interceptor.equals(m.getInterceptorName())),
+                              type + "#" + method + " should be instrumented by " + interceptor);
     }
 }

--- a/agent/agent-plugins/jdbc/sqlite/pom.xml
+++ b/agent/agent-plugins/jdbc/sqlite/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0">
+
+  <parent>
+    <groupId>org.bithon.agent</groupId>
+    <artifactId>agent-plugins</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>agent-plugin-jdbc-sqlite</artifactId>
+  <modelVersion>4.0.0</modelVersion>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.bithon.agent</groupId>
+      <artifactId>agent-plugin-jdbc-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.50.3.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+</project>

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/CorePreparedStatement$ExecuteBatch.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/CorePreparedStatement$ExecuteBatch.java
@@ -1,0 +1,40 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.jdbc.sqlite;
+
+import org.bithon.agent.instrumentation.aop.IBithonObject;
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.plugin.jdbc.common.AbstractStatement$ExecuteBatch;
+import org.bithon.agent.plugin.jdbc.common.StatementContext;
+
+/**
+ * {@link org.sqlite.core.CorePreparedStatement#executeBatch()}
+ * {@link org.sqlite.core.CorePreparedStatement#executeLargeBatch()}
+ *
+ * @author frankchen
+ */
+public class CorePreparedStatement$ExecuteBatch extends AbstractStatement$ExecuteBatch {
+
+    /**
+     * The executing statement is injected by {@link JDBC3PreparedStatement$Ctor}.
+     */
+    @Override
+    protected StatementContext getStatementContext(AopContext aopContext) {
+        IBithonObject preparedStatement = aopContext.getTargetAs();
+        return (StatementContext) preparedStatement.getInjectedObject();
+    }
+}

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3PreparedStatement$Ctor.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3PreparedStatement$Ctor.java
@@ -1,0 +1,39 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.jdbc.sqlite;
+
+import org.bithon.agent.instrumentation.aop.IBithonObject;
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
+import org.bithon.agent.plugin.jdbc.common.StatementContext;
+import org.sqlite.SQLiteConnection;
+
+/**
+ * {@link org.sqlite.jdbc3.JDBC3PreparedStatement#JDBC3PreparedStatement(SQLiteConnection, String)}
+ *
+ * @author frankchen
+ */
+public class JDBC3PreparedStatement$Ctor extends AfterInterceptor {
+    @Override
+    public void after(AopContext aopContext) {
+        String sql = aopContext.getArgAs(1);
+
+        // Inject context so that it can be accessed in statement interceptors.
+        IBithonObject preparedStatement = aopContext.getTargetAs();
+        preparedStatement.setInjectedObject(new StatementContext(sql));
+    }
+}

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3PreparedStatement$Execute.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3PreparedStatement$Execute.java
@@ -1,0 +1,41 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.jdbc.sqlite;
+
+import org.bithon.agent.instrumentation.aop.IBithonObject;
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.plugin.jdbc.common.AbstractStatement$Execute;
+import org.bithon.agent.plugin.jdbc.common.StatementContext;
+
+/**
+ * {@link org.sqlite.jdbc3.JDBC3PreparedStatement#execute()}
+ * {@link org.sqlite.jdbc3.JDBC3PreparedStatement#executeQuery()}
+ * {@link org.sqlite.jdbc3.JDBC3PreparedStatement#executeUpdate()}
+ *
+ * @author frankchen
+ */
+public class JDBC3PreparedStatement$Execute extends AbstractStatement$Execute {
+
+    /**
+     * The executing statement is injected by {@link JDBC3PreparedStatement$Ctor}.
+     */
+    @Override
+    protected StatementContext getStatementContext(AopContext aopContext) {
+        IBithonObject preparedStatement = aopContext.getTargetAs();
+        return (StatementContext) preparedStatement.getInjectedObject();
+    }
+}

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3Statement$Execute.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3Statement$Execute.java
@@ -1,0 +1,36 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.jdbc.sqlite;
+
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.plugin.jdbc.common.AbstractStatement$Execute;
+import org.bithon.agent.plugin.jdbc.common.StatementContext;
+
+/**
+ * {@link org.sqlite.jdbc3.JDBC3Statement#execute(String)}
+ * {@link org.sqlite.jdbc3.JDBC3Statement#executeQuery(String)}
+ * {@link org.sqlite.jdbc3.JDBC3Statement#executeUpdate(String)}
+ * {@link org.sqlite.jdbc3.JDBC3Statement#executeLargeUpdate(String)}
+ *
+ * @author frankchen
+ */
+public class JDBC3Statement$Execute extends AbstractStatement$Execute {
+    @Override
+    protected StatementContext getStatementContext(AopContext aopContext) {
+        return new StatementContext(aopContext.getArgAs(0));
+    }
+}

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3Statement$ExecuteBatch.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/JDBC3Statement$ExecuteBatch.java
@@ -1,0 +1,28 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.jdbc.sqlite;
+
+import org.bithon.agent.plugin.jdbc.common.AbstractStatement$ExecuteBatch;
+
+/**
+ * {@link org.sqlite.jdbc3.JDBC3Statement#executeBatch()}
+ * {@link org.sqlite.jdbc3.JDBC3Statement#executeLargeBatch()}
+ *
+ * @author frankchen
+ */
+public class JDBC3Statement$ExecuteBatch extends AbstractStatement$ExecuteBatch {
+}

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/SQLiteConnection$Ctor.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/SQLiteConnection$Ctor.java
@@ -1,0 +1,49 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.jdbc.sqlite;
+
+import org.bithon.agent.instrumentation.aop.IBithonObject;
+import org.bithon.agent.instrumentation.aop.context.AopContext;
+import org.bithon.agent.instrumentation.aop.interceptor.declaration.AfterInterceptor;
+import org.bithon.agent.plugin.jdbc.common.ConnectionContext;
+import org.sqlite.SQLiteConnection;
+
+/**
+ * {@link org.sqlite.SQLiteConnection#SQLiteConnection(String, String, java.util.Properties)}
+ *
+ * @author frankchen
+ */
+public class SQLiteConnection$Ctor extends AfterInterceptor {
+
+    /**
+     * Inject ConnectionContext on the connection object which will be used by statement interceptors.
+     */
+    @Override
+    public void after(AopContext aopContext) {
+        if (aopContext.hasException()) {
+            return;
+        }
+
+        SQLiteConnection connection = aopContext.getTargetAs();
+        ((IBithonObject) connection).setInjectedObject(
+            new ConnectionContext(
+                connection.getUrl(),
+                "",
+                "sqlite")
+        );
+    }
+}

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/SQLitePlugin.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/SQLitePlugin.java
@@ -53,10 +53,19 @@ public class SQLitePlugin implements IPlugin {
                 .andArgs(1, "java.lang.String")
                 .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.JDBC3PreparedStatement$Ctor")
 
-                .onMethod(Matchers.names("execute", "executeQuery", "executeUpdate"))
+                .onMethod(Matchers.names("execute", "executeQuery", "executeUpdate", "executeLargeUpdate"))
                 .andVisibility(Visibility.PUBLIC)
                 .andNoArgs()
                 .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.JDBC3PreparedStatement$Execute")
+
+                .build(),
+
+            // PreparedStatement batch
+            forClass("org.sqlite.core.CorePreparedStatement")
+                .onMethod(Matchers.names("executeBatch", "executeLargeBatch"))
+                .andVisibility(Visibility.PUBLIC)
+                .andNoArgs()
+                .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.CorePreparedStatement$ExecuteBatch")
 
                 .build(),
 

--- a/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/SQLitePlugin.java
+++ b/agent/agent-plugins/jdbc/sqlite/src/main/java/org/bithon/agent/plugin/jdbc/sqlite/SQLitePlugin.java
@@ -1,0 +1,78 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.jdbc.sqlite;
+
+import org.bithon.agent.instrumentation.aop.interceptor.descriptor.InterceptorDescriptor;
+import org.bithon.agent.instrumentation.aop.interceptor.matcher.Matchers;
+import org.bithon.agent.instrumentation.aop.interceptor.plugin.IPlugin;
+import org.bithon.shaded.net.bytebuddy.description.modifier.Visibility;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.bithon.agent.instrumentation.aop.interceptor.descriptor.InterceptorDescriptorBuilder.forClass;
+
+/**
+ * @author frankchen
+ */
+public class SQLitePlugin implements IPlugin {
+
+    @Override
+    public List<InterceptorDescriptor> getInterceptors() {
+
+        return Arrays.asList(
+
+            // SQLiteConnection
+            forClass("org.sqlite.SQLiteConnection")
+                .onConstructor()
+                .andArgsSize(3)
+                .andArgs(0, "java.lang.String")
+                .andArgs(1, "java.lang.String")
+                .andArgs(2, "java.util.Properties")
+                .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.SQLiteConnection$Ctor")
+                .build(),
+
+            // PreparedStatement
+            forClass("org.sqlite.jdbc3.JDBC3PreparedStatement")
+                .onConstructor()
+                .andArgs(0, "org.sqlite.SQLiteConnection")
+                .andArgs(1, "java.lang.String")
+                .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.JDBC3PreparedStatement$Ctor")
+
+                .onMethod(Matchers.names("execute", "executeQuery", "executeUpdate"))
+                .andVisibility(Visibility.PUBLIC)
+                .andNoArgs()
+                .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.JDBC3PreparedStatement$Execute")
+
+                .build(),
+
+            // Statement
+            forClass("org.sqlite.jdbc3.JDBC3Statement")
+                .onMethod(Matchers.names("execute", "executeQuery", "executeUpdate", "executeLargeUpdate"))
+                .andVisibility(Visibility.PUBLIC)
+                .andArgs(0, "java.lang.String")
+                .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.JDBC3Statement$Execute")
+
+                .onMethod(Matchers.names("executeBatch", "executeLargeBatch"))
+                .andVisibility(Visibility.PUBLIC)
+                .andNoArgs()
+                .interceptedBy("org.bithon.agent.plugin.jdbc.sqlite.JDBC3Statement$ExecuteBatch")
+
+                .build()
+        );
+    }
+}

--- a/agent/agent-plugins/pom.xml
+++ b/agent/agent-plugins/pom.xml
@@ -40,6 +40,7 @@
     <module>jdbc/common</module>
     <module>jdbc/h2</module>
     <module>jdbc/postgresql</module>
+    <module>jdbc/sqlite</module>
     <module>jdbc/mysql5</module>
     <module>jdbc/mysql6</module>
     <module>jdbc/mysql8</module>


### PR DESCRIPTION
## Summary

Adds a new `agent-plugin-jdbc-sqlite` module for the Xerial SQLite JDBC driver. The plugin follows the existing JDBC module pattern by instrumenting SQLite connection creation, statement execution, prepared statement execution, and batch execution through the shared JDBC common interceptors.

The module is wired into the agent plugin reactor, agent distribution, and agent plugin interceptor test suite.

## Validation

- `mvn -pl agent/agent-plugins/jdbc/sqlite -am -DskipTests package`
- `mvn -pl :agent-plugins-test -am -Dtest=SQLiteJdbcPluginTest -Dsurefire.failIfNoSpecifiedTests=false package`
- `git diff --check`
