### PR TITLE
Upgrade minimal safe dependencies

### DIFF
--- a/agent/agent-plugins-test/pom.xml
+++ b/agent/agent-plugins-test/pom.xml
@@ -68,43 +68,43 @@
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-api</artifactId>
-      <version>1.9.18</version>
+      <version>1.9.27</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-spi</artifactId>
-      <version>1.9.18</version>
+      <version>1.9.27</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-util</artifactId>
-      <version>1.9.18</version>
+      <version>1.9.27</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-impl</artifactId>
-      <version>1.9.18</version>
+      <version>1.9.27</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-connector-basic</artifactId>
-      <version>1.9.18</version>
+      <version>1.9.27</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-transport-http</artifactId>
-      <version>1.9.18</version>
+      <version>1.9.27</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-resolver-provider</artifactId>
-      <version>3.9.6</version>
+      <version>3.9.16</version>
       <scope>test</scope>
     </dependency>
 

--- a/component/component-commons/pom.xml
+++ b/component/component-commons/pom.xml
@@ -24,19 +24,19 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.26.0</version>
+      <version>2.26.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.26.0</version>
+      <version>2.26.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.26.0</version>
+      <version>2.26.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/shaded/shaded-alibaba-sentinel/pom.xml
+++ b/shaded/shaded-alibaba-sentinel/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.alibaba.csp</groupId>
       <artifactId>sentinel-core</artifactId>
-      <version>1.8.8</version>
+      <version>1.8.10</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Summary

- Bump provided-scope Log4j 2 dependencies in `component-commons` from `2.26.0` to `2.26.1`.
- Bump `agent-plugins-test` Maven Resolver test dependencies from `1.9.18` to `1.9.27` and `maven-resolver-provider` from `3.9.6` to `3.9.16`.
- Bump shaded Sentinel core from `1.8.8` to `1.8.10`.

## Risk

This keeps the upgrade set patch-line and scoped: provided dependencies, test dependencies, and one shaded/relocated Sentinel patch. It intentionally does not include Netty, Spring Boot, gRPC/protobuf, JUnit 6, Mockito 5, or static-analysis minor upgrades because those require broader compatibility validation or migration work.

## Validation

- `mvn -ntp -B -N -f component/component-commons/pom.xml package`
- `mvn -ntp -B -N -f shaded/shaded-alibaba-sentinel/pom.xml package`
- `mvn -ntp -B -f shaded/pom.xml install`
- `mvn -ntp -B -pl :agent-plugin-processor -am install`
- `mvn -ntp -B -pl :agent-plugins-test -am test-compile`
