### PR TITLE
Avoid BRPC reconnects during exporter shutdown

### DIFF
--- a/agent/agent-exporter-brpc/pom.xml
+++ b/agent/agent-exporter-brpc/pom.xml
@@ -21,6 +21,11 @@
       <groupId>org.bithon.agent</groupId>
       <artifactId>agent-observability</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/agent/agent-exporter-brpc/pom.xml
+++ b/agent/agent-exporter-brpc/pom.xml
@@ -26,6 +26,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcEventMessageExporter.java
+++ b/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcEventMessageExporter.java
@@ -48,7 +48,7 @@ public class BrpcEventMessageExporter implements IMessageExporter {
 
     private final BrpcClient brpcClient;
     private final ExporterConfig exporterConfig;
-    private IEventCollector eventCollector;
+    private volatile IEventCollector eventCollector;
     private BrpcMessageHeader header;
     private volatile boolean shuttingDown;
 
@@ -86,16 +86,9 @@ public class BrpcEventMessageExporter implements IMessageExporter {
 
     @Override
     public void export(Object message) {
-        if (this.eventCollector == null) {
-            if (shuttingDown) {
-                return;
-            }
-            try {
-                this.eventCollector = brpcClient.getRemoteService(IEventCollector.class);
-            } catch (ServiceInvocationException e) {
-                LOG.warn("Unable to get remote service: {}", e.getMessage());
-                return;
-            }
+        IEventCollector eventCollector = getEventCollector();
+        if (eventCollector == null) {
+            return;
         }
 
         if (shuttingDown && !brpcClient.isActive()) {
@@ -128,7 +121,31 @@ public class BrpcEventMessageExporter implements IMessageExporter {
 
     @Override
     public void prepareShutdown() {
-        this.shuttingDown = true;
+        synchronized (this) {
+            this.shuttingDown = true;
+        }
+    }
+
+    private IEventCollector getEventCollector() {
+        IEventCollector eventCollector = this.eventCollector;
+        if (eventCollector != null) {
+            return eventCollector;
+        }
+
+        synchronized (this) {
+            if (this.shuttingDown) {
+                return null;
+            }
+            if (this.eventCollector == null) {
+                try {
+                    this.eventCollector = brpcClient.getRemoteService(IEventCollector.class);
+                } catch (ServiceInvocationException e) {
+                    LOG.warn("Unable to get remote service: {}", e.getMessage());
+                    return null;
+                }
+            }
+            return this.eventCollector;
+        }
     }
 
     @Override

--- a/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcEventMessageExporter.java
+++ b/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcEventMessageExporter.java
@@ -50,6 +50,7 @@ public class BrpcEventMessageExporter implements IMessageExporter {
     private final ExporterConfig exporterConfig;
     private IEventCollector eventCollector;
     private BrpcMessageHeader header;
+    private volatile boolean shuttingDown;
 
     public BrpcEventMessageExporter(ExporterConfig exporterConfig) {
         List<EndPoint> endpoints = Stream.of(exporterConfig.getServers().split(",")).map(hostAndPort -> {
@@ -86,6 +87,9 @@ public class BrpcEventMessageExporter implements IMessageExporter {
     @Override
     public void export(Object message) {
         if (this.eventCollector == null) {
+            if (shuttingDown) {
+                return;
+            }
             try {
                 this.eventCollector = brpcClient.getRemoteService(IEventCollector.class);
             } catch (ServiceInvocationException e) {
@@ -94,8 +98,12 @@ public class BrpcEventMessageExporter implements IMessageExporter {
             }
         }
 
+        if (shuttingDown && !brpcClient.isActive()) {
+            return;
+        }
+
         IBrpcChannel channel = ((IServiceController) eventCollector).getChannel();
-        if (channel.getConnectionLifeTime() > exporterConfig.getClient().getConnectionLifeTime()) {
+        if (!shuttingDown && channel.getConnectionLifeTime() > exporterConfig.getClient().getConnectionLifeTime()) {
             LOG.info("Disconnect for event-channel load balancing...");
             try {
                 channel.disconnect();
@@ -116,6 +124,11 @@ public class BrpcEventMessageExporter implements IMessageExporter {
             //suppress client exception
             LOG.warn("Failed to send event: {}", e.getMessage());
         }
+    }
+
+    @Override
+    public void prepareShutdown() {
+        this.shuttingDown = true;
     }
 
     @Override

--- a/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcMetricMessageExporter.java
+++ b/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcMetricMessageExporter.java
@@ -58,6 +58,7 @@ public class BrpcMetricMessageExporter implements IMessageExporter {
     private final BrpcClient brpcClient;
     private IMetricCollector metricCollector;
     private BrpcMessageHeader header;
+    private volatile boolean shuttingDown;
 
     public BrpcMetricMessageExporter(ExporterConfig exporterConfig) {
         Method[] methods = IMetricCollector.class.getDeclaredMethods();
@@ -122,12 +123,19 @@ public class BrpcMetricMessageExporter implements IMessageExporter {
     @Override
     public void export(Object message) {
         if (this.metricCollector == null) {
+            if (shuttingDown) {
+                return;
+            }
             try {
                 this.metricCollector = brpcClient.getRemoteService(IMetricCollector.class);
             } catch (ServiceInvocationException e) {
                 LOG.warn("Unable to get remote IMetricCollector service: {}", e.getMessage());
                 return;
             }
+        }
+
+        if (shuttingDown && !brpcClient.isActive()) {
+            return;
         }
 
         final String messageClass;
@@ -142,7 +150,7 @@ public class BrpcMetricMessageExporter implements IMessageExporter {
         }
 
         IBrpcChannel channel = ((IServiceController) metricCollector).getChannel();
-        if (channel.getConnectionLifeTime() > exporterConfig.getClient().getConnectionLifeTime()) {
+        if (!shuttingDown && channel.getConnectionLifeTime() > exporterConfig.getClient().getConnectionLifeTime()) {
             LOG.info("Disconnect metric-channel for client-side load balancing...");
             try {
                 channel.disconnect();
@@ -173,6 +181,11 @@ public class BrpcMetricMessageExporter implements IMessageExporter {
                 throw new RuntimeException(e.getTargetException());
             }
         }
+    }
+
+    @Override
+    public void prepareShutdown() {
+        this.shuttingDown = true;
     }
 
     @Override

--- a/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcMetricMessageExporter.java
+++ b/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcMetricMessageExporter.java
@@ -56,7 +56,7 @@ public class BrpcMetricMessageExporter implements IMessageExporter {
     private final ExporterConfig exporterConfig;
 
     private final BrpcClient brpcClient;
-    private IMetricCollector metricCollector;
+    private volatile IMetricCollector metricCollector;
     private BrpcMessageHeader header;
     private volatile boolean shuttingDown;
 
@@ -122,16 +122,9 @@ public class BrpcMetricMessageExporter implements IMessageExporter {
 
     @Override
     public void export(Object message) {
-        if (this.metricCollector == null) {
-            if (shuttingDown) {
-                return;
-            }
-            try {
-                this.metricCollector = brpcClient.getRemoteService(IMetricCollector.class);
-            } catch (ServiceInvocationException e) {
-                LOG.warn("Unable to get remote IMetricCollector service: {}", e.getMessage());
-                return;
-            }
+        IMetricCollector metricCollector = getMetricCollector();
+        if (metricCollector == null) {
+            return;
         }
 
         if (shuttingDown && !brpcClient.isActive()) {
@@ -185,7 +178,31 @@ public class BrpcMetricMessageExporter implements IMessageExporter {
 
     @Override
     public void prepareShutdown() {
-        this.shuttingDown = true;
+        synchronized (this) {
+            this.shuttingDown = true;
+        }
+    }
+
+    private IMetricCollector getMetricCollector() {
+        IMetricCollector metricCollector = this.metricCollector;
+        if (metricCollector != null) {
+            return metricCollector;
+        }
+
+        synchronized (this) {
+            if (this.shuttingDown) {
+                return null;
+            }
+            if (this.metricCollector == null) {
+                try {
+                    this.metricCollector = brpcClient.getRemoteService(IMetricCollector.class);
+                } catch (ServiceInvocationException e) {
+                    LOG.warn("Unable to get remote IMetricCollector service: {}", e.getMessage());
+                    return null;
+                }
+            }
+            return this.metricCollector;
+        }
     }
 
     @Override

--- a/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcTraceMessageExporter.java
+++ b/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcTraceMessageExporter.java
@@ -50,6 +50,7 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
     private final BrpcClient brpcClient;
     private ITraceCollector traceCollector;
     private BrpcMessageHeader header;
+    private volatile boolean shuttingDown;
 
     public BrpcTraceMessageExporter(ExporterConfig exporterConfig) {
 
@@ -87,6 +88,9 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
     @Override
     public void export(Object message) {
         if (this.traceCollector == null) {
+            if (shuttingDown) {
+                return;
+            }
             try {
                 this.traceCollector = this.brpcClient.getRemoteService(ITraceCollector.class);
             } catch (ServiceInvocationException e) {
@@ -102,8 +106,12 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
             return;
         }
 
+        if (shuttingDown && !brpcClient.isActive()) {
+            return;
+        }
+
         IBrpcChannel channel = ((IServiceController) traceCollector).getChannel();
-        if (channel.getConnectionLifeTime() > exporterConfig.getClient().getConnectionLifeTime()) {
+        if (!shuttingDown && channel.getConnectionLifeTime() > exporterConfig.getClient().getConnectionLifeTime()) {
             LOG.info("Disconnect trace-channel for client-side load balancing...");
             try {
                 channel.disconnect();
@@ -125,6 +133,11 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
             //suppress client exception
             LOG.warn("Failed to send tracing: {}", e.getMessage());
         }
+    }
+
+    @Override
+    public void prepareShutdown() {
+        this.shuttingDown = true;
     }
 
     @Override

--- a/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcTraceMessageExporter.java
+++ b/agent/agent-exporter-brpc/src/main/java/org/bithon/agent/exporter/brpc/BrpcTraceMessageExporter.java
@@ -48,7 +48,7 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
 
     private final ExporterConfig exporterConfig;
     private final BrpcClient brpcClient;
-    private ITraceCollector traceCollector;
+    private volatile ITraceCollector traceCollector;
     private BrpcMessageHeader header;
     private volatile boolean shuttingDown;
 
@@ -87,16 +87,9 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
 
     @Override
     public void export(Object message) {
-        if (this.traceCollector == null) {
-            if (shuttingDown) {
-                return;
-            }
-            try {
-                this.traceCollector = this.brpcClient.getRemoteService(ITraceCollector.class);
-            } catch (ServiceInvocationException e) {
-                LOG.warn("Unable to get remote ITraceCollector service: {}", e.getMessage());
-                return;
-            }
+        ITraceCollector traceCollector = getTraceCollector();
+        if (traceCollector == null) {
+            return;
         }
 
         if (!(message instanceof List)) {
@@ -127,8 +120,8 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
 
         try {
             //noinspection unchecked
-            this.traceCollector.sendTrace(this.header,
-                                          (List<BrpcTraceSpanMessage>) message);
+            traceCollector.sendTrace(this.header,
+                                     (List<BrpcTraceSpanMessage>) message);
         } catch (CallerSideException e) {
             //suppress client exception
             LOG.warn("Failed to send tracing: {}", e.getMessage());
@@ -137,7 +130,31 @@ public class BrpcTraceMessageExporter implements IMessageExporter {
 
     @Override
     public void prepareShutdown() {
-        this.shuttingDown = true;
+        synchronized (this) {
+            this.shuttingDown = true;
+        }
+    }
+
+    private ITraceCollector getTraceCollector() {
+        ITraceCollector traceCollector = this.traceCollector;
+        if (traceCollector != null) {
+            return traceCollector;
+        }
+
+        synchronized (this) {
+            if (this.shuttingDown) {
+                return null;
+            }
+            if (this.traceCollector == null) {
+                try {
+                    this.traceCollector = this.brpcClient.getRemoteService(ITraceCollector.class);
+                } catch (ServiceInvocationException e) {
+                    LOG.warn("Unable to get remote ITraceCollector service: {}", e.getMessage());
+                    return null;
+                }
+            }
+            return this.traceCollector;
+        }
     }
 
     @Override

--- a/agent/agent-exporter-brpc/src/test/java/org/bithon/agent/exporter/brpc/BrpcMetricMessageExporterTest.java
+++ b/agent/agent-exporter-brpc/src/test/java/org/bithon/agent/exporter/brpc/BrpcMetricMessageExporterTest.java
@@ -1,0 +1,64 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.exporter.brpc;
+
+import org.bithon.agent.config.RpcClientConfig;
+import org.bithon.agent.configuration.ConfigurationManager;
+import org.bithon.agent.observability.exporter.config.ExporterConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class BrpcMetricMessageExporterTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    public void testExportDoesNotCreateConnectionDuringShutdown() throws Exception {
+        Path agentConfig = tempDir.resolve("agent.yml");
+        Files.write(agentConfig, "application:\n  name: test\n  env: local\n".getBytes(StandardCharsets.UTF_8));
+        ConfigurationManager.createForTesting(agentConfig.toFile());
+
+        BrpcMetricMessageExporter exporter = new BrpcMetricMessageExporter(createExporterConfig());
+        try {
+            exporter.prepareShutdown();
+            exporter.export(new Object());
+
+            Field metricCollector = BrpcMetricMessageExporter.class.getDeclaredField("metricCollector");
+            metricCollector.setAccessible(true);
+            Assertions.assertNull(metricCollector.get(exporter));
+        } finally {
+            exporter.close();
+        }
+    }
+
+    private static ExporterConfig createExporterConfig() {
+        RpcClientConfig clientConfig = new RpcClientConfig();
+        clientConfig.setConnectionTimeout(60_000);
+
+        ExporterConfig exporterConfig = new ExporterConfig();
+        exporterConfig.setClient(clientConfig);
+        exporterConfig.setServers("127.0.0.1:1");
+        return exporterConfig;
+    }
+}

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/exporter/Exporter.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/exporter/Exporter.java
@@ -116,6 +116,8 @@ public class Exporter {
 
     public void shutdown() {
         LOG.info("Shutting down exporter task [{}]...", exporterName);
+        messageExporter.prepareShutdown();
+
         if (task != null) {
             task.stop();
         }

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/exporter/Exporter.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/exporter/Exporter.java
@@ -116,7 +116,11 @@ public class Exporter {
 
     public void shutdown() {
         LOG.info("Shutting down exporter task [{}]...", exporterName);
-        messageExporter.prepareShutdown();
+        try {
+            messageExporter.prepareShutdown();
+        } catch (Exception e) {
+            LOG.warn("Failed to prepare message exporter [{}] for shutdown: {}", exporterName, e.getMessage(), e);
+        }
 
         if (task != null) {
             task.stop();

--- a/agent/agent-observability/src/main/java/org/bithon/agent/observability/exporter/IMessageExporter.java
+++ b/agent/agent-observability/src/main/java/org/bithon/agent/observability/exporter/IMessageExporter.java
@@ -26,4 +26,10 @@ public interface IMessageExporter extends AutoCloseable {
      * In the current design, this method is called in one thread only, so it's thread-safe.
      */
     void export(Object message);
+
+    /**
+     * Called before draining queued messages during JVM shutdown.
+     */
+    default void prepareShutdown() {
+    }
 }

--- a/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
+++ b/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
@@ -252,7 +252,9 @@ public class BrpcClient implements IBrpcChannel, Closeable {
             return true;
         }
 
+        closeOnLateConnect(connectFuture);
         connectFuture.cancel(true);
+        closeChannel(connectFuture);
         if (LOG.isDebugEnabled()) {
             LOG.debug("Timed out connecting to remote service at [{}:{}] in {} ms",
                       server.getHost(),
@@ -260,6 +262,21 @@ public class BrpcClient implements IBrpcChannel, Closeable {
                       connectionTimeoutMilliseconds);
         }
         return false;
+    }
+
+    private static void closeOnLateConnect(ChannelFuture connectFuture) {
+        connectFuture.addListener(future -> {
+            if (future.isSuccess()) {
+                closeChannel(connectFuture);
+            }
+        });
+    }
+
+    private static void closeChannel(ChannelFuture connectFuture) {
+        try {
+            connectFuture.channel().close();
+        } catch (Exception ignored) {
+        }
     }
 
     public void bindService(Object serviceImpl) {

--- a/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
+++ b/component/component-brpc/src/main/java/org/bithon/component/brpc/channel/BrpcClient.java
@@ -70,6 +70,7 @@ public class BrpcClient implements IBrpcChannel, Closeable {
     private final ServiceRegistry serviceRegistry = new ServiceRegistry();
     private NioEventLoopGroup bossGroup;
     private final Duration retryBackoff;
+    private final Duration connectionTimeout;
     private final int maxRetry;
 
     /**
@@ -96,6 +97,7 @@ public class BrpcClient implements IBrpcChannel, Closeable {
         this.server = Preconditions.checkArgumentNotNull("server", builder.server);
         this.maxRetry = Math.max(1, builder.maxRetry);
         this.retryBackoff = builder.retryBackoff;
+        this.connectionTimeout = builder.connectionTimeout;
         this.appName = builder.appName;
         this.clientId = builder.clientId;
 
@@ -218,9 +220,8 @@ public class BrpcClient implements IBrpcChannel, Closeable {
         for (int i = 0; i < maxRetry; i++) {
             server = this.server.getEndpoint();
             try {
-                ChannelFuture connectFuture = bootstrap.connect(server.getHost(), server.getPort())
-                                                       .awaitUninterruptibly();
-                if (connectFuture.isSuccess()) {
+                ChannelFuture connectFuture = bootstrap.connect(server.getHost(), server.getPort());
+                if (awaitConnect(connectFuture, server, connectionTimeout) && connectFuture.isSuccess()) {
                     connectionTimestamp = System.currentTimeMillis();
 
                     // Directly update the ref so that we can use the channel immediately
@@ -243,6 +244,22 @@ public class BrpcClient implements IBrpcChannel, Closeable {
             }
         }
         throw new CallerSideException("Unable to connect to remote service at [%s:%d]", server.getHost(), server.getPort());
+    }
+
+    static boolean awaitConnect(ChannelFuture connectFuture, EndPoint server, Duration connectionTimeout) {
+        long connectionTimeoutMilliseconds = Math.max(1, connectionTimeout.toMillis());
+        if (connectFuture.awaitUninterruptibly(connectionTimeoutMilliseconds, TimeUnit.MILLISECONDS)) {
+            return true;
+        }
+
+        connectFuture.cancel(true);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Timed out connecting to remote service at [{}:{}] in {} ms",
+                      server.getHost(),
+                      server.getPort(),
+                      connectionTimeoutMilliseconds);
+        }
+        return false;
     }
 
     public void bindService(Object serviceImpl) {

--- a/component/component-brpc/src/test/java/org/bithon/component/brpc/channel/BrpcClientTest.java
+++ b/component/component-brpc/src/test/java/org/bithon/component/brpc/channel/BrpcClientTest.java
@@ -17,7 +17,9 @@
 package org.bithon.component.brpc.channel;
 
 import org.bithon.component.brpc.endpoint.EndPoint;
+import org.bithon.shaded.io.netty.channel.Channel;
 import org.bithon.shaded.io.netty.channel.ChannelFuture;
+import org.bithon.shaded.io.netty.util.concurrent.GenericFutureListener;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -25,14 +27,29 @@ import java.lang.reflect.Proxy;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class BrpcClientTest {
 
     @Test
-    public void testPendingConnectFutureIsCancelledAfterTimeout() {
+    public void testPendingConnectFutureIsCancelledAfterTimeout() throws Exception {
         AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicBoolean successful = new AtomicBoolean();
+        AtomicInteger closeCount = new AtomicInteger();
         AtomicReference<Object[]> awaitArguments = new AtomicReference<>();
+        AtomicReference<GenericFutureListener> lateConnectListener = new AtomicReference<>();
+
+        Channel channel = (Channel) Proxy.newProxyInstance(
+            Channel.class.getClassLoader(),
+            new Class[]{Channel.class},
+            (proxy, method, args) -> {
+                if ("close".equals(method.getName()) && method.getParameterCount() == 0) {
+                    closeCount.incrementAndGet();
+                    return null;
+                }
+                return defaultValue(method.getReturnType());
+            });
 
         ChannelFuture connectFuture = (ChannelFuture) Proxy.newProxyInstance(
             ChannelFuture.class.getClassLoader(),
@@ -46,27 +63,49 @@ public class BrpcClientTest {
                     return false;
                 }
 
+                if ("addListener".equals(method.getName())) {
+                    lateConnectListener.set((GenericFutureListener) args[0]);
+                    return proxy;
+                }
+
+                if ("channel".equals(method.getName())) {
+                    return channel;
+                }
+
+                if ("isSuccess".equals(method.getName())) {
+                    return successful.get();
+                }
+
                 if ("cancel".equals(method.getName())) {
                     cancelled.set((Boolean) args[0]);
                     return true;
                 }
 
-                Class<?> returnType = method.getReturnType();
-                if (returnType == boolean.class) {
-                    return false;
-                }
-                if (returnType == int.class) {
-                    return 0;
-                }
-                if (returnType == long.class) {
-                    return 0L;
-                }
-                return null;
+                return defaultValue(method.getReturnType());
             });
 
         Assertions.assertFalse(BrpcClient.awaitConnect(connectFuture, new EndPoint("127.0.0.1", 1), Duration.ZERO));
         Assertions.assertEquals(1L, awaitArguments.get()[0]);
         Assertions.assertEquals(TimeUnit.MILLISECONDS, awaitArguments.get()[1]);
         Assertions.assertTrue(cancelled.get());
+        Assertions.assertEquals(1, closeCount.get());
+        Assertions.assertNotNull(lateConnectListener.get());
+
+        successful.set(true);
+        lateConnectListener.get().operationComplete(connectFuture);
+        Assertions.assertEquals(2, closeCount.get());
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        return null;
     }
 }

--- a/component/component-brpc/src/test/java/org/bithon/component/brpc/channel/BrpcClientTest.java
+++ b/component/component-brpc/src/test/java/org/bithon/component/brpc/channel/BrpcClientTest.java
@@ -1,0 +1,72 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.component.brpc.channel;
+
+import org.bithon.component.brpc.endpoint.EndPoint;
+import org.bithon.shaded.io.netty.channel.ChannelFuture;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class BrpcClientTest {
+
+    @Test
+    public void testPendingConnectFutureIsCancelledAfterTimeout() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicReference<Object[]> awaitArguments = new AtomicReference<>();
+
+        ChannelFuture connectFuture = (ChannelFuture) Proxy.newProxyInstance(
+            ChannelFuture.class.getClassLoader(),
+            new Class[]{ChannelFuture.class},
+            (proxy, method, args) -> {
+                if ("awaitUninterruptibly".equals(method.getName())
+                    && method.getParameterCount() == 2
+                    && method.getParameterTypes()[0] == long.class
+                    && method.getParameterTypes()[1] == TimeUnit.class) {
+                    awaitArguments.set(args);
+                    return false;
+                }
+
+                if ("cancel".equals(method.getName())) {
+                    cancelled.set((Boolean) args[0]);
+                    return true;
+                }
+
+                Class<?> returnType = method.getReturnType();
+                if (returnType == boolean.class) {
+                    return false;
+                }
+                if (returnType == int.class) {
+                    return 0;
+                }
+                if (returnType == long.class) {
+                    return 0L;
+                }
+                return null;
+            });
+
+        Assertions.assertFalse(BrpcClient.awaitConnect(connectFuture, new EndPoint("127.0.0.1", 1), Duration.ZERO));
+        Assertions.assertEquals(1L, awaitArguments.get()[0]);
+        Assertions.assertEquals(TimeUnit.MILLISECONDS, awaitArguments.get()[1]);
+        Assertions.assertTrue(cancelled.get());
+    }
+}


### PR DESCRIPTION
## Summary
- add an exporter shutdown hook before queue draining
- prevent BRPC metric/trace/event exporters from opening new connections during shutdown flush
- bound BRPC connect future waits with the configured connection timeout

## Tests
- git diff --cached --check
- mvn --ntp -pl :component-brpc -Dtest=BrpcClientTest test
- mvn --ntp -pl :agent-exporter-brpc -am -Dtest=BrpcMetricMessageExporterTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn --ntp -pl :agent-exporter-brpc -am -DskipTests package