### PR TITLE
[codex] Fix master CI Docker coverage

### DIFF
--- a/.github/workflows/build-docker-agent.yml
+++ b/.github/workflows/build-docker-agent.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
           changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
           printf '%s\n' "$changed_files"
 
-          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|agent/|component/|shaded/|license/|dev/|pom\.xml$|\.github/workflows/build-docker-agent\.yml$)"; then
+          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|agent/|component/|shaded/|licenses/|dev/|pom\.xml$|\.github/workflows/build-docker-agent\.yml$)"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -34,10 +34,10 @@ jobs:
 
       - name: Setup JDK8
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && steps.docker-changes.outputs.changed == 'true')
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: "8"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Build image
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && steps.docker-changes.outputs.changed == 'true')

--- a/.github/workflows/build-docker-agent.yml
+++ b/.github/workflows/build-docker-agent.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository and submodules
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/build-docker-agent.yml
+++ b/.github/workflows/build-docker-agent.yml
@@ -14,12 +14,19 @@ jobs:
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-      - name: Check for docker or workflow changes (PR only)
+      - name: Check for agent image changes (PR only)
         if: github.event_name == 'pull_request'
         id: docker-changes
         run: |
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -q "^docker/\|^\.github/workflows/build-docker-agent.yml"; then
+          set -euo pipefail
+
+          changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|agent/|component/|shaded/|license/|dev/|pom\.xml$|\.github/workflows/build-docker-agent\.yml$)"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-docker-server.yml
+++ b/.github/workflows/build-docker-server.yml
@@ -15,13 +15,19 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: recursive
 
-      - name: Check for docker or workflow changes (PR only)
+      - name: Check for server image changes (PR only)
         if: github.event_name == 'pull_request'
         id: docker-changes
         run: |
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -q "^docker/\|^\.github/workflows/build-docker-server.yml"; then
+          set -euo pipefail
+
+          changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|server/|component/|shaded/|license/|dev/|pom\.xml$|\.github/workflows/build-docker-server\.yml$)"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-docker-server.yml
+++ b/.github/workflows/build-docker-server.yml
@@ -27,7 +27,7 @@ jobs:
           changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
           printf '%s\n' "$changed_files"
 
-          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|server/|component/|shaded/|licenses/|dev/|pom\.xml$|\.github/workflows/build-docker-server\.yml$)"; then
+          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|server/|component/|shaded/|licenses/|dev/|pom\.xml$|\.gitmodules$|\.github/workflows/build-docker-server\.yml$)"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-docker-server.yml
+++ b/.github/workflows/build-docker-server.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -27,7 +27,7 @@ jobs:
           changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
           printf '%s\n' "$changed_files"
 
-          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|server/|component/|shaded/|license/|dev/|pom\.xml$|\.github/workflows/build-docker-server\.yml$)"; then
+          if printf '%s\n' "$changed_files" | grep -Eq "^(docker/|server/|component/|shaded/|licenses/|dev/|pom\.xml$|\.github/workflows/build-docker-server\.yml$)"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -35,10 +35,10 @@ jobs:
 
       - name: Setup JDK8
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && steps.docker-changes.outputs.changed == 'true')
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Build image
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && steps.docker-changes.outputs.changed == 'true')

--- a/agent/agent-plugins-test/pom.xml
+++ b/agent/agent-plugins-test/pom.xml
@@ -396,7 +396,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.3</version>
+        <version>${maven.surefire.version}</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>

--- a/docker/Dockerfile-agent
+++ b/docker/Dockerfile-agent
@@ -33,7 +33,7 @@ RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
 
 WORKDIR /src
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -ntp -P!server clean install -DskipTests -T 1C \
+      mvn -ntp --activate-profiles agent,component clean install -DskipTests -T 1C \
       ; fi
 
 FROM eclipse-temurin:8-jre-alpine

--- a/docker/Dockerfile-agent
+++ b/docker/Dockerfile-agent
@@ -40,4 +40,4 @@ FROM eclipse-temurin:8-jre-alpine
 
 COPY --from=builder /src/agent/agent-distribution/target/agent-distribution/agent-distribution/ /opt/agent-distribution
 
-CMD [""]
+CMD ["true"]

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -42,7 +42,7 @@ RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
 # Build Server
 WORKDIR /src
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -ntp -pl server/server-starter -am \
+      mvn -ntp --activate-profiles server,component -pl server/server-starter -am \
       clean package \
       -T 1C \
       -DskipTests \

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <checkstyle.version>13.4.2</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
+    <maven.surefire.version>3.5.3</maven.surefire.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -206,6 +207,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.7.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven.surefire.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## Summary

- Make agent and server image PR checks rebuild when their Maven/build inputs change, not only when Docker files change.
- Fix the agent image Docker build to activate `agent,component` explicitly so the distribution directory is produced.
- Pin the inherited Surefire version to avoid floating plugin resolution in the agent JDK matrix.

## Root Cause

PR #1205 changed Maven/build inputs and passed because the agent image workflow skipped the Docker build on PRs unless `docker/` or the workflow file changed. The `master` push always builds the image, so it exposed the missing agent distribution output. The JDK10 matrix also resolved unpinned Surefire plugin versions during `mvn surefire:test`.

## Validation

- `git diff --check`
- YAML parse for `build-docker-agent.yml` and `build-docker-server.yml`
- Path matcher smoke checks for agent and server image workflows
- `mvn -ntp --activate-profiles agent,component clean install -DskipTests -T 1C`
- Effective POM check confirmed inherited Surefire `3.5.3`
- `docker build --platform linux/amd64 --build-arg BUILD_FROM_SOURCE=false -t bithon/agent-ci-smoke -f docker/Dockerfile-agent .`
