### PR TITLE
[codex] Upgrade minimal safe Maven dependencies

### DIFF
--- a/agent/agent-sdk/pom.xml
+++ b/agent/agent-sdk/pom.xml
@@ -42,7 +42,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.deploy.skip>false</maven.deploy.skip>
     <spotbugs.version>4.9.8</spotbugs.version>
-    <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
+    <spotbugs.maven.plugin.version>4.9.8.5</spotbugs.maven.plugin.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
          but it can still validate agent modules that target Java 8 bytecode. -->
     <checkstyle.version>13.4.2</checkstyle.version>
     <spotbugs.version>4.9.8</spotbugs.version>
-    <spotbugs.maven.plugin.version>4.9.8.3</spotbugs.maven.plugin.version>
-    <maven.surefire.version>3.5.5</maven.surefire.version>
+    <spotbugs.maven.plugin.version>4.9.8.5</spotbugs.maven.plugin.version>
+    <maven.surefire.version>3.5.6</maven.surefire.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -26,8 +26,8 @@
     <!-- Dependency Note: https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions -->
     <!-- Maven release: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot -->
     <!-- Maven release: https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies -->
-    <spring-boot.version>4.0.6</spring-boot.version>
-    <spring-cloud.version>2025.1.1</spring-cloud.version>
+    <spring-boot.version>4.0.7</spring-boot.version>
+    <spring-cloud.version>2025.1.2</spring-cloud.version>
 
     <!-- The Alibaba Nacos is used -->
     <!-- Dependency Note: https://github.com/alibaba/spring-cloud-alibaba/wiki/%E7%89%88%E6%9C%AC%E8%AF%B4%E6%98%8E -->


### PR DESCRIPTION
## Summary

- Updates the minimal safe Maven dependency set from the dependency sweep.
- Bumps Surefire from `3.5.5` to `3.5.6`.
- Bumps the SpotBugs Maven plugin property from `4.9.8.3` to `4.9.8.5` in both root and `agent-sdk` POMs.
- Bumps server BOM patch versions: Spring Boot `4.0.6 -> 4.0.7` and Spring Cloud `2025.1.1 -> 2025.1.2`.

## Notes

This intentionally leaves out larger or migration-sized updates such as JUnit 6, Mockito 5, Protobuf 4, gRPC latest, Spring Boot 4.1, SLF4J 2/Logback 1.5, and shaded Netty/Sentinel updates.

## Validation

- `mvn -ntp -DskipTests validate`
- `mvn -ntp -pl server/collector -am -DskipTests clean package`

The collector package check requires the `server/opentelemetry/opentelemetry-proto` submodule to be initialized so OTLP generated sources are available.