### PR TITLE
[codex] Upgrade minimal safe dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <checkstyle.version>13.4.2</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
-    <maven.surefire.version>3.5.3</maven.surefire.version>
+    <maven.surefire.version>3.5.5</maven.surefire.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -106,7 +106,7 @@
       <dependency>
         <groupId>com.alibaba</groupId>
         <artifactId>druid-spring-boot-starter</artifactId>
-        <version>1.2.27</version>
+        <version>1.2.28</version>
       </dependency>
 
       <dependency>
@@ -388,7 +388,7 @@
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.5</version>
         <scope>provided</scope>
       </dependency>
 


### PR DESCRIPTION
## Summary

- Bump Maven Surefire Plugin from 3.5.3 to 3.5.5.
- Bump `com.alibaba:druid-spring-boot-starter` from 1.2.27 to 1.2.28.
- Bump `jakarta.xml.bind:jakarta.xml.bind-api` from 4.0.0 to 4.0.5.

## Rationale

These were the smallest low-risk upgrades identified in the dependency sweep after excluding `agent/agent-plugins/**`. Larger major-version moves were intentionally deferred.

## Deferred Risk Items

- JUnit 6 and Mockito 5 remain deferred because the agent test matrix still covers Java 8/9/10.
- Protobuf 4.x, Jackson 2.21.x, Byte Buddy 1.18.x, MySQL 9.x, ClickHouse JDBC 0.9.x, H2 2.4.x, jOOQ 3.19.x, SLF4J 2/Logback 1.5, Central Publishing 0.10, and broad Maven plugin jumps should be handled as separate migrations with targeted validation.

## Validation

- `mvn -ntp -B -Pserver -pl server/storage-jdbc,server/datasource/reader-jdbc,server/storage-jdbc-postgresql,server/server-commons -am -DskipTests test-compile`
- `mvn -ntp -B -Pserver -pl server/server-commons -am test`