### PR TITLE
Upgrade Spring Boot BOM and Checkstyle

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -46,11 +46,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup JDK17
+      - name: Setup JDK21
         uses: actions/setup-java@v3
         with:
-          java-version: "17"
-          distribution: "adopt"
+          java-version: "21"
+          distribution: "temurin"
 
       #
       # separate shaded building from other modules because if it's built with other modules,
@@ -127,9 +127,8 @@ jobs:
     strategy:
       matrix:
         include:
+          # Mockito 5 requires Java 11+ at test runtime.
           # LTS versions using temurin
-          - java-version: "8"
-            distribution: "temurin"
           - java-version: "11"
             distribution: "temurin"
           - java-version: "17"
@@ -145,10 +144,6 @@ jobs:
           - java-version: "25"
             distribution: "temurin"
           # Non-LTS versions using zulu (better historical support)
-          - java-version: "9"
-            distribution: "zulu"
-          - java-version: "10"
-            distribution: "zulu"
           - java-version: "12"
             distribution: "zulu"
           - java-version: "13"
@@ -313,8 +308,10 @@ jobs:
       - name: Run tests with JDK ${{ matrix.java-version }}
         run: |
           echo "=== Running tests with TestContainers support ==="
+          BYTE_BUDDY_AGENT="$(find "$HOME/.m2/repository/net/bytebuddy/byte-buddy-agent" -name "byte-buddy-agent-*.jar" | sort -V | tail -n 1)"
+          test -n "$BYTE_BUDDY_AGENT"
           # Ensure test resources are in classpath by running from project root
-          mvn surefire:test --activate-profiles agent -P-server -ntp -Dtest.working.directory=$PWD
+          mvn surefire:test --activate-profiles agent -P-server -ntp -Dtest.working.directory=$PWD -DargLine="-javaagent:${BYTE_BUDDY_AGENT}"
         env:
           # Ensure TestContainers environment variables are available
           TESTCONTAINERS_RYUK_DISABLED: true

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -46,11 +46,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup JDK21
+      - name: Setup JDK17
         uses: actions/setup-java@v3
         with:
-          java-version: "21"
-          distribution: "temurin"
+          java-version: "17"
+          distribution: "adopt"
 
       #
       # separate shaded building from other modules because if it's built with other modules,
@@ -127,8 +127,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # Mockito 5 requires Java 11+ at test runtime.
           # LTS versions using temurin
+          - java-version: "8"
+            distribution: "temurin"
           - java-version: "11"
             distribution: "temurin"
           - java-version: "17"
@@ -144,6 +145,10 @@ jobs:
           - java-version: "25"
             distribution: "temurin"
           # Non-LTS versions using zulu (better historical support)
+          - java-version: "9"
+            distribution: "zulu"
+          - java-version: "10"
+            distribution: "zulu"
           - java-version: "12"
             distribution: "zulu"
           - java-version: "13"
@@ -308,10 +313,8 @@ jobs:
       - name: Run tests with JDK ${{ matrix.java-version }}
         run: |
           echo "=== Running tests with TestContainers support ==="
-          BYTE_BUDDY_AGENT="$(find "$HOME/.m2/repository/net/bytebuddy/byte-buddy-agent" -name "byte-buddy-agent-*.jar" | sort -V | tail -n 1)"
-          test -n "$BYTE_BUDDY_AGENT"
           # Ensure test resources are in classpath by running from project root
-          mvn surefire:test --activate-profiles agent -P-server -ntp -Dtest.working.directory=$PWD -DargLine="-javaagent:${BYTE_BUDDY_AGENT}"
+          mvn surefire:test --activate-profiles agent -P-server -ntp -Dtest.working.directory=$PWD
         env:
           # Ensure TestContainers environment variables are available
           TESTCONTAINERS_RYUK_DISABLED: true

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -46,11 +46,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup JDK17
+      - name: Setup JDK21
         uses: actions/setup-java@v3
         with:
-          java-version: "17"
-          distribution: "adopt"
+          java-version: "21"
+          distribution: "temurin"
 
       #
       # separate shaded building from other modules because if it's built with other modules,
@@ -63,7 +63,7 @@ jobs:
         run: mvn clean install -T 1C -ntp --activate-profiles agent,component -Dmaven.javadoc.skip=true -DskipTests
 
       - name: Process test resources
-        run: mvn test-compile -T 1C -ntp --activate-profiles agent,component -DskipTests
+        run: mvn test-compile -T 1C -ntp --activate-profiles agent,component -DskipTests -Dcheckstyle.skip=true
 
       - name: Verify test resources are built
         run: |
@@ -269,7 +269,7 @@ jobs:
           
           if [ "$MISSING_RESOURCES" = true ]; then
             echo "=== Rebuilding test resources ==="
-            mvn test-compile -T 1C -ntp --activate-profiles agent,component -DskipTests
+            mvn test-compile -T 1C -ntp --activate-profiles agent,component -DskipTests -Dcheckstyle.skip=true
             
             echo "=== Verifying resources after rebuild ==="
             find agent/ -path "*/target/test-classes/*" -name "init-mysql*.sql" -type f

--- a/.github/workflows/build-server-jdk21.yml
+++ b/.github/workflows/build-server-jdk21.yml
@@ -52,4 +52,7 @@ jobs:
 
       # Execute UT excluding component modules
       - name: UT
-        run: mvn test -P-component -P-agent
+        run: |
+          BYTE_BUDDY_AGENT="$(find "$HOME/.m2/repository/net/bytebuddy/byte-buddy-agent" -name "byte-buddy-agent-*.jar" | sort -V | tail -n 1)"
+          test -n "$BYTE_BUDDY_AGENT"
+          mvn test -P-component -P-agent -DargLine="-javaagent:${BYTE_BUDDY_AGENT}"

--- a/.github/workflows/build-server-jdk21.yml
+++ b/.github/workflows/build-server-jdk21.yml
@@ -52,7 +52,4 @@ jobs:
 
       # Execute UT excluding component modules
       - name: UT
-        run: |
-          BYTE_BUDDY_AGENT="$(find "$HOME/.m2/repository/net/bytebuddy/byte-buddy-agent" -name "byte-buddy-agent-*.jar" | sort -V | tail -n 1)"
-          test -n "$BYTE_BUDDY_AGENT"
-          mvn test -P-component -P-agent -DargLine="-javaagent:${BYTE_BUDDY_AGENT}"
+        run: mvn test -P-component -P-agent

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <junit.jupiter.version>5.10.5</junit.jupiter.version>
     <junit.platform.version>1.10.5</junit.platform.version>
     <lombok.version>1.18.46</lombok.version>
-    <!-- Keep on 12.x: Checkstyle 13.x requires Java 21 to run, which would force CI off
-         the current JDK8/9/10 compatibility coverage. -->
+    <!-- Keep on 12.x: Checkstyle runs during Maven validate, so 13.x would make any
+         Maven CI/build step running on JDK <21 fail before tests. -->
     <checkstyle.version>12.3.1</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,9 @@
     <junit.jupiter.version>5.10.5</junit.jupiter.version>
     <junit.platform.version>1.10.5</junit.platform.version>
     <lombok.version>1.18.46</lombok.version>
-    <checkstyle.version>13.4.2</checkstyle.version>
+    <!-- Keep on 12.x: Checkstyle 13.x requires Java 21 to run, which would force CI off
+         the current JDK8/9/10 compatibility coverage. -->
+    <checkstyle.version>12.3.1</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -153,8 +155,9 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <!-- Mockito 5 requires Java 11+ at test runtime. Agent production bytecode still targets Java 8. -->
-        <version>5.2.0</version>
+        <!-- DO NOT UPGRADE to Mockito 5.x while the agent test matrix still covers JDK8/9/10:
+        Mockito 5 artifacts require Java 11+ at test runtime. -->
+        <version>4.11.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <junit.jupiter.version>5.10.5</junit.jupiter.version>
     <junit.platform.version>1.10.5</junit.platform.version>
     <lombok.version>1.18.46</lombok.version>
-    <checkstyle.version>12.3.1</checkstyle.version>
+    <checkstyle.version>13.4.2</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -153,9 +153,8 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <!-- DO NOT UPGRADE -
-        This is the latest version that supports JDK8 only since we're using it in the agent which uses JDK8 only-->
-        <version>4.11.0</version>
+        <!-- Mockito 5 requires Java 11+ at test runtime. Agent production bytecode still targets Java 8. -->
+        <version>5.2.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <junit.jupiter.version>5.10.5</junit.jupiter.version>
     <junit.platform.version>1.10.5</junit.platform.version>
     <lombok.version>1.18.46</lombok.version>
-    <!-- Keep on 12.x: Checkstyle runs during Maven validate, so 13.x would make any
-         Maven CI/build step running on JDK <21 fail before tests. -->
-    <checkstyle.version>12.3.1</checkstyle.version>
+    <!-- Checkstyle 13.x requires the Maven/Checkstyle runtime to be JDK21+,
+         but it can still validate agent modules that target Java 8 bytecode. -->
+    <checkstyle.version>13.4.2</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -260,15 +260,6 @@
             <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <!-- license checking -->
@@ -463,6 +454,30 @@
   </reporting>
 
   <profiles>
+    <profile>
+      <id>jdk21-checkstyle</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>validate</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>component</id>
       <modules>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -26,7 +26,7 @@
     <!-- Dependency Note: https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions -->
     <!-- Maven release: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot -->
     <!-- Maven release: https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies -->
-    <spring-boot.version>4.0.0</spring-boot.version>
+    <spring-boot.version>4.0.6</spring-boot.version>
     <spring-cloud.version>2025.1.1</spring-cloud.version>
 
     <!-- The Alibaba Nacos is used -->


### PR DESCRIPTION
## Summary
- Upgrade the Spring Boot BOM from `4.0.0` to `4.0.6`.
- Upgrade Checkstyle from `12.3.1` to `13.4.2`.
- Keep Mockito inline at `4.11.0` and clarify the JDK8/9/10 compatibility reason in the existing POM comment.

## Breaking-change risks / migrations
- Checkstyle 13.x requires the Maven/Checkstyle runtime to be JDK21+. This PR keeps agent Java 8 bytecode compatibility by binding the validate-phase Checkstyle execution only when Maven runs on JDK21+.
- Agent compatibility jobs for JDK8/9/10 remain in the test matrix. Lifecycle fallback commands in that matrix skip Checkstyle so they do not load Java 21-only Checkstyle classes.
- Mockito is intentionally unchanged: Mockito 5.x requires Java 11+ at test runtime, so upgrading it would break the current JDK8/9/10 compatibility coverage.
- Spring Boot stays within the 4.0.x patch line, but it can still adjust the managed dependency graph for server modules; CI should focus on server compile/test coverage.

## Validation
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home mvn -ntp -B -Pcomponent,agent,server -pl agent/agent-core,agent/agent-observability,component/component-commons,server/server-commons,server/pipeline -am -DskipTests validate`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home mvn -ntp -B -Pagent -pl agent/agent-core -am -DskipTests test-compile`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home mvn -ntp -B -Pserver -pl server/server-commons,server/pipeline,server/metric-expression,server/web-service,server/alerting/manager,server/alerting/evaluator -am -DskipTests test-compile`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-agent.yml"); YAML.load_file(".github/workflows/build-server-jdk21.yml"); puts "workflow yaml ok"'