### PR TITLE
[codex] Upgrade safe Maven dependencies

### DIFF
--- a/agent/agent-sdk/pom.xml
+++ b/agent/agent-sdk/pom.xml
@@ -42,7 +42,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.deploy.skip>false</maven.deploy.skip>
     <spotbugs.version>4.9.8</spotbugs.version>
-    <spotbugs.maven.plugin.version>4.9.8.1</spotbugs.maven.plugin.version>
+    <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
   </properties>
 
   <build>
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
         <configuration>
           <release>8</release>
         </configuration>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -132,7 +132,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.15.0</version>
                     <configuration>
                         <source>8</source>
                         <target>8</target>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -37,7 +37,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.6.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <lombok.version>1.18.46</lombok.version>
     <checkstyle.version>12.3.1</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
-    <spotbugs.maven.plugin.version>4.9.8.1</spotbugs.maven.plugin.version>
+    <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -168,7 +168,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.14.0</version>
+          <version>3.15.0</version>
           <configuration>
             <release>${maven.compiler.release}</release>
             <encoding>UTF-8</encoding>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -36,8 +36,8 @@
 
     <grpc.version>1.59.1</grpc.version>
 
-    <!-- The version that is used by the current grpc -->
-    <protobuf.version>3.24.0</protobuf.version>
+    <!-- Keep server protobuf runtime on the same compatible Protobuf 3.x line as shaded-protobuf. -->
+    <protobuf.version>3.25.9</protobuf.version>
   </properties>
 
   <modules>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -25,7 +25,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.6.2</version>
           <configuration>
             <createSourcesJar>true</createSourcesJar>
             <shadeSourcesContent>true</shadeSourcesContent>

--- a/shaded/shaded-protobuf/pom.xml
+++ b/shaded/shaded-protobuf/pom.xml
@@ -16,7 +16,7 @@
     <java.version>8</java.version>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <proto.version>3.25.8</proto.version>
+    <proto.version>3.25.9</proto.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary

- Bump low-risk Maven build plugins: `maven-compiler-plugin` to 3.15.0, `maven-shade-plugin` to 3.6.2, and `spotbugs-maven-plugin` to 4.9.8.3 while keeping the SpotBugs engine on 4.9.8.
- Include the optional Protobuf 3.x alignment from the dependency sweep: server protobuf management and shaded protobuf move to 3.25.9.
- Leave higher-risk upgrades out of scope: JUnit 6 RC, Mockito inline 5.x, Checkstyle 13.x, Spring Boot BOM movement, Netty 4.2.x, and Protobuf 4.x.

## Risk notes

- Protobuf stays on the 3.x line to avoid the Protobuf 4.x migration surface.
- Compiler and shade changes are build-tool-only, but the PR validates Java 8 agent/component paths and server generated-proto paths.
- The OpenTelemetry proto submodule must be initialized for collector verification; otherwise the opentelemetry jar is empty in this checkout.

## Validation

- `mvn -ntp -B -Pcomponent,agent,server,shaded -pl agent/agent-sdk,component,shaded/shaded-protobuf,server/opentelemetry,server/collector -am -DskipTests clean package`

The first collector validation failed before initializing `server/opentelemetry/opentelemetry-proto`; after checking out the recorded submodule commit, the combined targeted build passed.