### PR TITLE
[codex] Upgrade safe dependency patch set

### DIFF
--- a/agent/agent-controller/pom.xml
+++ b/agent/agent-controller/pom.xml
@@ -28,12 +28,12 @@
     <dependency>
       <groupId>tools.profiler</groupId>
       <artifactId>jfr-converter</artifactId>
-      <version>4.1</version>
+      <version>4.4</version>
     </dependency>
     <dependency>
       <groupId>tools.profiler</groupId>
       <artifactId>async-profiler</artifactId>
-      <version>4.1</version>
+      <version>4.4</version>
     </dependency>
 
     <dependency>

--- a/agent/agent-sentinel/pom.xml
+++ b/agent/agent-sentinel/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
-      <version>8.5.99</version>
+      <version>8.5.100</version>
       <scope>provided</scope>
     </dependency>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -361,7 +361,7 @@
       <dependency>
         <groupId>redis.clients</groupId>
         <artifactId>jedis</artifactId>
-        <version>4.4.3</version>
+        <version>4.4.8</version>
       </dependency>
       <dependency>
         <groupId>org.bithon.server</groupId>


### PR DESCRIPTION
## Summary

- Upgrade `redis.clients:jedis` from `4.4.3` to `4.4.8` in server dependency management.
- Upgrade `org.apache.tomcat.embed:tomcat-embed-core` from `8.5.99` to `8.5.100` for the agent sentinel provided dependency.
- Upgrade `tools.profiler:async-profiler` and `tools.profiler:jfr-converter` from `4.1` to `4.4` for agent controller profiling support.

## Risk / Migration Notes

These are intentionally limited to the conservative dependency sweep set. No source changes or migrations are expected for these patch/minor updates. Larger candidates such as JUnit, Mockito, Spring Boot RCs, gRPC, shaded Jackson/Netty, jOOQ, and major plugin updates were intentionally deferred.

## Validation

- `mvn -ntp -Pagent,server -pl agent/agent-controller,agent/agent-sentinel,server -am -DskipTests compile`
- `mvn -ntp -Pagent -pl agent/agent-controller,agent/agent-sentinel -am test`
- `git diff --check`