### PR TITLE
[codex] Fix Druid SqlResource doPost interception

### DIFF
--- a/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/apache/druid/DruidPluginInterceptorInterceptorTest.java
+++ b/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/apache/druid/DruidPluginInterceptorInterceptorTest.java
@@ -16,11 +16,21 @@
 
 package org.bithon.agent.plugins.test.apache.druid;
 
+import org.bithon.agent.instrumentation.aop.interceptor.descriptor.InterceptorDescriptor;
+import org.bithon.agent.instrumentation.aop.interceptor.descriptor.MethodPointCutDescriptor;
 import org.bithon.agent.instrumentation.aop.interceptor.plugin.IPlugin;
 import org.bithon.agent.plugin.apache.druid.ApacheDruidPlugin;
 import org.bithon.agent.plugins.test.AbstractPluginInterceptorTest;
 import org.bithon.agent.plugins.test.MavenArtifact;
 import org.bithon.agent.plugins.test.MavenArtifactClassLoader;
+import org.bithon.shaded.net.bytebuddy.description.method.MethodDescription;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -34,20 +44,69 @@ public class DruidPluginInterceptorInterceptorTest extends AbstractPluginInterce
 
     @Override
     protected ClassLoader getCustomClassLoader() {
+        return createDruidClassLoader("24.0.0");
+    }
+
+    @Test
+    public void sqlResourceDoPostPointcutDoesNotMatchJerseyEntrypoint() throws Exception {
+        Class<?> sqlResource = Class.forName("org.apache.druid.sql.http.SqlResource",
+                                             false,
+                                             createDruid34ClassLoader());
+
+        MethodPointCutDescriptor doPostPointcut = getSqlResourceDoPostPointcut();
+        List<Method> matchedMethods = Arrays.stream(sqlResource.getDeclaredMethods())
+                                            .filter((method) -> "doPost".equals(method.getName()))
+                                            .filter((method) -> doPostPointcut.getMethodMatcher()
+                                                                              .matches(new MethodDescription.ForLoadedMethod(method)))
+                                            .collect(Collectors.toList());
+
+        Assertions.assertFalse(matchedMethods.isEmpty());
+        Assertions.assertTrue(matchedMethods.stream().allMatch(this::isSqlQueryDoPost),
+                              matchedMethods.stream()
+                                            .map(this::toSignature)
+                                            .collect(Collectors.joining("\n")));
+    }
+
+    private MethodPointCutDescriptor getSqlResourceDoPostPointcut() {
+        for (InterceptorDescriptor descriptor : new ApacheDruidPlugin().getInterceptors()) {
+            if ("org.apache.druid.sql.http.SqlResource".equals(descriptor.getTargetClass())) {
+                return descriptor.getMethodPointCutDescriptors()[0];
+            }
+        }
+
+        throw new AssertionError("SqlResource#doPost pointcut not found");
+    }
+
+    private boolean isSqlQueryDoPost(Method method) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        return parameterTypes.length == 2
+               && "org.apache.druid.sql.http.SqlQuery".equals(parameterTypes[0].getName())
+               && "javax.servlet.http.HttpServletRequest".equals(parameterTypes[1].getName());
+    }
+
+    private String toSignature(Method method) {
+        return method.getName() + "("
+               + Arrays.stream(method.getParameterTypes())
+                       .map(Class::getName)
+                       .collect(Collectors.joining(", "))
+               + ")";
+    }
+
+    private ClassLoader createDruidClassLoader(String druidVersion) {
         return MavenArtifactClassLoader.create(
 
             MavenArtifact.of("org.apache.druid",
                              "druid-core",
-                             "24.0.0"),
+                             druidVersion),
             MavenArtifact.of("org.apache.druid",
                              "druid-processing",
-                             "24.0.0"),
+                             druidVersion),
             MavenArtifact.of("org.apache.druid",
                              "druid-sql",
-                             "24.0.0"),
+                             druidVersion),
             MavenArtifact.of("org.apache.druid",
                              "druid-server",
-                             "24.0.0"),
+                             druidVersion),
 
             MavenArtifact.of("io.netty",
                              "netty",
@@ -63,7 +122,50 @@ public class DruidPluginInterceptorInterceptorTest extends AbstractPluginInterce
                              "1.1.1"),
             MavenArtifact.of("javax.servlet",
                              "javax.servlet-api",
-                             "3.1.0")
+                             "3.1.0"),
+            MavenArtifact.of("com.sun.jersey",
+                             "jersey-core",
+                             "1.19.4"),
+            MavenArtifact.of("com.sun.jersey",
+                             "jersey-server",
+                             "1.19.4")
+        );
+    }
+
+    private ClassLoader createDruid34ClassLoader() {
+        return MavenArtifactClassLoader.create(
+
+            MavenArtifact.of("org.apache.druid",
+                             "druid-processing",
+                             "34.0.0"),
+            MavenArtifact.of("org.apache.druid",
+                             "druid-sql",
+                             "34.0.0"),
+            MavenArtifact.of("org.apache.druid",
+                             "druid-server",
+                             "34.0.0"),
+
+            MavenArtifact.of("io.netty",
+                             "netty",
+                             "3.10.6.Final"),
+            MavenArtifact.of("com.fasterxml.jackson.core",
+                             "jackson-databind",
+                             "2.10.5.1"),
+            MavenArtifact.of("com.fasterxml.jackson.core",
+                             "jackson-core",
+                             "2.10.5"),
+            MavenArtifact.of("javax.ws.rs",
+                             "jsr311-api",
+                             "1.1.1"),
+            MavenArtifact.of("javax.servlet",
+                             "javax.servlet-api",
+                             "3.1.0"),
+            MavenArtifact.of("com.sun.jersey",
+                             "jersey-core",
+                             "1.19.4"),
+            MavenArtifact.of("com.sun.jersey",
+                             "jersey-server",
+                             "1.19.4")
         );
     }
 }

--- a/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/apache/druid/DruidPluginInterceptorInterceptorTest.java
+++ b/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/apache/druid/DruidPluginInterceptorInterceptorTest.java
@@ -25,6 +25,7 @@ import org.bithon.agent.plugins.test.MavenArtifact;
 import org.bithon.agent.plugins.test.MavenArtifactClassLoader;
 import org.bithon.shaded.net.bytebuddy.description.method.MethodDescription;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -49,9 +50,7 @@ public class DruidPluginInterceptorInterceptorTest extends AbstractPluginInterce
 
     @Test
     public void sqlResourceDoPostPointcutDoesNotMatchJerseyEntrypoint() throws Exception {
-        Class<?> sqlResource = Class.forName("org.apache.druid.sql.http.SqlResource",
-                                             false,
-                                             createDruid34ClassLoader());
+        Class<?> sqlResource = loadDruid34SqlResourceOrSkip();
 
         MethodPointCutDescriptor doPostPointcut = getSqlResourceDoPostPointcut();
         List<Method> matchedMethods = Arrays.stream(sqlResource.getDeclaredMethods())
@@ -65,6 +64,17 @@ public class DruidPluginInterceptorInterceptorTest extends AbstractPluginInterce
                               matchedMethods.stream()
                                             .map(this::toSignature)
                                             .collect(Collectors.joining("\n")));
+    }
+
+    private Class<?> loadDruid34SqlResourceOrSkip() throws ClassNotFoundException {
+        try {
+            return Class.forName("org.apache.druid.sql.http.SqlResource",
+                                 false,
+                                 createDruid34ClassLoader());
+        } catch (UnsupportedClassVersionError ignored) {
+            Assumptions.assumeTrue(false, "Druid 34 requires Java 11+ bytecode support");
+            throw ignored;
+        }
     }
 
     private MethodPointCutDescriptor getSqlResourceDoPostPointcut() {

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/ApacheDruidPlugin.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/ApacheDruidPlugin.java
@@ -36,6 +36,7 @@ public class ApacheDruidPlugin implements IPlugin {
         return Arrays.asList(
             forClass("org.apache.druid.sql.http.SqlResource")
                 .onMethod("doPost")
+                .andArgs(0, "org.apache.druid.sql.http.SqlQuery")
                 .interceptedBy("org.bithon.agent.plugin.apache.druid.interceptor.SqlResource$DoPost")
                 .build(),
 

--- a/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/SqlResource$DoPost.java
+++ b/agent/agent-plugins/apache-druid/src/main/java/org/bithon/agent/plugin/apache/druid/interceptor/SqlResource$DoPost.java
@@ -47,7 +47,12 @@ public class SqlResource$DoPost extends BeforeInterceptor {
             return;
         }
 
-        SqlQuery sqlQuery = aopContext.getArgAs(0);
+        Object[] args = aopContext.getArgs();
+        if (args.length == 0 || !(args[0] instanceof SqlQuery)) {
+            return;
+        }
+
+        SqlQuery sqlQuery = (SqlQuery) args[0];
         Object sqlQueryId = sqlQuery.getContext().get("sqlQueryId");
         if (sqlQueryId == null) {
             try {
@@ -62,7 +67,7 @@ public class SqlResource$DoPost extends BeforeInterceptor {
                 sqlQuery = ObjectMapperInstance.fromTree(newQuery, SqlQuery.class);
 
                 // Update the input argument
-                aopContext.getArgs()[0] = sqlQuery;
+                args[0] = sqlQuery;
             } catch (IOException ignored) {
                 // Ignore the exception
                 sqlQueryId = "";


### PR DESCRIPTION
## Summary
- Narrow `SqlResource#doPost` interception so it only handles calls whose first argument is `SqlQuery`.
- Add a defensive runtime guard before mutating the SQL query argument.
- Add regression coverage for newer Druid `SqlResource#doPost` overloads so the Jersey entrypoint is not matched.

## Root Cause
Newer Druid versions expose multiple `SqlResource#doPost` overloads. The existing pointcut matched by method name only, so it could intercept the Jersey entrypoint where argument 0 is an HTTP request proxy instead of `SqlQuery`, causing a `ClassCastException`.

## Validation
- `mvn -pl agent/agent-plugins/apache-druid -am install -DskipTests`
- `mvn -pl agent/agent-plugins/jdbc/sqlite -am install -DskipTests` (needed because current `master` adds this `agent-plugins-test` dependency)
- `mvn -pl agent/agent-plugins-test -Dtest=org.bithon.agent.plugins.test.apache.druid.DruidPluginInterceptorInterceptorTest test`