### PR TITLE
Move default Maven modules to root reactor

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -57,7 +57,9 @@ jobs:
       # there might be library pollution in the agent-distribution
       #
       - name: Install shaded libs
-        run: mvn -f shaded/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
+        run: |
+          mvn -N install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
+          mvn -f shaded/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
 
       - name: Compilation
         run: |

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -57,13 +57,15 @@ jobs:
       # there might be library pollution in the agent-distribution
       #
       - name: Install shaded libs
-        run: mvn clean install -T 1C -ntp --activate-profiles shaded -Dmaven.javadoc.skip=true -DskipTests
+        run: mvn -f shaded/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
 
       - name: Compilation
-        run: mvn clean install -T 1C -ntp --activate-profiles agent,component -Dmaven.javadoc.skip=true -DskipTests
+        run: |
+          mvn -f component/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
+          mvn clean install -T 1C -ntp -pl agent -amd -Dmaven.javadoc.skip=true -DskipTests
 
       - name: Process test resources
-        run: mvn test-compile -T 1C -ntp --activate-profiles agent,component -DskipTests -Dcheckstyle.skip=true
+        run: mvn test-compile -T 1C -ntp -pl agent -amd -DskipTests -Dcheckstyle.skip=true
 
       - name: Verify test resources are built
         run: |
@@ -87,7 +89,9 @@ jobs:
           done
 
       - name: Code Check
-        run: mvn --ntp -T 1C -P-server com.github.spotbugs:spotbugs-maven-plugin:check dependency:analyze-only
+        run: |
+          mvn -f component/pom.xml --ntp -T 1C com.github.spotbugs:spotbugs-maven-plugin:check dependency:analyze-only
+          mvn --ntp -T 1C -pl agent -amd com.github.spotbugs:spotbugs-maven-plugin:check dependency:analyze-only
 
       - name: Verify agent distribution was built
         run: |
@@ -269,7 +273,7 @@ jobs:
           
           if [ "$MISSING_RESOURCES" = true ]; then
             echo "=== Rebuilding test resources ==="
-            mvn test-compile -T 1C -ntp --activate-profiles agent,component -DskipTests -Dcheckstyle.skip=true
+            mvn test-compile -T 1C -ntp -pl agent -amd -DskipTests -Dcheckstyle.skip=true
             
             echo "=== Verifying resources after rebuild ==="
             find agent/ -path "*/target/test-classes/*" -name "init-mysql*.sql" -type f
@@ -314,7 +318,7 @@ jobs:
         run: |
           echo "=== Running tests with TestContainers support ==="
           # Ensure test resources are in classpath by running from project root
-          mvn surefire:test --activate-profiles agent -P-server -ntp -Dtest.working.directory=$PWD
+          mvn surefire:test -pl agent -amd -ntp -Dtest.working.directory=$PWD
         env:
           # Ensure TestContainers environment variables are available
           TESTCONTAINERS_RYUK_DISABLED: true

--- a/.github/workflows/build-server-jdk21.yml
+++ b/.github/workflows/build-server-jdk21.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Compilation
         run: |
+          mvn -N install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
           mvn -f shaded/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
           mvn -f server/jOOQ/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
           mvn clean install -T 1C -ntp -pl server/server-starter -am -Dmaven.javadoc.skip=true -DskipTests

--- a/.github/workflows/build-server-jdk21.yml
+++ b/.github/workflows/build-server-jdk21.yml
@@ -41,15 +41,18 @@ jobs:
           distribution: "adopt"
 
       - name: Compilation
-        run: mvn clean install -T 1C -ntp --activate-profiles shaded,jooq,server,component -Dmaven.javadoc.skip=true -DskipTests
+        run: |
+          mvn -f shaded/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
+          mvn -f server/jOOQ/pom.xml clean install -T 1C -ntp -Dmaven.javadoc.skip=true -DskipTests
+          mvn clean install -T 1C -ntp -pl server/server-starter -am -Dmaven.javadoc.skip=true -DskipTests
 
       - name: Code Check
-        run: mvn --ntp -T 1C -P-agent animal-sniffer:check checkstyle:checkstyle com.github.spotbugs:spotbugs-maven-plugin:check
+        run: mvn --ntp -T 1C -pl server/server-starter -am animal-sniffer:check checkstyle:checkstyle com.github.spotbugs:spotbugs-maven-plugin:check
 
       # No use of -T parameter because it will mess up the output message
       - name: Dependency Check
-        run: mvn -ntp -P-agent dependency:analyze-only
+        run: mvn -ntp -pl server/server-starter -am dependency:analyze-only
 
       # Execute UT excluding component modules
       - name: UT
-        run: mvn test -P-component -P-agent
+        run: mvn test -pl server -amd

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ cd bithon && git submodule update --init
 
 ## 2. Configure JDK
 
-JDK 17 and above are required to build this project.
+JDK 21 and above are required to build this project.
 If you have multiple JDKs on your machine, use `export JAVA_HOME={YOUR_JDK_HOME}` command to set correct JDK. 
 For example
 
 ```bash
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-21.jdk/Contents/Home
 ```
 
 ## 3. Build the project

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home
 For the first time to build this project, use the following command to build dependencies first: 
 
 ```bash
+mvn -N install
 mvn -f shaded/pom.xml clean install -T 1C
 mvn -f server/jOOQ/pom.xml clean install -T 1C
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home
 For the first time to build this project, use the following command to build dependencies first: 
 
 ```bash
-mvn clean install --activate-profiles shaded,jooq -T 1C
+mvn -f shaded/pom.xml clean install -T 1C
+mvn -f server/jOOQ/pom.xml clean install -T 1C
 ```
 
 and then execute the following command to build the project. 

--- a/doc/dev/release.md
+++ b/doc/dev/release.md
@@ -30,11 +30,12 @@ gpg --full-generate-key
 
 Upload your key to [opengpg](https://keys.openpgp.org/upload/)
 
-# Step 3. Build and deploy agent to sonatype
+# Step 3. Build and deploy to sonatype
 
 ```bash
 export GPG_TTY=$(tty)
 mvn -N clean deploy -DskipTests -Pdist
 mvn -f component/pom.xml clean deploy -DskipTests -Pdist
 mvn clean deploy -DskipTests -Pdist -pl agent -amd
+mvn clean deploy -DskipTests -Pdist -pl server -amd
 ```

--- a/doc/dev/release.md
+++ b/doc/dev/release.md
@@ -34,6 +34,7 @@ Upload your key to [opengpg](https://keys.openpgp.org/upload/)
 
 ```bash
 export GPG_TTY=$(tty)
+mvn -N clean deploy -DskipTests -Pdist
 mvn -f component/pom.xml clean deploy -DskipTests -Pdist
 mvn clean deploy -DskipTests -Pdist -pl agent -amd
 ```

--- a/doc/dev/release.md
+++ b/doc/dev/release.md
@@ -34,6 +34,6 @@ Upload your key to [opengpg](https://keys.openpgp.org/upload/)
 
 ```bash
 export GPG_TTY=$(tty)
-mvn clean deploy -DskipTests -Pdist -P-server
+mvn -f component/pom.xml clean deploy -DskipTests -Pdist
+mvn clean deploy -DskipTests -Pdist -pl agent -amd
 ```
-

--- a/docker/Dockerfile-agent
+++ b/docker/Dockerfile-agent
@@ -26,14 +26,19 @@ RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
       ; fi
 
 COPY . /src
+WORKDIR /src
+RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+      mvn -ntp -N install -DskipTests -T 1C \
+      ; fi
+
 WORKDIR /src/shaded
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
       mvn -ntp clean install -T 1C \
       ; fi
 
-WORKDIR /src/component
+WORKDIR /src
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -ntp clean install -DskipTests -T 1C \
+      mvn -ntp -f component/pom.xml clean install -DskipTests -T 1C \
       ; fi
 
 WORKDIR /src

--- a/docker/Dockerfile-agent
+++ b/docker/Dockerfile-agent
@@ -31,9 +31,14 @@ RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
       mvn -ntp clean install -T 1C \
       ; fi
 
+WORKDIR /src/component
+RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+      mvn -ntp clean install -DskipTests -T 1C \
+      ; fi
+
 WORKDIR /src
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -ntp --activate-profiles agent,component clean install -DskipTests -T 1C \
+      mvn -ntp -pl agent -amd clean install -DskipTests -T 1C \
       ; fi
 
 FROM eclipse-temurin:8-jre-alpine

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -42,7 +42,7 @@ RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
 # Build Server
 WORKDIR /src
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -ntp --activate-profiles server,component -pl server/server-starter -am \
+      mvn -ntp -pl server/server-starter -am \
       clean package \
       -T 1C \
       -DskipTests \

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
     </developer>
   </developers>
 
+  <modules>
+    <module>component</module>
+    <module>agent</module>
+    <module>server</module>
+  </modules>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -461,63 +467,6 @@
   </reporting>
 
   <profiles>
-    <profile>
-      <id>jdk21-checkstyle</id>
-      <activation>
-        <jdk>[21,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>component</id>
-      <modules>
-        <module>component</module>
-      </modules>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-    </profile>
-
-    <profile>
-      <id>agent</id>
-      <modules>
-        <module>agent</module>
-      </modules>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-    </profile>
-
-    <profile>
-      <!--
-      Include all server modules by default.
-      Use -P!server to exclude server modules.
-      -->
-      <id>server</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <modules>
-        <module>server</module>
-      </modules>
-    </profile>
     <profile>
       <id>shaded</id>
       <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,30 @@
 
   <profiles>
     <profile>
+      <id>jdk21-checkstyle</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>validate</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>shaded</id>
       <modules>
         <module>shaded</module>


### PR DESCRIPTION
## Summary
- Move component, agent, and server into the root Maven reactor modules instead of activeByDefault profiles
- Update CI, Docker, and docs to use direct module builds or Maven reactor selectors after removing module profiles
- Keep shaded and jOOQ dependency builds explicit via their own POMs

## Validation
- mvn -DskipTests validate
- mvn -f shaded/pom.xml -DskipTests validate
- mvn -f server/jOOQ/pom.xml -DskipTests validate
- mvn -f component/pom.xml -DskipTests validate
- mvn -pl agent -amd -DskipTests validate
- mvn -pl server/server-starter -am -DskipTests validate
- mvn -f component/pom.xml -Pdist help:active-profiles