### PR TITLE
[codex] Fix Bithon SDK root span kind

### DIFF
--- a/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/interceptor/TraceScopeBuilder$Attach.java
+++ b/agent/agent-plugins/bithon-sdk/src/main/java/org/bithon/agent/plugin/bithon/sdk/tracing/interceptor/TraceScopeBuilder$Attach.java
@@ -62,8 +62,25 @@ public class TraceScopeBuilder$Attach extends ReplaceInterceptor {
         SamplingMode samplingMode = builder.tracingMode() == TracingMode.TRACING ? SamplingMode.FULL : SamplingMode.NONE;
         ITraceContext ctx = TraceContextFactory.newContext(samplingMode, traceId, parentSpanId);
         ITraceSpan rootSpan = ctx.currentSpan();
-        rootSpan.name(builder.operationName()).start();
+        rootSpan.name(builder.operationName())
+                .kind(toKind(builder.kind()))
+                .start();
 
         return new TraceScopeImpl(ctx, ctx.currentSpan(), previousContext);
+    }
+
+    private static org.bithon.component.commons.tracing.SpanKind toKind(org.bithon.agent.sdk.tracing.SpanKind kind) {
+        if (kind == org.bithon.agent.sdk.tracing.SpanKind.CLIENT) {
+            return org.bithon.component.commons.tracing.SpanKind.CLIENT;
+        } else if (kind == org.bithon.agent.sdk.tracing.SpanKind.SERVER) {
+            return org.bithon.component.commons.tracing.SpanKind.SERVER;
+        } else if (kind == org.bithon.agent.sdk.tracing.SpanKind.PRODUCER) {
+            return org.bithon.component.commons.tracing.SpanKind.PRODUCER;
+        } else if (kind == org.bithon.agent.sdk.tracing.SpanKind.CONSUMER) {
+            return org.bithon.component.commons.tracing.SpanKind.CONSUMER;
+        } else if (kind == org.bithon.agent.sdk.tracing.SpanKind.INTERNAL) {
+            return org.bithon.component.commons.tracing.SpanKind.INTERNAL;
+        }
+        return org.bithon.component.commons.tracing.SpanKind.INTERNAL;
     }
 }

--- a/agent/agent-plugins/bithon-sdk/src/test/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImplTest.java
+++ b/agent/agent-plugins/bithon-sdk/src/test/java/org/bithon/agent/plugin/bithon/sdk/tracing/TraceScopeImplTest.java
@@ -29,6 +29,7 @@ import org.bithon.agent.observability.tracing.id.ISpanIdGenerator;
 import org.bithon.agent.observability.tracing.id.impl.DefaultSpanIdGenerator;
 import org.bithon.agent.observability.tracing.reporter.ITraceReporter;
 import org.bithon.agent.observability.tracing.reporter.ReporterConfig;
+import org.bithon.agent.plugin.bithon.sdk.tracing.interceptor.TraceScopeBuilder$Attach;
 import org.bithon.agent.plugin.bithon.sdk.tracing.interceptor.TraceScopeBuilder$AttachOrReplaceCurrent;
 import org.bithon.agent.sdk.tracing.ITraceScope;
 import org.bithon.agent.sdk.tracing.TraceContext;
@@ -171,6 +172,23 @@ public class TraceScopeImplTest {
         Assertions.assertSame(previous, TraceContextHolder.current());
         Assertions.assertFalse(previous.finished);
         Assertions.assertFalse(previous.span.finished);
+    }
+
+    @Test
+    public void testAttachAppliesRootSpanKind() {
+        TraceScopeBuilder$Attach interceptor = new TraceScopeBuilder$Attach();
+        ITraceScope scope = (ITraceScope) interceptor.execute(TraceContext.newTrace("current")
+                                                                          .kind(org.bithon.agent.sdk.tracing.SpanKind.SERVER),
+                                                              null,
+                                                              null);
+
+        ITraceContext current = TraceContextHolder.current();
+        Assertions.assertEquals("current", current.currentSpan().name());
+        Assertions.assertEquals(SpanKind.SERVER, current.currentSpan().kind());
+
+        scope.close();
+
+        Assertions.assertNull(TraceContextHolder.current());
     }
 
     private static Tracer setTracer(Tracer tracer) throws Exception {


### PR DESCRIPTION
## Summary
- Apply the SDK `TraceContext` span kind when `TraceScopeBuilder.attach` creates a new root span.
- Map SDK span kinds to the agent tracing span kind enum.
- Add coverage that an attached SERVER SDK trace creates a SERVER root span.

## Root Cause
`TraceScopeBuilder.attach` created and started the root span with the operation name, but did not copy the SDK-provided span kind onto the agent span. SDK-created server scopes therefore defaulted to INTERNAL.

## Validation
- `mvn -pl agent/agent-plugins/bithon-sdk -Dtest=TraceScopeImplTest test`
- `git diff --check`