### PR TITLE
Add attachOrReplaceCurrent tracing scope API

### DIFF
--- a/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/bithon/sdk/BithonSdkInterceptorTest.java
+++ b/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/bithon/sdk/BithonSdkInterceptorTest.java
@@ -49,7 +49,7 @@ public class BithonSdkInterceptorTest extends AbstractPluginInterceptorTest {
     protected ClassLoader getCustomClassLoader() {
         return MavenArtifactClassLoader.create(
             // Keep this on a published SDK artifact. New SDK APIs are covered in agent-plugin-bithon-sdk tests.
-            MavenArtifact.of("org.bithon.agent", "agent-sdk", "1.2.3")
+            MavenArtifact.of("org.bithon.agent", "agent-sdk", "1.2.4")
         );
     }
 

--- a/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/bithon/sdk/BithonSdkInterceptorTest.java
+++ b/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/bithon/sdk/BithonSdkInterceptorTest.java
@@ -48,8 +48,8 @@ public class BithonSdkInterceptorTest extends AbstractPluginInterceptorTest {
     @Override
     protected ClassLoader getCustomClassLoader() {
         return MavenArtifactClassLoader.create(
-            // Bithon SDK - use local version for testing new API
-            MavenArtifact.of("org.bithon.agent", "agent-sdk", "1.2.4")
+            // Keep this on a published SDK artifact. New SDK APIs are covered in agent-plugin-bithon-sdk tests.
+            MavenArtifact.of("org.bithon.agent", "agent-sdk", "1.2.3")
         );
     }
 

--- a/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/bithon/sdk/BithonSdkInterceptorTest.java
+++ b/agent/agent-plugins-test/src/test/java/org/bithon/agent/plugins/test/bithon/sdk/BithonSdkInterceptorTest.java
@@ -49,7 +49,7 @@ public class BithonSdkInterceptorTest extends AbstractPluginInterceptorTest {
     protected ClassLoader getCustomClassLoader() {
         return MavenArtifactClassLoader.create(
             // Bithon SDK - use local version for testing new API
-            MavenArtifact.of("org.bithon.agent", "agent-sdk", "1.2.3")
+            MavenArtifact.of("org.bithon.agent", "agent-sdk", "1.2.4")
         );
     }
 

--- a/agent/agent-plugins/bithon-sdk/pom.xml
+++ b/agent/agent-plugins/bithon-sdk/pom.xml
@@ -18,6 +18,16 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>agent-sdk</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/BithonSdkPlugin.java
+++ b/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/BithonSdkPlugin.java
@@ -64,6 +64,9 @@ public class BithonSdkPlugin implements IPlugin {
                 .onMethod("attach")
                 .replacedBy("org.bithon.agent.plugin.bithon.sdk.tracing.interceptor.TraceScopeBuilder$Attach")
 
+                .onMethod("attachOrReplaceCurrent")
+                .replacedBy("org.bithon.agent.plugin.bithon.sdk.tracing.interceptor.TraceScopeBuilder$AttachOrReplaceCurrent")
+
                 .build(),
 
             forClass("org.bithon.agent.sdk.tracing.SpanScopeBuilder")

--- a/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImpl.java
+++ b/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImpl.java
@@ -73,19 +73,22 @@ public class TraceScopeImpl implements ITraceScope {
 
     @Override
     public void close() {
-        rootSpan.finish();
-        if (context != null) {
-            context.finish();
-        }
-
         if (Thread.currentThread().getId() != attachedThreadId) {
             throw new SdkException("TraceScope is created in thread(id=%d), but is being closed from another thread(id=%d).",
                                    attachedThreadId,
                                    Thread.currentThread().getId());
         }
-        TraceContextHolder.detach();
-        if (previousContext != null) {
-            TraceContextHolder.attach(previousContext);
+
+        try {
+            rootSpan.finish();
+            if (context != null) {
+                context.finish();
+            }
+        } finally {
+            TraceContextHolder.detach();
+            if (previousContext != null) {
+                TraceContextHolder.attach(previousContext);
+            }
         }
     }
 }

--- a/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImpl.java
+++ b/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImpl.java
@@ -34,11 +34,17 @@ import org.bithon.agent.sdk.tracing.TracingMode;
  */
 public class TraceScopeImpl implements ITraceScope {
     private final ITraceContext context;
+    private final ITraceContext previousContext;
     private final ISpan rootSpan;
     private final long attachedThreadId;
 
     public TraceScopeImpl(ITraceContext context, ITraceSpan rootSpan) {
+        this(context, rootSpan, null);
+    }
+
+    public TraceScopeImpl(ITraceContext context, ITraceSpan rootSpan, ITraceContext previousContext) {
         this.context = context;
+        this.previousContext = previousContext;
         this.rootSpan = new SpanImpl(rootSpan);
 
         TraceContextHolder.attach(context);
@@ -78,5 +84,8 @@ public class TraceScopeImpl implements ITraceScope {
                                    Thread.currentThread().getId());
         }
         TraceContextHolder.detach();
+        if (previousContext != null) {
+            TraceContextHolder.attach(previousContext);
+        }
     }
 }

--- a/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/interceptor/TraceScopeBuilder$Attach.java
+++ b/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/interceptor/TraceScopeBuilder$Attach.java
@@ -48,8 +48,10 @@ public class TraceScopeBuilder$Attach extends ReplaceInterceptor {
                                    span == null ? "" : span.toString());
         }
 
-        TraceScopeBuilder builder = (TraceScopeBuilder) thisObject;
+        return createScope((TraceScopeBuilder) thisObject, null);
+    }
 
+    static TraceScopeImpl createScope(TraceScopeBuilder builder, ITraceContext previousContext) {
         String traceId = builder.traceId();
         String parentSpanId = builder.parentSpanId();
         if (StringUtils.isEmpty(traceId) || StringUtils.isEmpty(parentSpanId)) {
@@ -62,6 +64,6 @@ public class TraceScopeBuilder$Attach extends ReplaceInterceptor {
         ITraceSpan rootSpan = ctx.currentSpan();
         rootSpan.name(builder.operationName()).start();
 
-        return new TraceScopeImpl(ctx, ctx.currentSpan());
+        return new TraceScopeImpl(ctx, ctx.currentSpan(), previousContext);
     }
 }

--- a/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/interceptor/TraceScopeBuilder$AttachOrReplaceCurrent.java
+++ b/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/interceptor/TraceScopeBuilder$AttachOrReplaceCurrent.java
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.bithon.sdk.tracing.interceptor;
+
+import org.bithon.agent.instrumentation.aop.interceptor.declaration.ReplaceInterceptor;
+import org.bithon.agent.observability.tracing.context.ITraceContext;
+import org.bithon.agent.observability.tracing.context.TraceContextHolder;
+import org.bithon.agent.sdk.tracing.TraceScopeBuilder;
+import org.bithon.agent.sdk.tracing.impl.NoopTraceScope;
+import org.bithon.component.commons.utils.StringUtils;
+
+/**
+ * Interceptor for {@link TraceScopeBuilder#attachOrReplaceCurrent()}.
+ *
+ * @author frank.chen021@outlook.com
+ * @date 2026/05/22
+ */
+public class TraceScopeBuilder$AttachOrReplaceCurrent extends ReplaceInterceptor {
+
+    @Override
+    public Object execute(Object thisObject, Object[] args, Object returning) {
+        TraceScopeBuilder builder = (TraceScopeBuilder) thisObject;
+        if (StringUtils.isEmpty(builder.traceId()) || StringUtils.isEmpty(builder.parentSpanId())) {
+            return NoopTraceScope.INSTANCE;
+        }
+
+        ITraceContext previousContext = TraceContextHolder.current();
+        return TraceScopeBuilder$Attach.createScope(builder, previousContext);
+    }
+}

--- a/agent/agent-plugins/bithon-sdk/src/test/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImplTest.java
+++ b/agent/agent-plugins/bithon-sdk/src/test/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImplTest.java
@@ -1,0 +1,313 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.bithon.agent.plugin.bithon.sdk.tracing;
+
+
+import org.bithon.agent.observability.tracing.context.ITraceContext;
+import org.bithon.agent.observability.tracing.context.ITraceSpan;
+import org.bithon.agent.observability.tracing.context.TraceContextHolder;
+import org.bithon.agent.observability.tracing.context.TraceMode;
+import org.bithon.agent.observability.tracing.context.propagation.PropagationSetter;
+import org.bithon.agent.observability.tracing.id.ISpanIdGenerator;
+import org.bithon.agent.plugin.bithon.sdk.tracing.interceptor.TraceScopeBuilder$AttachOrReplaceCurrent;
+import org.bithon.agent.sdk.tracing.TraceContext;
+import org.bithon.agent.sdk.tracing.impl.NoopTraceScope;
+import org.bithon.component.commons.time.Clock;
+import org.bithon.component.commons.tracing.SpanKind;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Executable;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author frank.chen021@outlook.com
+ * @date 2026/05/22
+ */
+public class TraceScopeImplTest {
+
+    @AfterEach
+    public void tearDown() {
+        TraceContextHolder.detach();
+    }
+
+    @Test
+    public void testCloseClearsCurrentContextWhenNoPreviousContextExists() {
+        TestTraceContext current = new TestTraceContext("current");
+
+        new TraceScopeImpl(current, current.currentSpan()).close();
+
+        Assertions.assertNull(TraceContextHolder.current());
+        Assertions.assertTrue(current.finished);
+        Assertions.assertTrue(current.span.finished);
+    }
+
+    @Test
+    public void testCloseRestoresPreviousContext() {
+        TestTraceContext previous = new TestTraceContext("previous");
+        TraceContextHolder.attach(previous);
+
+        TestTraceContext current = new TestTraceContext("current");
+        TraceScopeImpl scope = new TraceScopeImpl(current, current.currentSpan(), previous);
+        Assertions.assertSame(current, TraceContextHolder.current());
+
+        scope.close();
+
+        Assertions.assertSame(previous, TraceContextHolder.current());
+        Assertions.assertFalse(previous.finished);
+        Assertions.assertFalse(previous.span.finished);
+        Assertions.assertTrue(current.finished);
+        Assertions.assertTrue(current.span.finished);
+    }
+
+    @Test
+    public void testAttachOrReplaceCurrentReturnsNoopWhenParentContextIsIncomplete() {
+        TestTraceContext previous = new TestTraceContext("previous");
+        TraceContextHolder.attach(previous);
+
+        TraceScopeBuilder$AttachOrReplaceCurrent interceptor = new TraceScopeBuilder$AttachOrReplaceCurrent();
+
+        Assertions.assertSame(NoopTraceScope.INSTANCE,
+                              interceptor.execute(TraceContext.newTrace("missing-parent"), null, null));
+        Assertions.assertSame(NoopTraceScope.INSTANCE,
+                              interceptor.execute(TraceContext.newTrace("missing-trace").parent("", "0000000000000001"),
+                                                  null,
+                                                  null));
+        Assertions.assertSame(NoopTraceScope.INSTANCE,
+                              interceptor.execute(TraceContext.newTrace("missing-parent").parent("00000000000000000000000000000001", ""),
+                                                  null,
+                                                  null));
+        Assertions.assertSame(previous, TraceContextHolder.current());
+        Assertions.assertFalse(previous.finished);
+        Assertions.assertFalse(previous.span.finished);
+    }
+
+    private static class TestTraceContext implements ITraceContext {
+        private final Clock clock = new Clock();
+        private final ISpanIdGenerator spanIdGenerator = () -> "0000000000000001";
+        private final String traceId;
+        private final TestTraceSpan span;
+        private boolean finished;
+
+        private TestTraceContext(String traceId) {
+            this.traceId = traceId;
+            this.span = new TestTraceSpan(this);
+        }
+
+        @Override
+        public TraceMode traceMode() {
+            return TraceMode.TRACING;
+        }
+
+        @Override
+        public String traceId() {
+            return traceId;
+        }
+
+        @Override
+        public ITraceSpan currentSpan() {
+            return span;
+        }
+
+        @Override
+        public Clock clock() {
+            return clock;
+        }
+
+        @Override
+        public ISpanIdGenerator spanIdGenerator() {
+            return spanIdGenerator;
+        }
+
+        @Override
+        public ITraceSpan newSpan(String parentSpanId, String spanId) {
+            return span;
+        }
+
+        @Override
+        public void finish() {
+            finished = true;
+        }
+
+        @Override
+        public <T> void propagate(T injectedTo, PropagationSetter<T> setter) {
+        }
+
+        @Override
+        public ITraceContext copy() {
+            return new TestTraceContext(traceId);
+        }
+
+        @Override
+        public boolean finished() {
+            return finished;
+        }
+    }
+
+    private static class TestTraceSpan implements ITraceSpan {
+        private final ITraceContext context;
+        private boolean finished;
+
+        private TestTraceSpan(ITraceContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public ITraceContext context() {
+            return context;
+        }
+
+        @Override
+        public String spanId() {
+            return "0000000000000001";
+        }
+
+        @Override
+        public String parentSpanId() {
+            return "";
+        }
+
+        @Override
+        public SpanKind kind() {
+            return SpanKind.INTERNAL;
+        }
+
+        @Override
+        public ITraceSpan kind(SpanKind kind) {
+            return this;
+        }
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public ITraceSpan name(String name) {
+            return this;
+        }
+
+        @Override
+        public Map<String, String> tags() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public ITraceSpan tag(String name, String value) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan tag(String name, SocketAddress address) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan tag(String name, InetSocketAddress address) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan tag(String name, int value) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan tag(String name, long value) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan tag(String name, Object value) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan tag(Throwable exception) {
+            return this;
+        }
+
+        @Override
+        public String parentApplication() {
+            return null;
+        }
+
+        @Override
+        public ITraceSpan parentApplication(String sourceApp) {
+            return this;
+        }
+
+        @Override
+        public String clazz() {
+            return "";
+        }
+
+        @Override
+        public String method() {
+            return "";
+        }
+
+        @Override
+        public ITraceSpan method(Executable method) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan method(Class<?> clazz, String method) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan method(String clazz, String method) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan clazz(String clazz) {
+            return this;
+        }
+
+        @Override
+        public long startTime() {
+            return 0;
+        }
+
+        @Override
+        public long endTime() {
+            return 0;
+        }
+
+        @Override
+        public ITraceSpan newChildSpan(String name) {
+            return this;
+        }
+
+        @Override
+        public ITraceSpan start() {
+            return this;
+        }
+
+        @Override
+        public void finish() {
+            finished = true;
+        }
+    }
+}

--- a/agent/agent-plugins/bithon-sdk/src/test/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImplTest.java
+++ b/agent/agent-plugins/bithon-sdk/src/test/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImplTest.java
@@ -17,25 +17,35 @@
 package org.bithon.agent.plugin.bithon.sdk.tracing;
 
 
+import org.bithon.agent.configuration.ConfigurationManager;
+import org.bithon.agent.observability.tracing.Tracer;
+import org.bithon.agent.observability.tracing.config.TraceConfig;
 import org.bithon.agent.observability.tracing.context.ITraceContext;
 import org.bithon.agent.observability.tracing.context.ITraceSpan;
 import org.bithon.agent.observability.tracing.context.TraceContextHolder;
 import org.bithon.agent.observability.tracing.context.TraceMode;
 import org.bithon.agent.observability.tracing.context.propagation.PropagationSetter;
 import org.bithon.agent.observability.tracing.id.ISpanIdGenerator;
+import org.bithon.agent.observability.tracing.id.impl.DefaultSpanIdGenerator;
+import org.bithon.agent.observability.tracing.reporter.ITraceReporter;
+import org.bithon.agent.observability.tracing.reporter.ReporterConfig;
 import org.bithon.agent.plugin.bithon.sdk.tracing.interceptor.TraceScopeBuilder$AttachOrReplaceCurrent;
+import org.bithon.agent.sdk.tracing.ITraceScope;
 import org.bithon.agent.sdk.tracing.TraceContext;
 import org.bithon.agent.sdk.tracing.impl.NoopTraceScope;
 import org.bithon.component.commons.time.Clock;
 import org.bithon.component.commons.tracing.SpanKind;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,10 +53,30 @@ import java.util.Map;
  * @date 2026/05/22
  */
 public class TraceScopeImplTest {
+    private Tracer originalTracer;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        ConfigurationManager.createForTesting();
+        originalTracer = setTracer(new Tracer("test", "test")
+                                       .traceConfig(new TraceConfig())
+                                       .spanIdGenerator(new DefaultSpanIdGenerator())
+                                       .reporter(new ITraceReporter() {
+                                           @Override
+                                           public ReporterConfig getReporterConfig() {
+                                               return new ReporterConfig();
+                                           }
+
+                                           @Override
+                                           public void report(List<ITraceSpan> spans) {
+                                           }
+                                       }));
+    }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         TraceContextHolder.detach();
+        setTracer(originalTracer);
     }
 
     @Test
@@ -79,6 +109,24 @@ public class TraceScopeImplTest {
     }
 
     @Test
+    public void testCloseRestoresPreviousContextWhenCurrentContextFinishThrows() {
+        TestTraceContext previous = new TestTraceContext("previous");
+        TraceContextHolder.attach(previous);
+
+        RuntimeException finishException = new RuntimeException("finish failed");
+        TestTraceContext current = new TestTraceContext("current");
+        current.finishException = finishException;
+        TraceScopeImpl scope = new TraceScopeImpl(current, current.currentSpan(), previous);
+
+        Assertions.assertSame(finishException, Assertions.assertThrows(RuntimeException.class, scope::close));
+        Assertions.assertSame(previous, TraceContextHolder.current());
+        Assertions.assertFalse(previous.finished);
+        Assertions.assertFalse(previous.span.finished);
+        Assertions.assertTrue(current.finished);
+        Assertions.assertTrue(current.span.finished);
+    }
+
+    @Test
     public void testAttachOrReplaceCurrentReturnsNoopWhenParentContextIsIncomplete() {
         TestTraceContext previous = new TestTraceContext("previous");
         TraceContextHolder.attach(previous);
@@ -100,12 +148,46 @@ public class TraceScopeImplTest {
         Assertions.assertFalse(previous.span.finished);
     }
 
+    @Test
+    public void testAttachOrReplaceCurrentReplacesAndRestoresPreviousContext() {
+        TestTraceContext previous = new TestTraceContext("previous");
+        TraceContextHolder.attach(previous);
+
+        TraceScopeBuilder$AttachOrReplaceCurrent interceptor = new TraceScopeBuilder$AttachOrReplaceCurrent();
+        ITraceScope scope = (ITraceScope) interceptor.execute(TraceContext.newTrace("current")
+                                                                          .parent("00000000000000000000000000000001",
+                                                                                  "0000000000000002"),
+                                                              null,
+                                                              null);
+
+        ITraceContext current = TraceContextHolder.current();
+        Assertions.assertNotSame(previous, current);
+        Assertions.assertEquals("00000000000000000000000000000001", current.traceId());
+        Assertions.assertEquals("0000000000000002", current.currentSpan().parentSpanId());
+        Assertions.assertEquals("current", current.currentSpan().name());
+
+        scope.close();
+
+        Assertions.assertSame(previous, TraceContextHolder.current());
+        Assertions.assertFalse(previous.finished);
+        Assertions.assertFalse(previous.span.finished);
+    }
+
+    private static Tracer setTracer(Tracer tracer) throws Exception {
+        Field field = Tracer.class.getDeclaredField("INSTANCE");
+        field.setAccessible(true);
+        Tracer previous = (Tracer) field.get(null);
+        field.set(null, tracer);
+        return previous;
+    }
+
     private static class TestTraceContext implements ITraceContext {
         private final Clock clock = new Clock();
         private final ISpanIdGenerator spanIdGenerator = () -> "0000000000000001";
         private final String traceId;
         private final TestTraceSpan span;
         private boolean finished;
+        private RuntimeException finishException;
 
         private TestTraceContext(String traceId) {
             this.traceId = traceId;
@@ -145,6 +227,9 @@ public class TraceScopeImplTest {
         @Override
         public void finish() {
             finished = true;
+            if (finishException != null) {
+                throw finishException;
+            }
         }
 
         @Override

--- a/agent/agent-sdk/pom.xml
+++ b/agent/agent-sdk/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.bithon.agent</groupId>
   <artifactId>agent-sdk</artifactId>
-  <version>1.2.3</version>
+  <version>1.2.4</version>
   <name>agent-sdk</name>
   <description>The observability SDK</description>
   <url>https://bithon.org</url>

--- a/agent/agent-sdk/src/main/java/org/bithon/agent/sdk/tracing/TraceScopeBuilder.java
+++ b/agent/agent-sdk/src/main/java/org/bithon/agent/sdk/tracing/TraceScopeBuilder.java
@@ -114,6 +114,29 @@ public class TraceScopeBuilder {
         return NoopTraceScope.INSTANCE;
     }
 
+    /**
+     * Creates a trace scope and attaches it to the current thread, temporarily replacing any existing context.
+     * <p>
+     * If {@link #parent(String, String)} is not configured with a non-empty trace ID and parent span ID, this method
+     * returns a no-op scope.
+     * <p>
+     * If a tracing context already exists on the current thread, it will be suspended while the returned scope is active,
+     * and restored when the returned scope is closed. The suspended context is not finished by this scope.
+     * <p>
+     * This method is intended for asynchronous task frameworks that need to restore the task's own trace context even
+     * when the executor thread already has a context propagated by instrumentation.
+     *
+     * @return an attached ITraceScope ready for use in try-with-resources.
+     * Callers MUST ensure to close the scope to avoid resource leaks and restore the previous context.
+     * @since 1.2.4
+     */
+    public ITraceScope attachOrReplaceCurrent() {
+        if (shouldLog()) {
+            LOGGER.warning("The agent is not loaded.");
+        }
+        return NoopTraceScope.INSTANCE;
+    }
+
     // Public getters for agent interceptors
     public String operationName() {
         return operationName;

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>org.bithon.agent</groupId>
                 <artifactId>agent-sdk</artifactId>
-                <version>1.2.3</version>
+                <version>1.2.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/doc/sdk/metrics.md
+++ b/doc/sdk/metrics.md
@@ -15,7 +15,7 @@ Following steps guides how to use this SDK
     <dependency>
       <groupId>org.bithon.agent</groupId>
       <artifactId>agent-sdk</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.4</version>
     </dependency>
    ```
 2. Define metrics in your application
@@ -85,4 +85,3 @@ Following steps guides how to use this SDK
     GatewayMetrics metrics = gatewayMetrics.getPermanent(request.getTargetIp());
     metrics.activeConnections = ()->{ someClass.getActiveConnection(); };
    ```
-   

--- a/doc/sdk/tracing.md
+++ b/doc/sdk/tracing.md
@@ -14,13 +14,13 @@ Add the Bithon Tracing API dependency to your project. The dependency is availab
 <dependency>
     <groupId>org.bithon.agent</groupId>
     <artifactId>agent-sdk</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
 </dependency>
 ```
 
 > NOTE:
 > 
-> 1.2.3 is the current release version. You can find the latest version in [Maven Central](https://search.maven.org/artifact/org.bithon.agent/agent-sdk).
+> 1.2.4 is the current release version. You can find the latest version in [Maven Central](https://search.maven.org/artifact/org.bithon.agent/agent-sdk).
 
 ### Step.2: Create trace spans
 
@@ -129,6 +129,8 @@ This is useful when you want to control how or when the `traceId` is generated, 
 > 
 >
 
+If the current thread might already have a tracing context propagated by instrumentation, but the task itself carries an authoritative trace context that must be restored, use `attachOrReplaceCurrent()` instead of `attach()`. The existing context is suspended while the returned scope is active and restored when the scope is closed. This API requires a non-empty `traceId` and `parentSpanId`; if either value is missing, it returns a no-op scope.
+
 The following examples demonstrates the usage of this API in two scenarios:
 1. Set up a tracing context on a background task
 2. Propagate the tracing context for asynchronous processing by using of `java.lang.Thread`
@@ -198,6 +200,15 @@ public class BackgroundTaskService {
             }
         }).start();
     }
+
+    // Restore a task-carried context even if the executor thread already has one.
+    private void runTaskWithCarriedTrace(String traceId, String parentSpanId, Runnable task) {
+        try (ITraceScope scope = TraceContext.newTrace("user-task")
+                                             .parent(traceId, parentSpanId)
+                                             .attachOrReplaceCurrent()) {
+            task.run();
+        }
+    }
 }
 ```
 
@@ -226,6 +237,13 @@ public class BackgroundTaskService {
 | `TraceContext.currentTraceId()`                    | Gets the trace ID for the current request. Returns `null` if tracing is not enabled or request is not sampled. |
 | `TraceContext.currentSpanId()`                     | Gets the span ID for the current span. Returns `null` if tracing is not enabled or request is not sampled.     |
 | `TraceContext.currentSpan()`                       | Gets the active span on current running thread. Returns `null` if there's no tracing on running thread.        |
+
+#### TraceScopeBuilder APIs
+
+| API Name                   | Description                                                                                                                       |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `attach()`                 | Attaches the new trace scope to the current thread. Throws if a tracing context is already attached.                              |
+| `attachOrReplaceCurrent()` | Attaches the new trace scope and temporarily replaces any existing current context. Requires non-empty parent context IDs; otherwise returns a no-op scope. Restores the previous context on scope close. |
 
 
 ### Understand how the tracing SDK works


### PR DESCRIPTION
## Summary
- Add `TraceScopeBuilder.attachOrReplaceCurrent()` to temporarily replace the current tracing context for task-carried context restore flows.
- Wire the new API through the `bithon-sdk` agent plugin interceptor and restore the suspended context on close.
- Bump `agent-sdk` to `1.2.4` and update SDK docs/examples.

## Validation
- `git diff --check`
- `mvn -pl agent/agent-sdk,agent/agent-plugins/bithon-sdk -am test`