### PR TITLE
Upgrade safe dependency patches

### DIFF
--- a/server/storage-jdbc-postgresql/pom.xml
+++ b/server/storage-jdbc-postgresql/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <version>42.7.13</version>
     </dependency>
   </dependencies>
 

--- a/shaded/shaded-jackson/pom.xml
+++ b/shaded/shaded-jackson/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>shaded-jackson</artifactId>
 
   <properties>
-    <jackson.version>2.22.0</jackson.version>
+    <jackson.version>2.22.1</jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary

- Upgrade the shaded Jackson bundle from `2.22.0` to `2.22.1`.
- Pin the PostgreSQL JDBC driver in the PostgreSQL storage module at `42.7.13`, overriding the Spring Boot BOM's current `42.7.11` without taking the broader Spring Boot `4.1.0` ecosystem update.

## Why

These were the smallest safe dependency updates found in the dependency sweep. Larger reported updates such as Spring Boot, JUnit, Mockito Inline, gRPC/protobuf, ClickHouse JDBC, Netty, jOOQ, and other major/prerelease jumps were intentionally left out because they require compatibility review or migration work.

## Validation

- `mvn -B -N -f shaded/shaded-jackson/pom.xml org.codehaus.mojo:versions-maven-plugin:2.18.0:display-dependency-updates org.codehaus.mojo:versions-maven-plugin:2.18.0:display-property-updates`
- `mvn -B -N -DprocessDependencyManagement=false -DprocessPluginDependencies=false -DprocessPlugins=false -f server/storage-jdbc-postgresql/pom.xml org.codehaus.mojo:versions-maven-plugin:2.18.0:display-dependency-updates`
- `mvn -B -N -f shaded/shaded-jackson/pom.xml package`
- `mvn -B -pl :server-storage-jdbc-postgresql -am package`

Note: I initially tried a root reactor selector by module path/artifact for the shaded module; the root profile did not include `shaded`, so I reran the shaded build directly by POM.